### PR TITLE
l2 interface for existing `allowed vlan all`

### DIFF
--- a/plugins/module_utils/network/ios/config/l2_interfaces/l2_interfaces.py
+++ b/plugins/module_utils/network/ios/config/l2_interfaces/l2_interfaces.py
@@ -361,8 +361,9 @@ class L2_Interfaces(ConfigBase):
                             if self.state == "merged" and diff
                             else self.trunk_cmds["allowed_vlans"]
                         )
-                        cmd = trunk_cmd + " {0}".format(allowed_vlans)
-                        add_command_to_config_list(interface, cmd, commands)
+                        if self.state != "merged" or (have_trunk and diff):
+                            cmd = trunk_cmd + " {0}".format(allowed_vlans)
+                            add_command_to_config_list(interface, cmd, commands)
                 if pruning_vlans and self._check_for_correct_vlan_range(
                     pruning_vlans, module
                 ):


### PR DESCRIPTION
##### SUMMARY
Dear community, and to all strugeling with `switchport trunk allowed vlan all` configuration, this fix will prevent overriding the allowed vlans if none were defined. Fixes: #77 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
In the current implementation, configuring an L2 interface with an allowed vlan and the merged method result in the vlan(s) beeing added also for interfaces configured with `trunk allowed vlan all`.
The `trunk allowed vlan all` is hidden in configuration, and therefore not gathered in the facts.
As a result, the config module applies an allowed vlan configuration.

Examples:
```
# Before state:
# -------------
#
# viosl2#show running-config | section ^interface
# interface GigabitEthernet0/1
#  switchport mode trunk
#  negotiation auto
# interface GigabitEthernet0/2
#  switchport trunk allowed vlan 10-20
#  switchport mode trunk
#  negotiation auto
# interface GigabitEthernet0/3
#  negotiation auto

- name: Merge provided configuration with device configuration
  cisco.ios.ios_l2_interfaces:
    config:
    - name: GigabitEthernet0/1
      mode: trunk
      trunk:
        allowed_vlans: 40
        encapsulation: dot1q
    - name: GigabitEthernet0/2
      mode: trunk
      trunk:
        allowed_vlans: 40
        encapsulation: dot1q
    - name: GigabitEthernet0/3
      mode: trunk
      trunk:
        allowed_vlans: 40
        encapsulation: dot1q
    state: merged

# After state:
# ------------
#
# viosl2#show running-config | section ^interface
# interface GigabitEthernet0/1
#  switchport trunk allowed vlan 40
#  switchport mode trunk
#  negotiation auto
# interface GigabitEthernet0/2
#  switchport trunk allowed vlan 10-20,40
#  switchport mode trunk
#  negotiation auto
# interface GigabitEthernet0/3
#  switchport trunk allowed vlan 40
#  switchport mode trunk
#  negotiation auto
```

GigabitEthernet0/1 was allowing all vlans and is now only allowing the provided vlan(s).

When "merging" an allowed vlan configuration on interfaces configured for all vlans, it should not be applied instead of the all vlan configuration.

This fix only triggers the configuration change when:
- The requested state is not merged, or
- The interface is already in "trunk" and a diff has been found

Examples:
```
# Before state:
# -------------
#
# viosl2#show running-config | section ^interface
# interface GigabitEthernet0/1
#  switchport mode trunk
#  negotiation auto
# interface GigabitEthernet0/2
#  switchport trunk allowed vlan 10-20
#  switchport mode trunk
#  negotiation auto
# interface GigabitEthernet0/3
#  negotiation auto

- name: Merge provided configuration with device configuration
  cisco.ios.ios_l2_interfaces:
    config:
    - name: GigabitEthernet0/1
      mode: trunk
      trunk:
        allowed_vlans: 40
        encapsulation: dot1q
    - name: GigabitEthernet0/2
      mode: trunk
      trunk:
        allowed_vlans: 40
        encapsulation: dot1q
    - name: GigabitEthernet0/3
      mode: trunk
      trunk:
        allowed_vlans: 40
        encapsulation: dot1q
    state: merged

# After state:
# ------------
#
# viosl2#show running-config | section ^interface
# interface GigabitEthernet0/1
#  switchport mode trunk
#  negotiation auto
# interface GigabitEthernet0/2
#  switchport trunk allowed vlan 10-20,40
#  switchport mode trunk
#  negotiation auto
# interface GigabitEthernet0/3
#  switchport trunk allowed vlan 40
#  switchport mode trunk
#  negotiation auto
```