### PR TITLE
Allowing ios_ospfv2 to accept multiple networks per process

### DIFF
--- a/changelogs/fragments/135_accept_list_of_dict_for_ospfv2_network.yaml
+++ b/changelogs/fragments/135_accept_list_of_dict_for_ospfv2_network.yaml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - To accept list of dict for OSPFv2 network param(https://github.com/ansible-collections/cisco.ios/issues/152)
+

--- a/changelogs/fragments/135_accept_list_of_dict_for_ospfv2_network.yaml
+++ b/changelogs/fragments/135_accept_list_of_dict_for_ospfv2_network.yaml
@@ -1,4 +1,3 @@
 ---
 bugfixes:
   - To accept list of dict for OSPFv2 network param(https://github.com/ansible-collections/cisco.ios/issues/152)
-

--- a/plugins/module_utils/network/ios/argspec/ospfv2/ospfv2.py
+++ b/plugins/module_utils/network/ios/argspec/ospfv2/ospfv2.py
@@ -416,7 +416,8 @@ class Ospfv2Args(object):
                                 "area": {"type": "str"},
                                 "wildcard_bits": {"type": "str"},
                             },
-                            "type": "dict",
+                            "type": "list",
+                            "elements": "dict",
                         },
                         "nsf": {
                             "options": {

--- a/plugins/module_utils/network/ios/rm_templates/ospfv2.py
+++ b/plugins/module_utils/network/ios/rm_templates/ospfv2.py
@@ -476,13 +476,14 @@ def _tmplt_ospf_neighbor(config_data):
 
 def _tmplt_ospf_network(config_data):
     if "network" in config_data:
-        command = "network"
-        if "address" in config_data["network"]:
-            command += " {address} {wildcard_bits}".format(
-                **config_data["network"]
-            )
-        if "area" in config_data["network"]:
-            command += " area {area}".format(**config_data["network"])
+        command = []
+        for each in config_data["network"]:
+            cmd = "network"
+            if "address" in each:
+                cmd += " {address} {wildcard_bits}".format(**each)
+            if "area" in each:
+                cmd += " area {area}".format(**each)
+            command.append(cmd)
         return command
 
 
@@ -1591,11 +1592,13 @@ class Ospfv2Template(NetworkTemplate):
             "result": {
                 "processes": {
                     "{{ pid }}": {
-                        "network": {
-                            "address": "{{ address }}",
-                            "wildcard_bits": "{{ wildcard }}",
-                            "area": "{{ area.split(" ")[1] }}",
-                        }
+                        "network": [
+                            {
+                                "address": "{{ address }}",
+                                "wildcard_bits": "{{ wildcard }}",
+                                "area": "{{ area.split(" ")[1] }}",
+                            }
+                        ]
                     }
                 }
             },

--- a/plugins/modules/ios_ospfv2.py
+++ b/plugins/modules/ios_ospfv2.py
@@ -701,7 +701,8 @@ options:
                 type: int
           network:
             description: Enable routing on an IP network
-            type: dict
+            type: list
+            elements: dict
             suboptions:
               address:
                 description: Network number

--- a/tests/integration/targets/ios_ospfv2/tests/cli/_populate_config.yaml
+++ b/tests/integration/targets/ios_ospfv2/tests/cli/_populate_config.yaml
@@ -27,9 +27,9 @@
                 - name: test_prefix_out
                   direction: out
           network:
-            address: 198.51.100.0
-            wildcard_bits: 0.0.0.255
-            area: 5
+            - address: 198.51.100.0
+              wildcard_bits: 0.0.0.255
+              area: 5
           default_information:
             originate: true
         - process_id: 200

--- a/tests/integration/targets/ios_ospfv2/tests/cli/merged.yaml
+++ b/tests/integration/targets/ios_ospfv2/tests/cli/merged.yaml
@@ -37,9 +37,9 @@
                     - name: test_prefix_out
                       direction: out
               network:
-                address: 198.51.100.0
-                wildcard_bits: 0.0.0.255
-                area: 5
+                - address: 198.51.100.0
+                  wildcard_bits: 0.0.0.255
+                  area: 5
               default_information:
                 originate: true
             - process_id: 200

--- a/tests/integration/targets/ios_ospfv2/tests/cli/rendered.yaml
+++ b/tests/integration/targets/ios_ospfv2/tests/cli/rendered.yaml
@@ -33,9 +33,9 @@
                     - name: test_prefix_out
                       direction: out
               network:
-                address: 198.51.100.0
-                wildcard_bits: 0.0.0.255
-                area: 5
+                - address: 198.51.100.0
+                  wildcard_bits: 0.0.0.255
+                  area: 5
               default_information:
                 originate: true
             - process_id: 200

--- a/tests/integration/targets/ios_ospfv2/tests/cli/rtt.yaml
+++ b/tests/integration/targets/ios_ospfv2/tests/cli/rtt.yaml
@@ -37,9 +37,9 @@
                     - name: test_prefix_out
                       direction: out
               network:
-                address: 198.51.100.0
-                wildcard_bits: 0.0.0.255
-                area: 5
+                - address: 198.51.100.0
+                  wildcard_bits: 0.0.0.255
+                  area: 5
               default_information:
                 originate: true
             - process_id: 200

--- a/tests/integration/targets/ios_ospfv2/vars/main.yaml
+++ b/tests/integration/targets/ios_ospfv2/vars/main.yaml
@@ -50,9 +50,9 @@ merged:
             time: 110
           router_lsa: true
         network:
-          address: 198.51.100.0
-          area: "5"
-          wildcard_bits: 0.0.0.255
+          - address: 198.51.100.0
+            area: "5"
+            wildcard_bits: 0.0.0.255
         process_id: 1
       - areas:
           - area_id: "10"
@@ -122,9 +122,9 @@ replaced:
             time: 110
           router_lsa: true
         network:
-          address: 198.51.100.0
-          area: "5"
-          wildcard_bits: 0.0.0.255
+          - address: 198.51.100.0
+            area: "5"
+            wildcard_bits: 0.0.0.255
         process_id: 1
       - areas:
           - area_id: "5"

--- a/tests/unit/modules/network/ios/test_ios_ospfv2.py
+++ b/tests/unit/modules/network/ios/test_ios_ospfv2.py
@@ -87,6 +87,18 @@ class TestIosOspfV2Module(TestIosModule):
                                     dict(direction="in", name="123"),
                                 ]
                             ),
+                            network=[
+                                dict(
+                                    address="198.51.100.0",
+                                    wildcard_bits="0.0.0.255",
+                                    area=5,
+                                ),
+                                dict(
+                                    address="192.0.2.0",
+                                    wildcard_bits="0.0.0.255",
+                                    area=5,
+                                ),
+                            ],
                             domain_id=dict(
                                 ip_address=dict(address="192.0.3.1")
                             ),
@@ -105,6 +117,8 @@ class TestIosOspfV2Module(TestIosModule):
             "auto-cost reference-bandwidth 4",
             "distribute-list 123 in",
             "distribute-list 10 out",
+            "network 198.51.100.0 0.0.0.255 area 5",
+            "network 192.0.2.0 0.0.0.255 area 5",
             "domain-id 192.0.3.1",
             "max-metric router-lsa on-startup 100",
         ]


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Allowing ios_ospfv2 to accept multiple networks per process, so changing the logic of accepting list of dict instead of single dict. PR fixes issue: #135
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios_ospfv2

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
