### PR TITLE
Increase shell timeout value to avoid failure for ios_user integration test

### DIFF
--- a/tests/integration/targets/ios_user/tests/cli/auth.yaml
+++ b/tests/integration/targets/ios_user/tests/cli/auth.yaml
@@ -64,7 +64,7 @@
       shell: ssh ssh_user@{{ ansible_ssh_host }} -p {{ ansible_ssh_port|default(22)
         }} -o IdentityFile={{ role_path }}/files/test_rsa -o UserKnownHostsFile=/dev/null
         -o StrictHostKeyChecking=no -o BatchMode=yes -o PubkeyAuthentication=yes
-        show version -o ConnectTimeout=100
+        show version -o ConnectTimeout=200
 
     - name: test login without sshkey (should fail)
       expect:

--- a/tests/integration/targets/ios_user/tests/cli/auth.yaml
+++ b/tests/integration/targets/ios_user/tests/cli/auth.yaml
@@ -61,7 +61,9 @@
         sshkey: "{{ lookup('file', 'files/test_rsa.pub') }}"
 
     - name: test sshkey login
-      shell: ssh ssh_user@{{ ansible_ssh_host }} -p {{ ansible_ssh_port|default(22)
+      shell: |
+        set timeout 100
+        ssh ssh_user@{{ ansible_ssh_host }} -p {{ ansible_ssh_port|default(22)
         }} -o IdentityFile={{ role_path }}/files/test_rsa -o UserKnownHostsFile=/dev/null
         -o StrictHostKeyChecking=no -o BatchMode=yes -o PubkeyAuthentication=yes
         show version

--- a/tests/integration/targets/ios_user/tests/cli/auth.yaml
+++ b/tests/integration/targets/ios_user/tests/cli/auth.yaml
@@ -62,7 +62,7 @@
 
     - name: test sshkey login
       shell: |
-        set timeout 100
+        set timeout 300
         ssh ssh_user@{{ ansible_ssh_host }} -p {{ ansible_ssh_port|default(22)
         }} -o IdentityFile={{ role_path }}/files/test_rsa -o UserKnownHostsFile=/dev/null
         -o StrictHostKeyChecking=no -o BatchMode=yes -o PubkeyAuthentication=yes

--- a/tests/integration/targets/ios_user/tests/cli/auth.yaml
+++ b/tests/integration/targets/ios_user/tests/cli/auth.yaml
@@ -63,9 +63,9 @@
     - name: test sshkey login
       shell: |
         ssh ssh_user@{{ ansible_ssh_host }} -p {{ ansible_ssh_port|default(22)
-        }} -o ConnectTimeout=100 -o IdentityFile={{ role_path }}/files/test_rsa
-        -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no
-        -o BatchMode=yes -o PubkeyAuthentication=yes show version
+        }} -o IdentityFile={{ role_path }}/files/test_rsa -o UserKnownHostsFile=/dev/null
+        -o StrictHostKeyChecking=no -o BatchMode=yes -o PubkeyAuthentication=yes
+        show version -o ConnectTimeout=100
 
     - name: test login without sshkey (should fail)
       expect:

--- a/tests/integration/targets/ios_user/tests/cli/auth.yaml
+++ b/tests/integration/targets/ios_user/tests/cli/auth.yaml
@@ -62,11 +62,10 @@
 
     - name: test sshkey login
       shell: |
-        set timeout 300
         ssh ssh_user@{{ ansible_ssh_host }} -p {{ ansible_ssh_port|default(22)
-        }} -o IdentityFile={{ role_path }}/files/test_rsa -o UserKnownHostsFile=/dev/null
-        -o StrictHostKeyChecking=no -o BatchMode=yes -o PubkeyAuthentication=yes
-        show version
+        }} -o ConnectTimeout=100 -o IdentityFile={{ role_path }}/files/test_rsa
+        -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no
+        -o BatchMode=yes -o PubkeyAuthentication=yes show version
 
     - name: test login without sshkey (should fail)
       expect:

--- a/tests/integration/targets/ios_user/tests/cli/auth.yaml
+++ b/tests/integration/targets/ios_user/tests/cli/auth.yaml
@@ -61,8 +61,7 @@
         sshkey: "{{ lookup('file', 'files/test_rsa.pub') }}"
 
     - name: test sshkey login
-      shell: |
-        ssh ssh_user@{{ ansible_ssh_host }} -p {{ ansible_ssh_port|default(22)
+      shell: ssh ssh_user@{{ ansible_ssh_host }} -p {{ ansible_ssh_port|default(22)
         }} -o IdentityFile={{ role_path }}/files/test_rsa -o UserKnownHostsFile=/dev/null
         -o StrictHostKeyChecking=no -o BatchMode=yes -o PubkeyAuthentication=yes
         show version -o ConnectTimeout=100


### PR DESCRIPTION
Depends-On: https://github.com/ansible-collections/cisco.ios/pull/82
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Increase shell timeout value to avoid failure for `ios_user` integration test
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios_user

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
