### PR TITLE
To fix bug where gather_network_resources: l3_interfaces puts all interfaces in the dictionary instead of just those that have L3 addresses

### DIFF
--- a/plugins/module_utils/network/ios/facts/l3_interfaces/l3_interfaces.py
+++ b/plugins/module_utils/network/ios/facts/l3_interfaces/l3_interfaces.py
@@ -64,7 +64,7 @@ class L3_InterfacesFacts(object):
         for conf in config:
             if conf:
                 obj = self.render_config(self.generated_spec, conf)
-                if obj:
+                if obj and len(obj.keys()) > 1:
                     objs.append(obj)
         facts = {}
 


### PR DESCRIPTION
Make the facts module return only interfaces that have an ip address defined when using gather_network_resources: l3_interfaces

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The change makes the facts module return only interfaces with an l3 address when specifying gather_network_resources: l3_interfaces
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #116 
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios_facts module gather_network_resources: l3_interfaces
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Just invoke ios_facts with gather_network_resources: l3_interfaces
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
Before:
"l3_interfaces": [
{
"name": "Port-channel1"
},
{
"ipv4": [
{
"address": "172.25.1.1 255.255.255.0"
}
],
"name": "GigabitEthernet0/0"
},
{
"name": "GigabitEthernet1/0/1"
},
{
"name": "GigabitEthernet1/0/2"
},
{
"name": "GigabitEthernet1/0/3"
},
{
"name": "GigabitEthernet1/0/4"
},
{
"name": "GigabitEthernet1/0/5"
},
{
"name": "GigabitEthernet1/0/6"
},
{
"name": "GigabitEthernet1/0/7"
},
{
"name": "GigabitEthernet1/0/8"
},
{
"name": "GigabitEthernet1/0/9"
},
{
"name": "GigabitEthernet1/0/10"
},
{
"name": "GigabitEthernet1/0/11"
},
{
"name": "GigabitEthernet1/0/12"
},
{
"name": "GigabitEthernet1/0/13"
},
{
"name": "GigabitEthernet1/0/14"
},
{
"name": "GigabitEthernet1/0/15"
},
{
"name": "GigabitEthernet1/0/16"
},
{
"name": "GigabitEthernet1/0/17"
},
{
"name": "GigabitEthernet1/0/18"
},
{
"name": "GigabitEthernet1/0/19"
},
{
"name": "GigabitEthernet1/0/20"
},
{
"name": "GigabitEthernet1/0/21"
},
{
"name": "GigabitEthernet1/0/22"
},
{
"name": "GigabitEthernet1/0/23"
},
{
"name": "GigabitEthernet1/0/24"
},
{
"name": "GigabitEthernet1/1/1"
},
{
"name": "GigabitEthernet1/1/2"
},
{
"name": "TenGigabitEthernet1/1/3"
},
{
"name": "TenGigabitEthernet1/1/4"
},
{
"name": "Vlan1"
}
]

After:
 "l3_interfaces": [
                {
                    "ipv4": [
                        {
                            "address": "172.25.1.1 255.255.255.0"
                        }
                    ],
                    "name": "GigabitEthernet0/0"
                }
            ]
```
