### PR TITLE
To fix IOS ACLs merge state

### DIFF
--- a/plugins/module_utils/network/ios/config/acls/acls.py
+++ b/plugins/module_utils/network/ios/config/acls/acls.py
@@ -27,7 +27,7 @@ from ansible_collections.cisco.ios.plugins.module_utils.network.ios.facts.facts 
 )
 from ansible.module_utils.six import iteritems
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
-    remove_empties,
+    remove_empties, dict_merge
 )
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.utils.utils import (
     new_dict_to_set,
@@ -341,6 +341,7 @@ class Acls(ConfigBase):
                                     "sequence"
                                 ):
                                     ace_want = remove_empties(ace_want)
+                                    ace_want = dict_merge(ace_have, ace_want)
                                     cmd, change = self._set_config(
                                         ace_want,
                                         ace_have,
@@ -821,7 +822,7 @@ class Acls(ConfigBase):
                     cmd = "no ip access-list standard {0}".format(name)
                 elif name >= 100 and not sequence:
                     cmd = "no ip access-list extended {0}".format(name)
-                elif sequence and self.state in ("replaced", "overridden"):
+                elif sequence:
                     if name <= 99:
                         cmd = "ip access-list standard {0} ".format(name)
                     elif name >= 100:
@@ -833,7 +834,7 @@ class Acls(ConfigBase):
                     cmd = "no ip access-list extended {0}".format(name)
                 elif acl_type == "standard" and not sequence:
                     cmd = "no ip access-list standard {0}".format(name)
-                elif sequence and self.state in ("replaced", "overridden"):
+                elif sequence:
                     if acl_type == "extended":
                         cmd = "ip access-list extended {0} ".format(name)
                     elif acl_type == "standard":
@@ -844,7 +845,7 @@ class Acls(ConfigBase):
                         msg="ACL type value is required for Named ACL!"
                     )
         elif afi == "ipv6" and name:
-            if sequence and self.state in ("replaced", "overridden"):
+            if sequence:
                 cmd = "no sequence {0}".format(sequence)
             else:
                 cmd = "no ipv6 access-list {0}".format(name)

--- a/plugins/module_utils/network/ios/config/acls/acls.py
+++ b/plugins/module_utils/network/ios/config/acls/acls.py
@@ -27,7 +27,8 @@ from ansible_collections.cisco.ios.plugins.module_utils.network.ios.facts.facts 
 )
 from ansible.module_utils.six import iteritems
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
-    remove_empties, dict_merge
+    remove_empties,
+    dict_merge,
 )
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.utils.utils import (
     new_dict_to_set,

--- a/plugins/modules/ios_acls.py
+++ b/plugins/modules/ios_acls.py
@@ -624,20 +624,10 @@ EXAMPLES = """
             wildcard_bits: 0.0.0.255
       - name: 110
         aces:
-        - grant: deny
-          sequence: 10
+        - sequence: 10
           protocol_options:
             icmp:
               traceroute: true
-          source:
-            address: 192.0.2.0
-            wildcard_bits: 0.0.0.255
-          destination:
-            address: 192.0.3.0
-            wildcard_bits: 0.0.0.255
-          dscp: ef
-          ttl:
-            eq: 10
         - grant: deny
           protocol_options:
             tcp:

--- a/tests/integration/targets/ios_acls/tests/cli/merged.yaml
+++ b/tests/integration/targets/ios_acls/tests/cli/merged.yaml
@@ -6,28 +6,14 @@
 - include_tasks: _remove_config.yaml
 
 - block:
-
-    - name: Merge provided configuration with device configuration
-      register: result
-      cisco.ios.ios_acls: &id001
+    - name: Merge initial config with device configuration
+      cisco.ios.ios_acls:
         config:
-
           - afi: ipv4
             acls:
-
-              - name: std_acl
-                acl_type: standard
-                aces:
-
-                  - grant: deny
-                    source:
-                      address: 192.0.2.0
-                      wildcard_bits: 0.0.0.255
-
               - name: test_acl
                 acl_type: extended
                 aces:
-
                   - grant: deny
                     protocol_options:
                       tcp:
@@ -44,10 +30,33 @@
                       traceroute: true
                     ttl:
                       eq: 10
+        state: merged
 
+    - name: Merge new configuration with existing device configuration
+      register: result
+      cisco.ios.ios_acls: &id001
+        config:
+          - afi: ipv4
+            acls:
+              - name: std_acl
+                acl_type: standard
+                aces:
+                  - grant: deny
+                    source:
+                      address: 192.0.2.0
+                      wildcard_bits: 0.0.0.255
+              - name: test_acl
+                acl_type: extended
+                aces:
+                  - sequence: 10
+                    source:
+                      address: 192.0.4.0
+                      wildcard_bits: 0.0.0.255
+                    destination:
+                      address: 192.0.5.0
+                      wildcard_bits: 0.0.0.255
               - name: 110
                 aces:
-
                   - grant: deny
                     sequence: 10
                     protocol_options:
@@ -62,10 +71,8 @@
                     dscp: ef
                     ttl:
                       eq: 10
-
               - name: 123
                 aces:
-
                   - grant: deny
                     protocol_options:
                       tcp:
@@ -80,7 +87,6 @@
                         eq: telnet
                     tos:
                       service_value: 12
-
                   - grant: deny
                     protocol_options:
                       tcp:
@@ -96,10 +102,8 @@
                     dscp: ef
                     ttl:
                       lt: 20
-
           - afi: ipv6
             acls:
-
               - name: R1_TRAFFIC
                 aces:
 
@@ -120,7 +124,7 @@
 
     - assert:
         that:
-          - result.commands|length == 11
+          - result.commands|length == 12
           - result.changed == true
           - result.commands|symmetric_difference(merged.commands) == []
 

--- a/tests/integration/targets/ios_acls/vars/main.yaml
+++ b/tests/integration/targets/ios_acls/vars/main.yaml
@@ -15,7 +15,8 @@ merged:
     - ip access-list standard std_acl
     - deny 192.0.2.0 0.0.0.255
     - ip access-list extended test_acl
-    - deny tcp 192.0.2.0 0.0.0.255 192.0.3.0 0.0.0.255 eq www fin option traceroute
+    - no 10
+    - 10 deny tcp 192.0.4.0 0.0.0.255 192.0.5.0 0.0.0.255 eq www fin option traceroute
       ttl eq 10
     - ip access-list extended 110
     - 10 deny icmp 192.0.2.0 0.0.0.255 192.0.3.0 0.0.0.255 echo dscp ef ttl eq 10


### PR DESCRIPTION
Depends-On: https://github.com/ansible-collections/cisco.ios/pull/82
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
To fix IOS ACLs merge state, and now users can give input only to value that they want to update using merge state and module will tc of merging the have and want dict. Resolves bug raised in #20 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios_acls

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
