### PR TITLE
To fix ios_static_routes where interface ip route-cache config was being parsed and resulted traceback

### DIFF
--- a/changelogs/fragments/161_static_route_facts_cmd_update.yaml
+++ b/changelogs/fragments/161_static_route_facts_cmd_update.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - To fix ios_static_routes where interface ip route-cache config was being parsed and resulted traceback

--- a/plugins/module_utils/network/ios/facts/static_routes/static_routes.py
+++ b/plugins/module_utils/network/ios/facts/static_routes/static_routes.py
@@ -48,7 +48,7 @@ class Static_RoutesFacts(object):
 
     def get_static_routes_data(self, connection):
         return connection.get(
-            "sh running-config | include ip route|ipv6 route"
+            "sh running-config | section ^ip route|ipv6 route"
         )
 
     def populate_facts(self, connection, ansible_facts, data=None):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
To fix ios_static_routes where interface ip route-cache config was being parsed and resulted trackback. Fixes issue: #161 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios_static_routes

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
