### PR TITLE
update regex match string for parse_iostype

### DIFF
--- a/plugins/module_utils/network/ios/facts/legacy/base.py
+++ b/plugins/module_utils/network/ios/facts/legacy/base.py
@@ -62,7 +62,7 @@ class Default(FactsBase):
             self.parse_stacks(data)
 
     def parse_iostype(self, data):
-        match = re.search(r"\S+(X86_64_LINUX_IOSD-UNIVERSALK9-M)(\S+)", data)
+        match = re.search(r"\sIOS-XE\s", data)
         if match:
             return "IOS-XE"
         else:


### PR DESCRIPTION
##### SUMMARY
Update regex to look for ' IOS-XE ' in show version output. Previous regex was unable to match older IOS-XE versions (Version 03.04.02.SG on cat4500 for example).

Closes #71

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ios_facts

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
IOS-XE does not appear in any IOS show version outputs I have tested. Set the regex to '\sIOS-XE\s' as whitespace characters should not be allowed in hostname in case someone is weird and does that.

Previous regex does not match:
``` 
Cisco IOS Software, IOS-XE Software, Catalyst 4500 L3 Switch Software (cat4500e-UNIVERSALK9-M), Version 03.04.02.SG RELEASE SOFTWARE (fc1)
Technical Support: http://www.cisco.com/techsupport
Copyright (c) 1986-2013 by Cisco Systems, Inc.
Compiled Thu 05-Sep-13 19:06 by prod_rel_team



Cisco IOS-XE software, Copyright (c) 2005-2010, 2012 by cisco Systems, Inc.
All rights reserved.  Certain components of Cisco IOS-XE software are
licensed under the GNU General Public License ("GPL") Version 2.0.  The
software code licensed under GPL Version 2.0 is free software that comes
with ABSOLUTELY NO WARRANTY.  You can redistribute and/or modify such
GPL code under the terms of GPL Version 2.0.  For more details, see the
documentation or "License Notice" file accompanying the IOS-XE software,
or the applicable URL provided on the flyer accompanying the IOS-XE
software.



ROM: 15.0(1r)SG10
xxx uptime is 1 year, 41 weeks, 5 days, 10 hours, 33 minutes
System returned to ROM by reload
System restarted at 06:10:09 UTC Sat Aug 18 2018
Running default software
Jawa Revision 2, Winter Revision 0x0.0x41

Last reload reason: Reload command



This product contains cryptographic features and is subject to United
States and local country laws governing import, export, transfer and
use. Delivery of Cisco cryptographic products does not imply
third-party authority to import, export, distribute or use encryption.
Importers, exporters, distributors and users are responsible for
compliance with U.S. and local country laws. By using this product you
agree to comply with applicable laws and regulations. If you are unable
to comply with U.S. and local laws, return this product immediately.

A summary of U.S. laws governing Cisco cryptographic products may be found at:
http://www.cisco.com/wwl/export/crypto/tool/stqrg.html

If you require further assistance please contact us by sending email to
export@cisco.com.


License Information for 'WS-C4500X-16'
    License Level: entservices   Type: Permanent
    Next reboot license Level: entservices

cisco WS-C4500X-16 (MPC8572) processor (revision 9) with 4194304K/20480K bytes of memory.
Processor board ID xxx
MPC8572 CPU at 1.5GHz, Cisco Catalyst 4500X
Last reset from Reload
23 Virtual Ethernet interfaces
24 Ten Gigabit Ethernet interfaces
511K bytes of non-volatile configuration memory.

Configuration register is 0x2101

```
