### PR TITLE
To fix IOS static routes idempotency issue coz of netmask to cidr conversion

### DIFF
--- a/changelogs/fragments/137_ios_static_routes_idempotency_issue.yaml
+++ b/changelogs/fragments/137_ios_static_routes_idempotency_issue.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - To fix IOS static routes idempotency issue coz of netmask to cidr conversion(https://github.com/ansible-collections/cisco.ios/issues/137).

--- a/plugins/module_utils/network/ios/utils/utils.py
+++ b/plugins/module_utils/network/ios/utils/utils.py
@@ -11,6 +11,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 import socket
+from netaddr import IPAddress
 from ansible.module_utils.six import iteritems
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     is_masklen,
@@ -275,28 +276,7 @@ def validate_n_expand_ipv4(module, want):
 
 
 def netmask_to_cidr(netmask):
-    bit_range = [128, 64, 32, 16, 8, 4, 2, 1]
-    count = 0
-    cidr = 0
-    netmask_list = netmask.split(".")
-    netmask_calc = [i for i in netmask_list if int(i) != 255 and int(i) != 0]
-    if netmask_calc:
-        netmask_calc_index = netmask_list.index(netmask_calc[0])
-    elif sum(list(map(int, netmask_list))) == 0:
-        return "32"
-    else:
-        return "24"
-    for each in bit_range:
-        if cidr == int(netmask.split(".")[2]):
-            if netmask_calc_index == 1:
-                return str(8 + count)
-            elif netmask_calc_index == 2:
-                return str(8 * 2 + count)
-            elif netmask_calc_index == 3:
-                return str(8 * 3 + count)
-            break
-        cidr += each
-        count += 1
+    return str(IPAddress(netmask).netmask_bits())
 
 
 def normalize_interface(name):

--- a/plugins/module_utils/network/ios/utils/utils.py
+++ b/plugins/module_utils/network/ios/utils/utils.py
@@ -11,7 +11,6 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 import socket
-from netaddr import IPAddress
 from ansible.module_utils.six import iteritems
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     is_masklen,
@@ -276,7 +275,8 @@ def validate_n_expand_ipv4(module, want):
 
 
 def netmask_to_cidr(netmask):
-    return str(IPAddress(netmask).netmask_bits())
+    # convert netmask to cidr and returns the cidr notation
+    return str(sum([bin(int(x)).count("1") for x in netmask.split(".")]))
 
 
 def normalize_interface(name):

--- a/tests/unit/modules/network/ios/fixtures/ios_static_routes_config.cfg
+++ b/tests/unit/modules/network/ios/fixtures/ios_static_routes_config.cfg
@@ -1,2 +1,3 @@
-ip route vrf ansible_vrf 192.0.2.0 255.255.255.0 192.0.2.1 name test_vrf track 175 tag 50
+ip route vrf ansible_vrf 0.0.0.0 0.0.0.0 198.51.101.1 name test_vrf_1 track 150 tag 100
+ip route vrf ansible_vrf 192.0.2.0 255.255.255.0 192.0.2.1 name test_vrf_2 track 175 tag 50
 ip route 198.51.100.0 255.255.255.0 198.51.101.1 110 multicast name route_1 tag 60

--- a/tests/unit/modules/network/ios/test_ios_static_routes.py
+++ b/tests/unit/modules/network/ios/test_ios_static_routes.py
@@ -365,7 +365,8 @@ class TestIosStaticRoutesModule(TestIosModule):
         result = self.execute_module(changed=True)
         commands = [
             "no ip route 198.51.100.0 255.255.255.0 198.51.101.1 110 multicast name route_1 tag 60",
-            "no ip route vrf ansible_vrf 192.0.2.0 255.255.255.0 192.0.2.1 name test_vrf track 175 tag 50",
+            "no ip route vrf ansible_vrf 0.0.0.0 0.0.0.0 198.51.101.1 name test_vrf_1 track 150 tag 100",
+            "no ip route vrf ansible_vrf 192.0.2.0 255.255.255.0 192.0.2.1 name test_vrf_2 track 175 tag 50",
             "ip route 198.51.100.0 255.255.255.0 198.51.101.1 150 multicast name override_route_1 tag 50",
         ]
 
@@ -541,7 +542,7 @@ class TestIosStaticRoutesModule(TestIosModule):
         )
         result = self.execute_module(changed=True)
         commands = [
-            "no ip route vrf ansible_vrf 192.0.2.0 255.255.255.0 192.0.2.1 name test_vrf track 175 tag 50"
+            "no ip route vrf ansible_vrf 192.0.2.0 255.255.255.0 192.0.2.1 name test_vrf_2 track 175 tag 50"
         ]
         self.assertEqual(result["commands"], commands)
 

--- a/tests/unit/modules/network/ios/test_ios_static_routes.py
+++ b/tests/unit/modules/network/ios/test_ios_static_routes.py
@@ -141,11 +141,32 @@ class TestIosStaticRoutesModule(TestIosModule):
                                 afi="ipv4",
                                 routes=[
                                     dict(
+                                        dest="0.0.0.0/0",
+                                        next_hops=[
+                                            dict(
+                                                forward_router_address="198.51.101.1",
+                                                name="test_vrf_1",
+                                                tag=100,
+                                                track=150,
+                                            )
+                                        ],
+                                    )
+                                ],
+                            )
+                        ],
+                    ),
+                    dict(
+                        vrf="ansible_vrf",
+                        address_families=[
+                            dict(
+                                afi="ipv4",
+                                routes=[
+                                    dict(
                                         dest="192.0.2.0/24",
                                         next_hops=[
                                             dict(
                                                 forward_router_address="192.0.2.1",
-                                                name="test_vrf",
+                                                name="test_vrf_2",
                                                 tag=50,
                                                 track=175,
                                             )
@@ -250,11 +271,32 @@ class TestIosStaticRoutesModule(TestIosModule):
                                 afi="ipv4",
                                 routes=[
                                     dict(
+                                        dest="0.0.0.0/0",
+                                        next_hops=[
+                                            dict(
+                                                forward_router_address="198.51.101.1",
+                                                name="test_vrf_1",
+                                                tag=100,
+                                                track=150,
+                                            )
+                                        ],
+                                    )
+                                ],
+                            )
+                        ],
+                    ),
+                    dict(
+                        vrf="ansible_vrf",
+                        address_families=[
+                            dict(
+                                afi="ipv4",
+                                routes=[
+                                    dict(
                                         dest="192.0.2.0/24",
                                         next_hops=[
                                             dict(
                                                 forward_router_address="192.0.2.1",
-                                                name="test_vrf",
+                                                name="test_vrf_2",
                                                 tag=50,
                                                 track=175,
                                             )
@@ -340,11 +382,32 @@ class TestIosStaticRoutesModule(TestIosModule):
                                 afi="ipv4",
                                 routes=[
                                     dict(
+                                        dest="0.0.0.0/0",
+                                        next_hops=[
+                                            dict(
+                                                forward_router_address="198.51.101.1",
+                                                name="test_vrf_1",
+                                                tag=100,
+                                                track=150,
+                                            )
+                                        ],
+                                    )
+                                ],
+                            )
+                        ],
+                    ),
+                    dict(
+                        vrf="ansible_vrf",
+                        address_families=[
+                            dict(
+                                afi="ipv4",
+                                routes=[
+                                    dict(
                                         dest="192.0.2.0/24",
                                         next_hops=[
                                             dict(
                                                 forward_router_address="192.0.2.1",
-                                                name="test_vrf",
+                                                name="test_vrf_2",
                                                 tag=50,
                                                 track=175,
                                             )


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
To fix IOS static routes idempotency issue coz of netmask to cidr conversion. Fixes #137 and #178 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios_static_routes

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
