### PR TITLE
To fix ios_vlans traceback bug when the name had Remote in it and added unit TC for the module

### DIFF
--- a/changelogs/fragments/175_fix_ios_vlans_when_name_had_remote.yaml
+++ b/changelogs/fragments/175_fix_ios_vlans_when_name_had_remote.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - To fix ios_vlans traceback bug when the name had Remote in it(https://github.com/ansible-collections/cisco.ios/issues/175).

--- a/plugins/module_utils/network/ios/facts/vlans/vlans.py
+++ b/plugins/module_utils/network/ios/facts/vlans/vlans.py
@@ -65,13 +65,13 @@ class VlansFacts(object):
         # Get individual vlan configs separately
         vlan_info = ""
         for conf in config:
-            if "Name" in conf:
+            if "VLAN Name" in conf:
                 vlan_info = "Name"
-            elif "Type" in conf:
+            elif "VLAN Type" in conf:
                 vlan_info = "Type"
-            elif "Remote" in conf:
+            elif "Remote SPAN" in conf:
                 vlan_info = "Remote"
-            elif "AREHops" in conf or "STEHops" in conf:
+            elif "VLAN AREHops" in conf or "STEHops" in conf:
                 vlan_info = "Hops"
             if conf and " " not in filter(None, conf.split("-")):
                 obj = self.render_config(self.generated_spec, conf, vlan_info)
@@ -120,7 +120,7 @@ class VlansFacts(object):
         """
         config = deepcopy(spec)
 
-        if vlan_info == "Name" and "Name" not in conf:
+        if vlan_info == "Name" and "VLAN Name" not in conf:
             conf = list(filter(None, conf.split(" ")))
             config["vlan_id"] = int(conf[0])
             config["name"] = conf[1]
@@ -139,7 +139,7 @@ class VlansFacts(object):
                     config["shutdown"] = "disabled"
             except IndexError:
                 pass
-        elif vlan_info == "Type" and "Type" not in conf:
+        elif vlan_info == "Type" and "VLAN Type" not in conf:
             conf = list(filter(None, conf.split(" ")))
             config["mtu"] = int(conf[3])
         elif vlan_info == "Remote":

--- a/tests/unit/modules/network/ios/fixtures/ios_vlans_config.cfg
+++ b/tests/unit/modules/network/ios/fixtures/ios_vlans_config.cfg
@@ -1,6 +1,7 @@
 VLAN Name                             Status    Ports
 ---- -------------------------------- --------- -------------------------------
 1    default                          active    Gi0/1, Gi0/2
+123  RemoteIsInMyName                 act/unsup
 150  VLAN0150                         active
 1002 fddi-default                     act/unsup
 1003 trcrf-default                    act/unsup
@@ -10,6 +11,7 @@ VLAN Name                             Status    Ports
 VLAN Type  SAID       MTU   Parent RingNo BridgeNo Stp  BrdgMode Trans1 Trans2
 ---- ----- ---------- ----- ------ ------ -------- ---- -------- ------ ------
 1    enet  100001     1500  -      -      -        -    -        0      0
+123  enet  100150     610   -      -      -        -    -        0      0
 150  enet  100150     1500  -      -      -        -    -        0      0
 1002 fddi  101002     1500  -      -      -        -    -        0      0
 1003 trcrf 101003     4472  1005   3276   -        -    srb      0      0

--- a/tests/unit/modules/network/ios/fixtures/ios_vlans_config.cfg
+++ b/tests/unit/modules/network/ios/fixtures/ios_vlans_config.cfg
@@ -1,0 +1,29 @@
+VLAN Name                             Status    Ports
+---- -------------------------------- --------- -------------------------------
+1    default                          active    Gi0/1, Gi0/2
+150  VLAN0150                         active
+1002 fddi-default                     act/unsup
+1003 trcrf-default                    act/unsup
+1004 fddinet-default                  act/unsup
+1005 trbrf-default                    act/unsup
+
+VLAN Type  SAID       MTU   Parent RingNo BridgeNo Stp  BrdgMode Trans1 Trans2
+---- ----- ---------- ----- ------ ------ -------- ---- -------- ------ ------
+1    enet  100001     1500  -      -      -        -    -        0      0
+150  enet  100150     1500  -      -      -        -    -        0      0
+1002 fddi  101002     1500  -      -      -        -    -        0      0
+1003 trcrf 101003     4472  1005   3276   -        -    srb      0      0
+1004 fdnet 101004     1500  -      -      -        ieee -        0      0
+1005 trbrf 101005     4472  -      -      15       ibm  -        0      0
+
+
+VLAN AREHops STEHops Backup CRF
+---- ------- ------- ----------
+1003 7       7       off
+
+Remote SPAN VLANs
+------------------------------------------------------------------------------
+150
+
+Primary Secondary Type              Ports
+------- --------- ----------------- ------------------------------------------

--- a/tests/unit/modules/network/ios/test_ios_vlans.py
+++ b/tests/unit/modules/network/ios/test_ios_vlans.py
@@ -78,30 +78,18 @@ class TestIosVlansModule(TestIosModule):
             dict(
                 config=[
                     dict(
-                        mtu=610,
-                        name="RemoteIsInMyName",
-                        shutdown="enabled",
-                        state="active",
-                        vlan_id=123,
-                    ),
-                    dict(
                         name="test_vlan_200",
                         state="active",
                         shutdown="disabled",
                         remote_span=True,
                         vlan_id=200,
-                    ),
+                    )
                 ],
                 state="merged",
             )
         )
         result = self.execute_module(changed=True)
         commands = [
-            "vlan 123",
-            "name RemoteIsInMyName",
-            "state active",
-            "mtu 610",
-            "shutdown",
             "vlan 200",
             "name test_vlan_200",
             "state active",
@@ -120,6 +108,13 @@ class TestIosVlansModule(TestIosModule):
                         shutdown="disabled",
                         state="active",
                         vlan_id=1,
+                    ),
+                    dict(
+                        mtu=610,
+                        name="RemoteIsInMyName",
+                        shutdown="enabled",
+                        state="active",
+                        vlan_id=123,
                     ),
                     dict(
                         mtu=1500,
@@ -200,6 +195,13 @@ class TestIosVlansModule(TestIosModule):
                         vlan_id=1,
                     ),
                     dict(
+                        mtu=610,
+                        name="RemoteIsInMyName",
+                        shutdown="enabled",
+                        state="active",
+                        vlan_id=123,
+                    ),
+                    dict(
                         mtu=1500,
                         name="VLAN0150",
                         remote_span=True,
@@ -258,6 +260,7 @@ class TestIosVlansModule(TestIosModule):
         )
         result = self.execute_module(changed=True)
         commands = [
+            "no vlan 123",
             "no vlan 150",
             "vlan 200",
             "name test_vlan_200",
@@ -278,6 +281,13 @@ class TestIosVlansModule(TestIosModule):
                         shutdown="disabled",
                         state="active",
                         vlan_id=1,
+                    ),
+                    dict(
+                        mtu=610,
+                        name="RemoteIsInMyName",
+                        shutdown="enabled",
+                        state="active",
+                        vlan_id=123,
                     ),
                     dict(
                         mtu=1500,

--- a/tests/unit/modules/network/ios/test_ios_vlans.py
+++ b/tests/unit/modules/network/ios/test_ios_vlans.py
@@ -82,14 +82,14 @@ class TestIosVlansModule(TestIosModule):
                         name="RemoteIsInMyName",
                         shutdown="enabled",
                         state="active",
-                        vlan_id=123 
+                        vlan_id=123,
                     ),
                     dict(
                         name="test_vlan_200",
                         state="active",
                         shutdown="disabled",
                         remote_span=True,
-                        vlan_id=200
+                        vlan_id=200,
                     ),
                 ],
                 state="merged",
@@ -119,7 +119,7 @@ class TestIosVlansModule(TestIosModule):
                         name="default",
                         shutdown="disabled",
                         state="active",
-                        vlan_id=1
+                        vlan_id=1,
                     ),
                     dict(
                         mtu=1500,
@@ -127,36 +127,36 @@ class TestIosVlansModule(TestIosModule):
                         remote_span=True,
                         shutdown="disabled",
                         state="active",
-                        vlan_id=150
+                        vlan_id=150,
                     ),
                     dict(
                         mtu=1500,
                         name="fddi-default",
                         shutdown="enabled",
                         state="active",
-                        vlan_id=1002
+                        vlan_id=1002,
                     ),
                     dict(
                         mtu=4472,
                         name="trcrf-default",
                         shutdown="enabled",
                         state="active",
-                        vlan_id=1003
+                        vlan_id=1003,
                     ),
                     dict(
                         mtu=1500,
                         name="fddinet-default",
                         shutdown="enabled",
                         state="active",
-                        vlan_id=1004
+                        vlan_id=1004,
                     ),
                     dict(
                         mtu=4472,
                         name="trbrf-default",
                         shutdown="enabled",
                         state="active",
-                        vlan_id=1005
-                    )
+                        vlan_id=1005,
+                    ),
                 ],
                 state="merged",
             )
@@ -172,8 +172,8 @@ class TestIosVlansModule(TestIosModule):
                         state="active",
                         shutdown="disabled",
                         remote_span=True,
-                        vlan_id=200
-                    ),
+                        vlan_id=200,
+                    )
                 ],
                 state="replaced",
             )
@@ -197,7 +197,7 @@ class TestIosVlansModule(TestIosModule):
                         name="default",
                         shutdown="disabled",
                         state="active",
-                        vlan_id=1
+                        vlan_id=1,
                     ),
                     dict(
                         mtu=1500,
@@ -205,36 +205,36 @@ class TestIosVlansModule(TestIosModule):
                         remote_span=True,
                         shutdown="disabled",
                         state="active",
-                        vlan_id=150
+                        vlan_id=150,
                     ),
                     dict(
                         mtu=1500,
                         name="fddi-default",
                         shutdown="enabled",
                         state="active",
-                        vlan_id=1002
+                        vlan_id=1002,
                     ),
                     dict(
                         mtu=4472,
                         name="trcrf-default",
                         shutdown="enabled",
                         state="active",
-                        vlan_id=1003
+                        vlan_id=1003,
                     ),
                     dict(
                         mtu=1500,
                         name="fddinet-default",
                         shutdown="enabled",
                         state="active",
-                        vlan_id=1004
+                        vlan_id=1004,
                     ),
                     dict(
                         mtu=4472,
                         name="trbrf-default",
                         shutdown="enabled",
                         state="active",
-                        vlan_id=1005
-                    )
+                        vlan_id=1005,
+                    ),
                 ],
                 state="replaced",
             )
@@ -250,8 +250,8 @@ class TestIosVlansModule(TestIosModule):
                         state="active",
                         shutdown="disabled",
                         remote_span=True,
-                        vlan_id=200
-                    ),
+                        vlan_id=200,
+                    )
                 ],
                 state="overridden",
             )
@@ -277,7 +277,7 @@ class TestIosVlansModule(TestIosModule):
                         name="default",
                         shutdown="disabled",
                         state="active",
-                        vlan_id=1
+                        vlan_id=1,
                     ),
                     dict(
                         mtu=1500,
@@ -285,36 +285,36 @@ class TestIosVlansModule(TestIosModule):
                         remote_span=True,
                         shutdown="disabled",
                         state="active",
-                        vlan_id=150
+                        vlan_id=150,
                     ),
                     dict(
                         mtu=1500,
                         name="fddi-default",
                         shutdown="enabled",
                         state="active",
-                        vlan_id=1002
+                        vlan_id=1002,
                     ),
                     dict(
                         mtu=4472,
                         name="trcrf-default",
                         shutdown="enabled",
                         state="active",
-                        vlan_id=1003
+                        vlan_id=1003,
                     ),
                     dict(
                         mtu=1500,
                         name="fddinet-default",
                         shutdown="enabled",
                         state="active",
-                        vlan_id=1004
+                        vlan_id=1004,
                     ),
                     dict(
                         mtu=4472,
                         name="trbrf-default",
                         shutdown="enabled",
                         state="active",
-                        vlan_id=1005
-                    )
+                        vlan_id=1005,
+                    ),
                 ],
                 state="overridden",
             )
@@ -322,22 +322,10 @@ class TestIosVlansModule(TestIosModule):
         self.execute_module(changed=False, commands=[], sort=True)
 
     def test_ios_delete_vlans_config(self):
-        set_module_args(
-            dict(
-                config=[
-                    dict(
-                        vlan_id=150
-                    ),
-                ],
-                state="deleted",
-            )
-        )
+        set_module_args(dict(config=[dict(vlan_id=150)], state="deleted"))
         result = self.execute_module(changed=True)
-        commands = [
-            "no vlan 150",
-        ]
+        commands = ["no vlan 150"]
         self.assertEqual(result["commands"], commands)
-
 
     def test_vlans_rendered(self):
         set_module_args(
@@ -348,8 +336,8 @@ class TestIosVlansModule(TestIosModule):
                         state="active",
                         shutdown="disabled",
                         remote_span=True,
-                        vlan_id=200
-                    ),
+                        vlan_id=200,
+                    )
                 ],
                 state="rendered",
             )

--- a/tests/unit/modules/network/ios/test_ios_vlans.py
+++ b/tests/unit/modules/network/ios/test_ios_vlans.py
@@ -1,0 +1,365 @@
+#
+# (c) 2019, Ansible by Red Hat, inc
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+#
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from ansible_collections.cisco.ios.tests.unit.compat.mock import patch
+from ansible_collections.cisco.ios.plugins.modules import ios_vlans
+from ansible_collections.cisco.ios.tests.unit.modules.utils import (
+    set_module_args,
+)
+from .ios_module import TestIosModule, load_fixture
+
+
+class TestIosVlansModule(TestIosModule):
+    module = ios_vlans
+
+    def setUp(self):
+        super(TestIosVlansModule, self).setUp()
+
+        self.mock_get_config = patch(
+            "ansible_collections.ansible.netcommon.plugins.module_utils.network.common.network.Config.get_config"
+        )
+        self.get_config = self.mock_get_config.start()
+
+        self.mock_load_config = patch(
+            "ansible_collections.ansible.netcommon.plugins.module_utils.network.common.network.Config.load_config"
+        )
+        self.load_config = self.mock_load_config.start()
+
+        self.mock_get_resource_connection_config = patch(
+            "ansible_collections.ansible.netcommon.plugins.module_utils.network.common.cfg.base."
+            "get_resource_connection"
+        )
+        self.get_resource_connection_config = (
+            self.mock_get_resource_connection_config.start()
+        )
+
+        self.mock_get_resource_connection_facts = patch(
+            "ansible_collections.ansible.netcommon.plugins.module_utils.network.common.facts.facts."
+            "get_resource_connection"
+        )
+        self.get_resource_connection_facts = (
+            self.mock_get_resource_connection_facts.start()
+        )
+
+        self.mock_edit_config = patch(
+            "ansible_collections.cisco.ios.plugins.module_utils.network.ios.providers.providers.CliProvider.edit_config"
+        )
+        self.edit_config = self.mock_edit_config.start()
+
+        self.mock_execute_show_command = patch(
+            "ansible_collections.cisco.ios.plugins.module_utils.network.ios.facts.vlans.vlans."
+            "VlansFacts.get_vlans_data"
+        )
+        self.execute_show_command = self.mock_execute_show_command.start()
+
+    def tearDown(self):
+        super(TestIosVlansModule, self).tearDown()
+        self.mock_get_resource_connection_config.stop()
+        self.mock_get_resource_connection_facts.stop()
+        self.mock_edit_config.stop()
+        self.mock_get_config.stop()
+        self.mock_load_config.stop()
+        self.mock_execute_show_command.stop()
+
+    def load_fixtures(self, commands=None, transport="cli"):
+        def load_from_file(*args, **kwargs):
+            return load_fixture("ios_vlans_config.cfg")
+
+        self.execute_show_command.side_effect = load_from_file
+
+    def test_ios_vlans_merged(self):
+        set_module_args(
+            dict(
+                config=[
+                    dict(
+                        mtu=610,
+                        name="RemoteIsInMyName",
+                        shutdown="enabled",
+                        state="active",
+                        vlan_id=123 
+                    ),
+                    dict(
+                        name="test_vlan_200",
+                        state="active",
+                        shutdown="disabled",
+                        remote_span=True,
+                        vlan_id=200
+                    ),
+                ],
+                state="merged",
+            )
+        )
+        result = self.execute_module(changed=True)
+        commands = [
+            "vlan 123",
+            "name RemoteIsInMyName",
+            "state active",
+            "mtu 610",
+            "shutdown",
+            "vlan 200",
+            "name test_vlan_200",
+            "state active",
+            "remote-span",
+            "no shutdown",
+        ]
+        self.assertEqual(result["commands"], commands)
+
+    def test_ios_vlans_merged_idempotent(self):
+        set_module_args(
+            dict(
+                config=[
+                    dict(
+                        mtu=1500,
+                        name="default",
+                        shutdown="disabled",
+                        state="active",
+                        vlan_id=1
+                    ),
+                    dict(
+                        mtu=1500,
+                        name="VLAN0150",
+                        remote_span=True,
+                        shutdown="disabled",
+                        state="active",
+                        vlan_id=150
+                    ),
+                    dict(
+                        mtu=1500,
+                        name="fddi-default",
+                        shutdown="enabled",
+                        state="active",
+                        vlan_id=1002
+                    ),
+                    dict(
+                        mtu=4472,
+                        name="trcrf-default",
+                        shutdown="enabled",
+                        state="active",
+                        vlan_id=1003
+                    ),
+                    dict(
+                        mtu=1500,
+                        name="fddinet-default",
+                        shutdown="enabled",
+                        state="active",
+                        vlan_id=1004
+                    ),
+                    dict(
+                        mtu=4472,
+                        name="trbrf-default",
+                        shutdown="enabled",
+                        state="active",
+                        vlan_id=1005
+                    )
+                ],
+                state="merged",
+            )
+        )
+        self.execute_module(changed=False, commands=[], sort=True)
+
+    def test_ios_vlans_replaced(self):
+        set_module_args(
+            dict(
+                config=[
+                    dict(
+                        name="test_vlan_200",
+                        state="active",
+                        shutdown="disabled",
+                        remote_span=True,
+                        vlan_id=200
+                    ),
+                ],
+                state="replaced",
+            )
+        )
+        result = self.execute_module(changed=True)
+        commands = [
+            "vlan 200",
+            "name test_vlan_200",
+            "state active",
+            "remote-span",
+            "no shutdown",
+        ]
+        self.assertEqual(result["commands"], commands)
+
+    def test_ios_vlans_replaced_idempotent(self):
+        set_module_args(
+            dict(
+                config=[
+                    dict(
+                        mtu=1500,
+                        name="default",
+                        shutdown="disabled",
+                        state="active",
+                        vlan_id=1
+                    ),
+                    dict(
+                        mtu=1500,
+                        name="VLAN0150",
+                        remote_span=True,
+                        shutdown="disabled",
+                        state="active",
+                        vlan_id=150
+                    ),
+                    dict(
+                        mtu=1500,
+                        name="fddi-default",
+                        shutdown="enabled",
+                        state="active",
+                        vlan_id=1002
+                    ),
+                    dict(
+                        mtu=4472,
+                        name="trcrf-default",
+                        shutdown="enabled",
+                        state="active",
+                        vlan_id=1003
+                    ),
+                    dict(
+                        mtu=1500,
+                        name="fddinet-default",
+                        shutdown="enabled",
+                        state="active",
+                        vlan_id=1004
+                    ),
+                    dict(
+                        mtu=4472,
+                        name="trbrf-default",
+                        shutdown="enabled",
+                        state="active",
+                        vlan_id=1005
+                    )
+                ],
+                state="replaced",
+            )
+        )
+        self.execute_module(changed=False, commands=[], sort=True)
+
+    def test_ios_vlans_overridden(self):
+        set_module_args(
+            dict(
+                config=[
+                    dict(
+                        name="test_vlan_200",
+                        state="active",
+                        shutdown="disabled",
+                        remote_span=True,
+                        vlan_id=200
+                    ),
+                ],
+                state="overridden",
+            )
+        )
+        result = self.execute_module(changed=True)
+        commands = [
+            "no vlan 150",
+            "vlan 200",
+            "name test_vlan_200",
+            "state active",
+            "remote-span",
+            "no shutdown",
+        ]
+
+        self.assertEqual(result["commands"], commands)
+
+    def test_ios_vlans_overridden_idempotent(self):
+        set_module_args(
+            dict(
+                config=[
+                    dict(
+                        mtu=1500,
+                        name="default",
+                        shutdown="disabled",
+                        state="active",
+                        vlan_id=1
+                    ),
+                    dict(
+                        mtu=1500,
+                        name="VLAN0150",
+                        remote_span=True,
+                        shutdown="disabled",
+                        state="active",
+                        vlan_id=150
+                    ),
+                    dict(
+                        mtu=1500,
+                        name="fddi-default",
+                        shutdown="enabled",
+                        state="active",
+                        vlan_id=1002
+                    ),
+                    dict(
+                        mtu=4472,
+                        name="trcrf-default",
+                        shutdown="enabled",
+                        state="active",
+                        vlan_id=1003
+                    ),
+                    dict(
+                        mtu=1500,
+                        name="fddinet-default",
+                        shutdown="enabled",
+                        state="active",
+                        vlan_id=1004
+                    ),
+                    dict(
+                        mtu=4472,
+                        name="trbrf-default",
+                        shutdown="enabled",
+                        state="active",
+                        vlan_id=1005
+                    )
+                ],
+                state="overridden",
+            )
+        )
+        self.execute_module(changed=False, commands=[], sort=True)
+
+    def test_ios_delete_vlans_config(self):
+        set_module_args(
+            dict(
+                config=[
+                    dict(
+                        vlan_id=150
+                    ),
+                ],
+                state="deleted",
+            )
+        )
+        result = self.execute_module(changed=True)
+        commands = [
+            "no vlan 150",
+        ]
+        self.assertEqual(result["commands"], commands)
+
+
+    def test_vlans_rendered(self):
+        set_module_args(
+            dict(
+                config=[
+                    dict(
+                        name="test_vlan_200",
+                        state="active",
+                        shutdown="disabled",
+                        remote_span=True,
+                        vlan_id=200
+                    ),
+                ],
+                state="rendered",
+            )
+        )
+        commands = [
+            "name test_vlan_200",
+            "no shutdown",
+            "remote-span",
+            "state active",
+            "vlan 200",
+        ]
+        result = self.execute_module(changed=False)
+        self.assertEqual(sorted(result["rendered"]), commands)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
To fix ios_vlans traceback bug when the name had Remote in it and added unit TC for the module. Fixes #175 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios_vlans

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
