### PR TITLE
To fix the incorrect command displayed under ios_l3_interfaces resource module docs

### DIFF
--- a/changelogs/fragments/132_update_ios_l3_doc_issue.yaml
+++ b/changelogs/fragments/132_update_ios_l3_doc_issue.yaml
@@ -1,4 +1,3 @@
 ---
 bugfixes:
   - To update the IOS L3 doc issue raised in issue(https://github.com/ansible-collections/cisco.ios/issue/132).
-

--- a/changelogs/fragments/132_update_ios_l3_doc_issue.yaml
+++ b/changelogs/fragments/132_update_ios_l3_doc_issue.yaml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - To update the IOS L3 doc issue raised in issue(https://github.com/ansible-collections/cisco.ios/issue/132).
+

--- a/plugins/modules/ios_l3_interfaces.py
+++ b/plugins/modules/ios_l3_interfaces.py
@@ -115,8 +115,8 @@ options:
       - The state I(parsed) reads the configuration from C(running_config) option and
         transforms it into JSON format as per the resource module parameters and the
         value is returned in the I(parsed) key within the result. The value of C(running_config)
-        option should be the same format as the output of command I(show running-config
-        | section ^interface) executed on device. For state I(parsed) active
+        option should be the same format as the output of command
+        I(show running-config | section ^interface) executed on device. For state I(parsed) active
         connection to remote host is not required.
     type: str
 

--- a/plugins/modules/ios_l3_interfaces.py
+++ b/plugins/modules/ios_l3_interfaces.py
@@ -115,8 +115,8 @@ options:
       - The state I(parsed) reads the configuration from C(running_config) option and
         transforms it into JSON format as per the resource module parameters and the
         value is returned in the I(parsed) key within the result. The value of C(running_config)
-        option should be the same format as the output of command I(show running-config | 
-        section ^interface) executed on device. For state I(parsed) active
+        option should be the same format as the output of command I(show running-config
+        | section ^interface) executed on device. For state I(parsed) active
         connection to remote host is not required.
     type: str
 

--- a/plugins/modules/ios_l3_interfaces.py
+++ b/plugins/modules/ios_l3_interfaces.py
@@ -115,8 +115,8 @@ options:
       - The state I(parsed) reads the configuration from C(running_config) option and
         transforms it into JSON format as per the resource module parameters and the
         value is returned in the I(parsed) key within the result. The value of C(running_config)
-        option should be the same format as the output of command I(show running-config
-        | include ip route|ipv6 route) executed on device. For state I(parsed) active
+        option should be the same format as the output of command I(show running-config | 
+        section ^interface) executed on device. For state I(parsed) active
         connection to remote host is not required.
     type: str
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
To fix the incorrect command displayed under ios_l3_interfaces resource module docs. Closes issue: #132 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios_l3_interfaces

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
