### PR TITLE
Allow --diff and --check to coexist on ios_config

### DIFF
--- a/changelogs/fragments/113-check-diff.yaml
+++ b/changelogs/fragments/113-check-diff.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - ios_config - Enable --diff when --check is also specified

--- a/plugins/modules/ios_config.py
+++ b/plugins/modules/ios_config.py
@@ -519,13 +519,7 @@ def main():
             indent=1, contents=contents, ignore_lines=diff_ignore_lines
         )
         if module.params["diff_against"] == "running":
-            if module.check_mode:
-                module.warn(
-                    "unable to perform diff against running-config due to check mode"
-                )
-                contents = None
-            else:
-                contents = config.config_text
+            contents = config.config_text
         elif module.params["diff_against"] == "startup":
             if not startup_config:
                 output = run_commands(module, "show startup-config")


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Specifying both `--check` and `--diff` produces a warning and not a diff. This seems undesirable.
See also: ansible-collections/arista.eos#91, ansible-collections/cisco.nxos#125

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios_config