### PR TITLE
Fixes Interface normalizing for all of interfaces resource module

### DIFF
--- a/plugins/module_utils/network/ios/config/interfaces/interfaces.py
+++ b/plugins/module_utils/network/ios/config/interfaces/interfaces.py
@@ -27,6 +27,7 @@ from ansible_collections.cisco.ios.plugins.module_utils.network.ios.facts.facts 
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.utils.utils import (
     get_interface_type,
     dict_to_set,
+    normalize_interface,
 )
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.utils.utils import (
     remove_command_from_config_list,
@@ -124,7 +125,12 @@ class Interfaces(ConfigBase):
         :returns: the commands necessary to migrate the current configuration
                   to the deisred configuration
         """
-        want = self._module.params["config"]
+        config = self._module.params.get("config")
+        want = []
+        if config:
+            for each in config:
+                each.update({"name": normalize_interface(each["name"])})
+                want.append(each)
         have = existing_interfaces_facts
         resp = self.set_state(want, have)
         return to_list(resp)

--- a/plugins/module_utils/network/ios/config/l2_interfaces/l2_interfaces.py
+++ b/plugins/module_utils/network/ios/config/l2_interfaces/l2_interfaces.py
@@ -25,6 +25,7 @@ from ansible_collections.cisco.ios.plugins.module_utils.network.ios.facts.facts 
 )
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.utils.utils import (
     dict_to_set,
+    normalize_interface,
 )
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.utils.utils import (
     remove_command_from_config_list,
@@ -126,7 +127,12 @@ class L2_Interfaces(ConfigBase):
                   to the deisred configuration
         """
 
-        want = self._module.params["config"]
+        config = self._module.params.get("config")
+        want = []
+        if config:
+            for each in config:
+                each.update({"name": normalize_interface(each["name"])})
+                want.append(each)
         have = existing_facts
         resp = self.set_state(want, have)
 

--- a/plugins/module_utils/network/ios/config/lacp_interfaces/lacp_interfaces.py
+++ b/plugins/module_utils/network/ios/config/lacp_interfaces/lacp_interfaces.py
@@ -27,6 +27,7 @@ from ansible_collections.cisco.ios.plugins.module_utils.network.ios.facts.facts 
 )
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.utils.utils import (
     dict_to_set,
+    normalize_interface,
 )
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.utils.utils import (
     remove_command_from_config_list,
@@ -126,7 +127,12 @@ class Lacp_Interfaces(ConfigBase):
         :returns: the commands necessary to migrate the current configuration
                   to the desired configuration
         """
-        want = self._module.params["config"]
+        config = self._module.params.get("config")
+        want = []
+        if config:
+            for each in config:
+                each.update({"name": normalize_interface(each["name"])})
+                want.append(each)
         have = existing_lacp_interfaces_facts
         resp = self.set_state(want, have)
 

--- a/plugins/module_utils/network/ios/config/lag_interfaces/lag_interfaces.py
+++ b/plugins/module_utils/network/ios/config/lag_interfaces/lag_interfaces.py
@@ -31,6 +31,7 @@ from ansible_collections.cisco.ios.plugins.module_utils.network.ios.facts.facts 
 )
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.utils.utils import (
     dict_to_set,
+    normalize_interface,
 )
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.utils.utils import (
     filter_dict_having_none_value,
@@ -101,7 +102,12 @@ class Lag_interfaces(ConfigBase):
         :returns: the commands necessary to migrate the current configuration
                   to the desired configuration
         """
-        want = self._module.params["config"]
+        config = self._module.params.get("config")
+        want = []
+        if config:
+            for each in config:
+                each.update({"name": normalize_interface(each["name"])})
+                want.append(each)
         have = existing_lag_interfaces_facts
         resp = self.set_state(want, have)
         return to_list(resp)

--- a/plugins/module_utils/network/ios/config/lldp_interfaces/lldp_interfaces.py
+++ b/plugins/module_utils/network/ios/config/lldp_interfaces/lldp_interfaces.py
@@ -27,6 +27,7 @@ from ansible_collections.cisco.ios.plugins.module_utils.network.ios.facts.facts 
 )
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.utils.utils import (
     dict_to_set,
+    normalize_interface,
 )
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.utils.utils import (
     remove_command_from_config_list,
@@ -124,7 +125,12 @@ class Lldp_Interfaces(ConfigBase):
         :returns: the commands necessary to migrate the current configuration
                   to the desired configuration
         """
-        want = self._module.params["config"]
+        config = self._module.params.get("config")
+        want = []
+        if config:
+            for each in config:
+                each.update({"name": normalize_interface(each["name"])})
+                want.append(each)
         have = existing_lldp_interfaces_facts
         resp = self.set_state(want, have)
 


### PR DESCRIPTION
Depends-On: https://github.com/ansible-collections/cisco.ios/pull/82
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes Interface normalizing for all of interfaces resource module. Fixes #73 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios_interfaces.py
ios_l2_interfaces.py
ios_lldp_interfaces.py
ios_lag_interfaces.py
ios_lacp_interfaces.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
