### PR TITLE
Add cdp platform information to ios_facts output

### DIFF
--- a/changelogs/fragments/146_add_cdp_platform_info_to_ios_facts.yaml
+++ b/changelogs/fragments/146_add_cdp_platform_info_to_ios_facts.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Add CDP platform information to ios_facts module output.

--- a/plugins/module_utils/network/ios/facts/legacy/base.py
+++ b/plugins/module_utils/network/ios/facts/legacy/base.py
@@ -304,6 +304,7 @@ class Interfaces(FactsBase):
                 facts[intf] = list()
             fact = dict()
             fact["host"] = self.parse_cdp_host(entry)
+            fact["platform"] = self.parse_cdp_platform(entry)
             fact["port"] = port
             facts[intf].append(fact)
         return facts
@@ -398,5 +399,10 @@ class Interfaces(FactsBase):
 
     def parse_cdp_host(self, data):
         match = re.search(r"^Device ID: (.+)$", data, re.M)
+        if match:
+            return match.group(1)
+
+    def parse_cdp_platform(self, data):
+        match = re.search(r"^Platform: (.+),", data, re.M)
         if match:
             return match.group(1)

--- a/tests/unit/modules/network/ios/test_ios_facts.py
+++ b/tests/unit/modules/network/ios/test_ios_facts.py
@@ -147,8 +147,16 @@ class TestIosFactsModule(TestIosModule):
                 "GigabitEthernet1"
             ],
             [
-                {"platform": "cisco CSR1000V", "host": "R2", "port": "GigabitEthernet2"},
-                {"platform": "cisco CSR1000V", "host": "R3", "port": "GigabitEthernet3"},
+                {
+                    "platform": "cisco CSR1000V",
+                    "host": "R2",
+                    "port": "GigabitEthernet2"
+                },
+                {
+                    "platform": "cisco CSR1000V",
+                    "host": "R3",
+                    "port": "GigabitEthernet3"
+                },
             ],
         )
         assertCountEqual(

--- a/tests/unit/modules/network/ios/test_ios_facts.py
+++ b/tests/unit/modules/network/ios/test_ios_facts.py
@@ -147,8 +147,8 @@ class TestIosFactsModule(TestIosModule):
                 "GigabitEthernet1"
             ],
             [
-                {"host": "R2", "port": "GigabitEthernet2"},
-                {"host": "R3", "port": "GigabitEthernet3"},
+                {"platform": "cisco CSR1000V", "host": "R2", "port": "GigabitEthernet2"},
+                {"platform": "cisco CSR1000V", "host": "R3", "port": "GigabitEthernet3"},
             ],
         )
         assertCountEqual(

--- a/tests/unit/modules/network/ios/test_ios_facts.py
+++ b/tests/unit/modules/network/ios/test_ios_facts.py
@@ -150,12 +150,12 @@ class TestIosFactsModule(TestIosModule):
                 {
                     "platform": "cisco CSR1000V",
                     "host": "R2",
-                    "port": "GigabitEthernet2"
+                    "port": "GigabitEthernet2",
                 },
                 {
                     "platform": "cisco CSR1000V",
                     "host": "R3",
-                    "port": "GigabitEthernet3"
+                    "port": "GigabitEthernet3",
                 },
             ],
         )


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Add cdp platform information to ios_facts ansible_net_neighbors return value.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- ios_facts

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before change (partial output)
```
        "GigabitEthernet1/0/17": [
            {
                "host": "cisco.ap.local",
                "port": "GigabitEthernet0"
            }
        ],
```
After change (partial output)
```
        "GigabitEthernet1/0/17": [
            {
                "host": "cisco.ap.local",
                "platform": "cisco AIR-CAP702W-E-K9",
                "port": "GigabitEthernet0"
            }
        ],
```
