### PR TITLE
Fix ios_command regex failure and ios_user shell timeout issue

### DIFF
--- a/tests/integration/targets/ios_command/tests/cli/error_regex.yaml
+++ b/tests/integration/targets/ios_command/tests/cli/error_regex.yaml
@@ -14,12 +14,16 @@
 
     - name: increase log buffer size
       ansible.netcommon.cli_config:
-        config: logging buffered 640000
+        config: logging buffered 9600000
 
     - name: send log with error regex match 1
       ignore_errors: true
       ansible.netcommon.cli_command: &id002
-        command: "send log 'IPSEC-3-REPLAY_ERROR: test log_1'"
+        command: "send log 'IPSEC-3-REPLAY_ERROR: test log_1'\n"
+
+    - name: pause to avoid rate limiting-1
+      pause:
+        seconds: 20
 
     - name: fetch logs without command specific error regex
       register: result
@@ -33,9 +37,9 @@
         that:
           - result.failed == true
 
-    - name: pause to avoid rate limiting
+    - name: pause to avoid rate limiting-2
       pause:
-        seconds: 10
+        seconds: 20
 
     - name: clear logs 2
       ignore_errors: true

--- a/tests/integration/targets/ios_command/tests/cli/error_regex.yaml
+++ b/tests/integration/targets/ios_command/tests/cli/error_regex.yaml
@@ -8,13 +8,13 @@
       ansible.netcommon.cli_command: &id001
         command: clear logging
         prompt:
-          - clear logging
+          - Clear logging buffer
         answer:
           - "\r"
 
     - name: increase log buffer size
       ansible.netcommon.cli_config:
-        config: logging buffered 64000
+        config: logging buffered 640000
 
     - name: send log with error regex match 1
       ignore_errors: true

--- a/tests/integration/targets/ios_command/tests/cli/error_regex.yaml
+++ b/tests/integration/targets/ios_command/tests/cli/error_regex.yaml
@@ -8,9 +8,13 @@
       ansible.netcommon.cli_command: &id001
         command: clear logging
         prompt:
-          - Clear logging buffer
+          - clear logging
         answer:
           - "\r"
+
+    - name: increase log buffer size
+      ansible.netcommon.cli_config:
+        config: logging buffered 64000
 
     - name: send log with error regex match 1
       ignore_errors: true

--- a/tests/integration/targets/ios_user/tasks/cli.yaml
+++ b/tests/integration/targets/ios_user/tasks/cli.yaml
@@ -15,10 +15,3 @@
   loop_control:
     loop_var: test_case_to_run
   tags: network_cli
-
-- name: run test case (connection=local)
-  include: '{{ test_case_to_run }} ansible_connection=local'
-  with_first_found: '{{ test_items }}'
-  loop_control:
-    loop_var: test_case_to_run
-  tags: local

--- a/tests/integration/targets/ios_user/tests/cli/auth.yaml
+++ b/tests/integration/targets/ios_user/tests/cli/auth.yaml
@@ -84,6 +84,9 @@
         ansible_user: ssh_user
         ansible_private_key_file: ""
 
+    - name: reset connection with {{ ansible_user }}
+      meta: reset_connection
+
     - name: check that attempt failed
       assert:
         that:

--- a/tests/integration/targets/ios_user/tests/cli/auth.yaml
+++ b/tests/integration/targets/ios_user/tests/cli/auth.yaml
@@ -70,7 +70,7 @@
       expect:
         command: ssh ssh_user@{{ ansible_ssh_host }} -p {{ ansible_ssh_port|default(22)
           }} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PubkeyAuthentication=no
-          show version
+          show version -o ConnectTimeout=200
         responses:
           (?i)password: badpass
       ignore_errors: true

--- a/tests/integration/targets/ios_user/tests/cli/auth.yaml
+++ b/tests/integration/targets/ios_user/tests/cli/auth.yaml
@@ -64,7 +64,7 @@
       shell: ssh ssh_user@{{ ansible_ssh_host }} -p {{ ansible_ssh_port|default(22)
         }} -o IdentityFile={{ role_path }}/files/test_rsa -o UserKnownHostsFile=/dev/null
         -o StrictHostKeyChecking=no -o BatchMode=yes -o PubkeyAuthentication=yes
-        show version
+        show version -o ConnectTimeout=200
 
     - name: test login without sshkey (should fail)
       expect:

--- a/tests/integration/targets/ios_user/tests/cli/auth.yaml
+++ b/tests/integration/targets/ios_user/tests/cli/auth.yaml
@@ -7,26 +7,34 @@
         privilege: 15
         role: network-operator
         state: present
-        provider: '{{ cli }}'
         configured_password: pass123
 
-    - name: test login
-      expect:
-        command: ssh auth_user@{{ ansible_ssh_host }} -p {{ ansible_ssh_port|default(22)
-          }} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PubkeyAuthentication=no
-          show version
-        responses:
-          (?i)password: pass123
+    - name: reset connection with {{ ansible_user }
+      meta: reset_connection
+
+    - name: test login for {{ ansible_user }} user with password
+      cisco.ios.ios_command:
+        commands:
+          - show version
+      vars:
+        ansible_user: auth_user
+        ansible_password: pass123
+
+    - name: reset connection with {{ ansible_user }
+      meta: reset_connection
 
     - name: test login with invalid password (should fail)
-      expect:
-        command: ssh auth_user@{{ ansible_ssh_host }} -p {{ ansible_ssh_port|default(22)
-          }} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PubkeyAuthentication=no
-          show version
-        responses:
-          (?i)password: badpass
+      cisco.ios.ios_command:
+        commands:
+          - show version
       ignore_errors: true
       register: results
+      vars:
+        ansible_user: auth_user
+        ansible_password: badpass
+
+    - name: reset connection with {{ ansible_user }
+      meta: reset_connection
 
     - name: check that attempt failed
       assert:
@@ -39,7 +47,6 @@
       cisco.ios.ios_user:
         name: auth_user
         state: absent
-        provider: '{{ cli }}'
 
     - name: reset connection
       meta: reset_connection
@@ -57,7 +64,6 @@
         privilege: 15
         role: network-operator
         state: present
-        provider: '{{ cli }}'
         sshkey: "{{ lookup('file', 'files/test_rsa.pub') }}"
 
     - name: reset connection with {{ ansible_user }
@@ -98,7 +104,6 @@
       cisco.ios.ios_user:
         name: ssh_user
         state: absent
-        provider: '{{ cli }}'
 
     - name: reset connection
       meta: reset_connection

--- a/tests/integration/targets/ios_user/tests/cli/auth.yaml
+++ b/tests/integration/targets/ios_user/tests/cli/auth.yaml
@@ -60,21 +60,29 @@
         provider: '{{ cli }}'
         sshkey: "{{ lookup('file', 'files/test_rsa.pub') }}"
 
-    - name: test sshkey login
-      shell: ssh ssh_user@{{ ansible_ssh_host }} -p {{ ansible_ssh_port|default(22)
-        }} -o IdentityFile={{ role_path }}/files/test_rsa -o UserKnownHostsFile=/dev/null
-        -o StrictHostKeyChecking=no -o BatchMode=yes -o PubkeyAuthentication=yes
-        show version -o ConnectTimeout=200
+    - name: reset connection with {{ ansible_user }
+      meta: reset_connection
 
-    - name: test login without sshkey (should fail)
-      expect:
-        command: ssh ssh_user@{{ ansible_ssh_host }} -p {{ ansible_ssh_port|default(22)
-          }} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PubkeyAuthentication=no
-          show version -o ConnectTimeout=200
-        responses:
-          (?i)password: badpass
+    - name: test sshkey login for {{ ansible_user }} user
+      cisco.ios.ios_command:
+        commands:
+          - show version
+      vars:
+        ansible_user: ssh_user
+        ansible_private_key_file: "{{ role_path }}/files/test_rsa"
+
+    - name: reset connection with {{ ansible_user }}
+      meta: reset_connection
+
+    - name: test with {{ ansible_user }} user without keys
+      cisco.ios.ios_command:
+        commands:
+          - show version
       ignore_errors: true
       register: results
+      vars:
+        ansible_user: ssh_user
+        ansible_private_key_file: ""
 
     - name: check that attempt failed
       assert:


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
*  Increase logging buffer size on device
   before issuing logs that matches error regex
* increase shell timeout to avoid ios_user failure

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
