### PR TITLE
Add DHCP support in IPv6 address

### DIFF
--- a/plugins/module_utils/network/ios/config/l3_interfaces/l3_interfaces.py
+++ b/plugins/module_utils/network/ios/config/l3_interfaces/l3_interfaces.py
@@ -406,7 +406,9 @@ class L3_Interfaces(ConfigBase):
                         cmd = "ipv6 address autoconfig"
                     else:
                         validate_ipv6(ipv6_dict.get("address"), module)
-                        cmd = "ipv6 address {0}".format(ipv6_dict.get("address"))
+                        cmd = "ipv6 address {0}".format(
+                            ipv6_dict.get("address")
+                        )
 
                     add_command_to_config_list(interface, cmd, commands)
 

--- a/plugins/module_utils/network/ios/config/l3_interfaces/l3_interfaces.py
+++ b/plugins/module_utils/network/ios/config/l3_interfaces/l3_interfaces.py
@@ -400,8 +400,12 @@ class L3_Interfaces(ConfigBase):
             if ipv6:
                 for each in ipv6:
                     ipv6_dict = dict(each)
-                    validate_ipv6(ipv6_dict.get("address"), module)
-                    cmd = "ipv6 address {0}".format(ipv6_dict.get("address"))
+                    if ipv6_dict.get("address") != "dhcp":
+                        validate_ipv6(ipv6_dict.get("address"), module)
+                        cmd = "ipv6 address {0}".format(ipv6_dict.get("address"))
+                    elif ipv6_dict.get("address") == "dhcp":
+                        cmd = "ipv6 address dhcp"
+
                     add_command_to_config_list(interface, cmd, commands)
 
         return commands

--- a/plugins/module_utils/network/ios/config/l3_interfaces/l3_interfaces.py
+++ b/plugins/module_utils/network/ios/config/l3_interfaces/l3_interfaces.py
@@ -400,11 +400,13 @@ class L3_Interfaces(ConfigBase):
             if ipv6:
                 for each in ipv6:
                     ipv6_dict = dict(each)
-                    if ipv6_dict.get("address") != "dhcp":
+                    if ipv6_dict.get("address") == "dhcp":
+                        cmd = "ipv6 address dhcp"
+                    elif ipv6_dict.get("address") == "autoconfig":
+                        cmd = "ipv6 address autoconfig"
+                    else:
                         validate_ipv6(ipv6_dict.get("address"), module)
                         cmd = "ipv6 address {0}".format(ipv6_dict.get("address"))
-                    elif ipv6_dict.get("address") == "dhcp":
-                        cmd = "ipv6 address dhcp"
 
                     add_command_to_config_list(interface, cmd, commands)
 

--- a/plugins/module_utils/network/ios/facts/l3_interfaces/l3_interfaces.py
+++ b/plugins/module_utils/network/ios/facts/l3_interfaces/l3_interfaces.py
@@ -137,10 +137,6 @@ class L3_InterfacesFacts(object):
         ipv6_all = re.findall(r"ipv6 address (\S+)", conf)
         for each in ipv6_all:
             each_ipv6 = dict()
-            if "autoconfig" in each:
-                each_ipv6["autoconfig"] = True
-            if "dhcp" in each:
-                each_ipv6["dhcp"] = True
             each_ipv6["address"] = each.lower()
             ipv6.append(each_ipv6)
         config["ipv6"] = ipv6

--- a/plugins/modules/ios_l3_interfaces.py
+++ b/plugins/modules/ios_l3_interfaces.py
@@ -53,7 +53,8 @@ options:
         suboptions:
           address:
             description:
-            - Configures the IPv4 address for Interface.
+            - Configures the IPv4 address for Interface. 
+            - Can be an address or 'dhcp' for DHCP.
             type: str
           secondary:
             description:
@@ -75,6 +76,7 @@ options:
         - IPv6 address to be set for the Layer-3 interface mentioned in I(name) option.
         - The address format is <ipv6 address>/<mask>, the mask is number in range
           0-128 eg. fd5d:12c9:2201:1::1/64
+        - Can be 'dhcp' for DHCP or 'autoconfig' for SLAAC. 
         type: list
         elements: dict
         suboptions:

--- a/plugins/modules/ios_l3_interfaces.py
+++ b/plugins/modules/ios_l3_interfaces.py
@@ -53,7 +53,7 @@ options:
         suboptions:
           address:
             description:
-            - Configures the IPv4 address for Interface. 
+            - Configures the IPv4 address for Interface.
             - Can be an address or 'dhcp' for DHCP.
             type: str
           secondary:
@@ -76,7 +76,7 @@ options:
         - IPv6 address to be set for the Layer-3 interface mentioned in I(name) option.
         - The address format is <ipv6 address>/<mask>, the mask is number in range
           0-128 eg. fd5d:12c9:2201:1::1/64
-        - Can be 'dhcp' for DHCP or 'autoconfig' for SLAAC. 
+        - Can be 'dhcp' for DHCP or 'autoconfig' for SLAAC.
         type: list
         elements: dict
         suboptions:

--- a/tests/integration/targets/ios_l3_interfaces/tests/cli/merged.yaml
+++ b/tests/integration/targets/ios_l3_interfaces/tests/cli/merged.yaml
@@ -27,8 +27,8 @@
                 secondary: true
               - address: 198.51.100.2/24
             ipv6:
-              - address: 2001:db8:0:3::/64
               - address: dhcp
+              - address: 2001:db8:0:3::/64
         state: merged
 
     - name: Assert that correct set of commands were generated

--- a/tests/integration/targets/ios_l3_interfaces/tests/cli/merged.yaml
+++ b/tests/integration/targets/ios_l3_interfaces/tests/cli/merged.yaml
@@ -19,6 +19,8 @@
               - address: dhcp
                 dhcp_client: 0
                 dhcp_hostname: test.com
+            ipv6:
+              - address: autoconfig
           - name: GigabitEthernet0/2
             ipv4:
               - address: 198.51.100.1/24
@@ -26,6 +28,7 @@
               - address: 198.51.100.2/24
             ipv6:
               - address: 2001:db8:0:3::/64
+              - address: dhcp
         state: merged
 
     - name: Assert that correct set of commands were generated

--- a/tests/integration/targets/ios_l3_interfaces/vars/main.yaml
+++ b/tests/integration/targets/ios_l3_interfaces/vars/main.yaml
@@ -29,6 +29,8 @@ merged:
         - address: dhcp
           dhcp_client: 0
           dhcp_hostname: test.com
+    - ipv6:
+        - address: autoconfig
       name: GigabitEthernet0/1
     - ipv4:
         - address: 198.51.100.1 255.255.255.0
@@ -36,6 +38,7 @@ merged:
         - address: 198.51.100.2 255.255.255.0
       ipv6:
         - address: 2001:db8:0:3::/64
+        - address: dhcp
       name: GigabitEthernet0/2
 replaced:
   before:

--- a/tests/integration/targets/ios_l3_interfaces/vars/main.yaml
+++ b/tests/integration/targets/ios_l3_interfaces/vars/main.yaml
@@ -37,8 +37,8 @@ merged:
           secondary: true
         - address: 198.51.100.2 255.255.255.0
       ipv6:
-        - address: 2001:db8:0:3::/64
         - address: dhcp
+        - address: 2001:db8:0:3::/64
       name: GigabitEthernet0/2
 replaced:
   before:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adds DHCP and autoconfig support for IPv6 addresses when configuring L3 interfaces. 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
l3_interfaces.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
I attempted to follow the existing IPv4 code. Someone previously implemented dhcp and autoconfig on facts but not config. Removed that implementation for a much simpler one. Tested on a 2960S. 
<!--- Paste verbatim command output below, e.g. before and after your change -->

##### TASKS REMAINING
- [x] Fix [test ordering](https://acad59b8dbb1219e3b1a-7b7558cb8162c46903419ce16b8b3ed6.ssl.cf1.rackcdn.com/15/a9a0e703442e9396f8fdb73f16c24c73e77c926b/check/ansible-test-network-integration-ios-network_cli-python27/3558aa3/job-output.html#l45695)