### PR TITLE
To fix IOS resource module traceback error 

### DIFF
--- a/plugins/module_utils/network/ios/config/acls/acls.py
+++ b/plugins/module_utils/network/ios/config/acls/acls.py
@@ -773,9 +773,8 @@ class Acls(ConfigBase):
                 cmd = self.source_dest_config(source, cmd, po)
             if destination:
                 cmd = self.source_dest_config(destination, cmd, po)
-            if po:
-                if po_val:
-                    cmd = cmd + " {0}".format(list(po_val)[0])
+            if po and po_val:
+                cmd = cmd + " {0}".format(list(po_val)[0])
             if dscp:
                 cmd = cmd + " dscp {0}".format(dscp)
             if fragments:

--- a/plugins/module_utils/network/ios/config/acls/acls.py
+++ b/plugins/module_utils/network/ios/config/acls/acls.py
@@ -755,6 +755,7 @@ class Acls(ConfigBase):
                 cmd = cmd + " {0}".format(grant)
             if po and isinstance(po, dict):
                 po_key = list(po)[0]
+                po_val = dict()
                 if protocol and protocol != po_key:
                     self._module.fail_json(
                         msg="Protocol value cannot be different from Protocol option protocol value!"
@@ -773,7 +774,8 @@ class Acls(ConfigBase):
             if destination:
                 cmd = self.source_dest_config(destination, cmd, po)
             if po:
-                cmd = cmd + " {0}".format(list(po_val)[0])
+                if po_val:
+                    cmd = cmd + " {0}".format(list(po_val)[0])
             if dscp:
                 cmd = cmd + " dscp {0}".format(dscp)
             if fragments:


### PR DESCRIPTION
Depends-On: https://github.com/ansible-collections/cisco.ios/pull/86

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
To fix IOS resource module traceback error, which was failing as `po_val` not getting populated when protocol_options other than `icmp`, `igmp` and `tcp` was set. PR fixes #13
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios_acls

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
