### PR TITLE
Add needs_triage label to new issues/PRs by default

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,59 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: 
+labels: needs_triage 
+assignees: 
+
+---
+
+<!--- Verify first that your issue is not already reported on GitHub -->
+<!--- Also test if the latest release and devel branch are affected too -->
+<!--- Complete *all* sections as described, this form is processed automatically -->
+
+##### SUMMARY
+<!--- Explain the problem briefly below -->
+
+##### ISSUE TYPE
+- Bug Report
+
+##### COMPONENT NAME
+<!--- Write the short name of the module, plugin, task or feature below, use your best guess if unsure -->
+
+##### ANSIBLE VERSION
+<!--- Paste verbatim output from "ansible --version" between quotes -->
+```paste below
+
+```
+
+##### CONFIGURATION
+<!--- Paste verbatim output from "ansible-config dump --only-changed" between quotes -->
+```paste below
+
+```
+
+##### OS / ENVIRONMENT
+<!--- Provide all relevant information below, e.g. target OS versions, network device firmware, etc. -->
+
+
+##### STEPS TO REPRODUCE
+<!--- Describe exactly how to reproduce the problem, using a minimal test-case -->
+
+<!--- Paste example playbooks or commands between quotes below -->
+```yaml
+
+```
+
+<!--- HINT: You can paste gist.github.com links for larger files -->
+
+##### EXPECTED RESULTS
+<!--- Describe what you expected to happen when running the steps above -->
+
+
+##### ACTUAL RESULTS
+<!--- Describe what actually happened. If possible run with extra verbosity (-vvvv) -->
+
+<!--- Paste verbatim command output between quotes -->
+```paste below
+
+```

--- a/.github/ISSUE_TEMPLATE/documentation_report.md
+++ b/.github/ISSUE_TEMPLATE/documentation_report.md
@@ -1,0 +1,25 @@
+---
+name: Documentation Report
+about: Ask us about docs
+labels: needs_triage
+---
+<!--- Verify first that your improvement is not already reported on GitHub -->
+<!--- Also test if the latest release and devel branch are affected too -->
+<!--- Complete *all* sections as described, this form is processed automatically -->
+
+##### SUMMARY
+<!--- Explain the problem briefly below, add suggestions to wording or structure -->
+
+<!--- HINT: Did you know the documentation has an "Edit on GitHub" link on every page ? -->
+
+##### ISSUE TYPE
+- Documentation Report
+
+##### COMPONENT NAME
+<!--- Write the short name of the rst file, module, plugin, task or feature below, use your best guess if unsure -->
+
+##### ANSIBLE VERSION
+<!--- Paste verbatim output from "ansible --version" between quotes -->
+```paste below
+
+```

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,26 @@
+---
+name: ✨ Feature request
+about: Suggest an idea for this project
+labels: needs_triage
+---
+<!--- Verify first that your feature was not already discussed on GitHub -->
+<!--- Complete *all* sections as described, this form is processed automatically -->
+
+##### SUMMARY
+<!--- Describe the new feature/improvement briefly below -->
+
+##### ISSUE TYPE
+- Feature Idea
+
+##### COMPONENT NAME
+<!--- Write the short name of the module, plugin, task or feature below, use your best guess if unsure -->
+
+##### ADDITIONAL INFORMATION
+<!--- Describe how the feature would be used, why it is needed and what it would solve -->
+
+<!--- Paste example playbooks or commands between quotes below -->
+```yaml
+
+```
+
+<!--- HINT: You can also paste gist.github.com links for larger files -->

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,113 @@
+###
+# https://probot.github.io/apps/settings/
+#
+# Used by some over repos via https://github.com/ansible-collections/community.general/blob/master/.github/settings.yml
+
+repository:
+  # See https://developer.github.com/v3/repos/#edit for all available settings.
+  has_issues: true
+  has_wiki: false
+  has_pages: false
+  default_branch: devel
+  allow_squash_merge: true
+  allow_merge_commit: false
+  allow_rebase_merge: true
+
+labels:
+  # States
+  - name: ci_verified
+    color: b60205
+    description: Push fixes to PR branch to re-run CI.
+  - name: needs_ci
+    color: b60205
+    description: This PR requires CI testing to be performed. Please close and re-open this PR to trigger CI.
+  - name: merge_commit
+    color: d93f0b
+    description: This PR contains at least one merge commit. Please resolve!
+  - name: needs_rebase
+    color: d93f0b
+    description: https://docs.ansible.com/ansible/devel/dev_guide/developing_rebasing.html
+  - name: needs_info
+    color: d93f0b
+    description: This issue requires further information. Please answer any outstanding questions.
+  - name: needs_revision
+    color: d93f0b
+    description: This PR fails CI tests or a maintainer has requested a review/revision of the PR.
+  - name: needs_template
+    color: d93f0b
+    description: This issue/PR has an incomplete description. Please fill in the proposed template correctly.
+  - name: stale_ci
+    color: d93f0b
+  - name: waiting_on_contributor
+    color: d93f0b
+    description: Needs help. Feel free to engage to get things unblocked.
+  - name: new_inventory
+    color: c2e0c6
+  - name: new_plugin
+    color: c2e0c6
+  - name: new_module
+    color: c2e0c6
+  - name: new_module_directory
+    color: c2e0c6
+  - name: new_contributor
+    color: 8aea94
+  - name: bug
+    color: fbca04
+    description: This issue/PR relates to a bug.
+  - name: feature
+    color: 006b75
+    description: This issue/PR relates to a feature request.
+  - name: has_issue
+    color: ededed
+  - name: has_pr
+    color: ededed
+  - name: owner_pr
+    color: 0e8a16
+  - name: pr_day
+    color: 0e8a16
+    description: Has been reviewed during a PR review Day. https://github.com/ansible/community/issues/407
+# components
+  - name: action
+    color: 71bc1c
+  - name: become
+    color: 71bc1c
+  - name: cache
+    color: 71bc1c
+  - name: callback
+    color: 71bc1c
+  - name: cliconf
+    color: 71bc1c
+  - name: connection
+    color: 71bc1c
+  - name: docs_fragments
+    color: 71bc1c
+  - name: filter
+    color: 71bc1c
+  - name: httpapi
+    color: 71bc1c
+  - name: integration
+    color: 71bc1c
+  - name: inventory
+    color: 71bc1c
+  - name: lookup
+    color: 71bc1c
+  - name: plugin
+    color: 71bc1c
+  - name: module
+    color: 71bc1c
+  - name: module_utils
+    color: 71bc1c
+  - name: netconf
+    color: 71bc1c
+  - name: shell
+    color: 71bc1c
+  - name: strategy
+    color: 71bc1c
+  - name: terminal
+    color: 71bc1c
+  - name: tests
+    color: 71bc1c
+  - name: units
+    color: 71bc1c
+  - name: vars
+    color: 71bc1c


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY
- Allow issues/PRs to be labelled `needs_triage` by default when created.
- This would facilitate the triager tool to be more efficient.
- This also overrides the ansible-collection org level .github/, hence the entire directory has been copied over and only `labels: needs_triage` has been added.
