### PR TITLE
To fix the issue where ios acls was complaining in absence of protocol option value

### DIFF
--- a/changelogs/fragments/124_resolved_ios_acls_issue.yaml
+++ b/changelogs/fragments/124_resolved_ios_acls_issue.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - To fix the issue where ios acls was complaining in absence of protocol option value(https://github.com/ansible-collections/cisco.ios/pull/124).

--- a/plugins/module_utils/network/ios/config/acls/acls.py
+++ b/plugins/module_utils/network/ios/config/acls/acls.py
@@ -664,15 +664,11 @@ class Acls(ConfigBase):
         if any:
             cmd = cmd + " {0}".format("any")
         port_protocol = config.get("port_protocol")
-        if port_protocol and (
-            protocol_option.get("tcp") or protocol_option.get("udp")
-        ):
+        if port_protocol and ('tcp' in cmd or 'udp' in cmd):
             cmd = cmd + " {0} {1}".format(
                 list(port_protocol)[0], list(port_protocol.values())[0]
             )
-        elif port_protocol and not (
-            protocol_option.get("tcp") or protocol_option.get("udp")
-        ):
+        elif port_protocol and ('tcp' not in cmd or 'udp' not in cmd):
             self._module.fail_json(
                 msg="Port Protocol option is valid only with TCP/UDP Protocol option!"
             )

--- a/plugins/module_utils/network/ios/config/acls/acls.py
+++ b/plugins/module_utils/network/ios/config/acls/acls.py
@@ -664,11 +664,11 @@ class Acls(ConfigBase):
         if any:
             cmd = cmd + " {0}".format("any")
         port_protocol = config.get("port_protocol")
-        if port_protocol and ('tcp' in cmd or 'udp' in cmd):
+        if port_protocol and ("tcp" in cmd or "udp" in cmd):
             cmd = cmd + " {0} {1}".format(
                 list(port_protocol)[0], list(port_protocol.values())[0]
             )
-        elif port_protocol and ('tcp' not in cmd or 'udp' not in cmd):
+        elif port_protocol and ("tcp" not in cmd or "udp" not in cmd):
             self._module.fail_json(
                 msg="Port Protocol option is valid only with TCP/UDP Protocol option!"
             )

--- a/plugins/module_utils/network/ios/facts/acls/acls.py
+++ b/plugins/module_utils/network/ios/facts/acls/acls.py
@@ -610,22 +610,16 @@ class AclsFacts(object):
                     tcp = {}
                     if temp_flag:
                         tcp[temp_flag] = True
-                    else:
-                        tcp["set"] = True
                     protocol_options[temp_option] = tcp
                 elif temp_option == "icmp":
                     icmp = dict()
                     if temp_flag:
                         icmp[temp_flag] = True
-                    else:
-                        icmp["set"] = True
                     protocol_options[temp_option] = icmp
                 elif temp_option == "igmp":
                     igmp = dict()
                     if temp_flag:
                         igmp[temp_flag] = True
-                    else:
-                        igmp["set"] = True
                     protocol_options[temp_option] = igmp
                 else:
                     protocol_options[temp_option] = True

--- a/tests/unit/modules/network/ios/test_ios_acls.py
+++ b/tests/unit/modules/network/ios/test_ios_acls.py
@@ -108,6 +108,28 @@ class TestIosAclsModule(TestIosModule):
                         ],
                     ),
                     dict(
+                        afi="ipv4",
+                        acls=[
+                            dict(
+                                name="in_to_out",
+                                acl_type="extended",
+                                aces=[
+                                    dict(
+                                        grant="permit",
+                                        protocol="tcp",
+                                        source=dict(
+                                            host="10.1.1.2",
+                                        ),
+                                        destination=dict(
+                                            host="172.16.1.1",
+                                            port_protocol=dict(eq="telnet"),
+                                        ),
+                                    )
+                                ],
+                            )
+                        ],
+                    ),
+                    dict(
                         afi="ipv6",
                         acls=[
                             dict(
@@ -140,6 +162,8 @@ class TestIosAclsModule(TestIosModule):
         commands = [
             "ip access-list standard std_acl",
             "deny 192.0.2.0 0.0.0.255",
+            "ip access-list extended in_to_out",
+            "permit tcp host 10.1.1.2 host 172.16.1.1 eq telnet",
             "ipv6 access-list merge_v6_acl",
             "deny tcp any eq www any eq telnet ack dscp af11",
         ]

--- a/tests/unit/modules/network/ios/test_ios_acls.py
+++ b/tests/unit/modules/network/ios/test_ios_acls.py
@@ -117,9 +117,7 @@ class TestIosAclsModule(TestIosModule):
                                     dict(
                                         grant="permit",
                                         protocol="tcp",
-                                        source=dict(
-                                            host="10.1.1.2",
-                                        ),
+                                        source=dict(host="10.1.1.2"),
                                         destination=dict(
                                             host="172.16.1.1",
                                             port_protocol=dict(eq="telnet"),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
To fix the issue where IOS ACLs was complaining in absence of protocol option value, PR fixes the issue raised in #122
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios_acls

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
