### PR TITLE
To fix the traceback issue for longer vlan name having more than 32 characters

### DIFF
--- a/changelogs/fragments/63_support_for_very_long_vlan_name.yaml
+++ b/changelogs/fragments/63_support_for_very_long_vlan_name.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - To add support for accepting vlan name more than 32 characters(https://github.com/ansible-collections/cisco.ios/issues/63).

--- a/plugins/module_utils/network/ios/facts/vlans/vlans.py
+++ b/plugins/module_utils/network/ios/facts/vlans/vlans.py
@@ -72,7 +72,8 @@ class VlansFacts(object):
                 and vlan_name
             ):
                 temp = temp + conf
-                continue
+                if len([each for each in temp.split(" ") if each != ""]) <= 2:
+                    continue
             if "VLAN Name" in conf:
                 vlan_info = "Name"
             elif "VLAN Type" in conf:

--- a/plugins/module_utils/network/ios/facts/vlans/vlans.py
+++ b/plugins/module_utils/network/ios/facts/vlans/vlans.py
@@ -22,7 +22,6 @@ from ansible_collections.ansible.netcommon.plugins.module_utils.network.common i
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.argspec.vlans.vlans import (
     VlansArgs,
 )
-import q
 
 
 class VlansFacts(object):
@@ -111,7 +110,6 @@ class VlansFacts(object):
                         if each == every.get("vlan_id"):
                             every.update({"remote_span": True})
                             break
-        q(final_objs)
         facts = {}
         if final_objs:
             facts["vlans"] = []
@@ -122,7 +120,7 @@ class VlansFacts(object):
             for cfg in params["config"]:
                 facts["vlans"].append(utils.remove_empties(cfg))
         ansible_facts["ansible_network_resources"].update(facts)
-        q(facts)
+
         return ansible_facts
 
     def render_config(self, spec, conf, vlan_info):

--- a/plugins/module_utils/network/ios/facts/vlans/vlans.py
+++ b/plugins/module_utils/network/ios/facts/vlans/vlans.py
@@ -67,12 +67,9 @@ class VlansFacts(object):
         temp = ""
         vlan_name = True
         for conf in config:
-            if (
-                len([each for each in conf.split(" ") if each != ""]) <= 2
-                and vlan_name
-            ):
+            if len(list(filter(None, conf.split(" ")))) <= 2 and vlan_name:
                 temp = temp + conf
-                if len([each for each in temp.split(" ") if each != ""]) <= 2:
+                if len(list(filter(None, temp.split(" ")))) <= 2:
                     continue
             if "VLAN Name" in conf:
                 vlan_info = "Name"

--- a/tests/unit/modules/network/ios/fixtures/ios_vlans_config.cfg
+++ b/tests/unit/modules/network/ios/fixtures/ios_vlans_config.cfg
@@ -13,8 +13,9 @@ VLAN Name                             Status    Ports
 VLAN Type  SAID       MTU   Parent RingNo BridgeNo Stp  BrdgMode Trans1 Trans2
 ---- ----- ---------- ----- ------ ------ -------- ---- -------- ------ ------
 1    enet  100001     1500  -      -      -        -    -        0      0
-123  enet  100150     610   -      -      -        -    -        0      0
+123  enet  100123     610   -      -      -        -    -        0      0
 150  enet  100150     1500  -      -      -        -    -        0      0
+888  enet  100888     1500  -      -      -        -    -        0      0
 1002 fddi  101002     1500  -      -      -        -    -        0      0
 1003 trcrf 101003     4472  1005   3276   -        -    srb      0      0
 1004 fdnet 101004     1500  -      -      -        ieee -        0      0

--- a/tests/unit/modules/network/ios/test_ios_vlans.py
+++ b/tests/unit/modules/network/ios/test_ios_vlans.py
@@ -126,6 +126,13 @@ class TestIosVlansModule(TestIosModule):
                     ),
                     dict(
                         mtu=1500,
+                        name="a_very_long_vlan_name_a_very_long_vlan_name",
+                        shutdown="disabled",
+                        state="active",
+                        vlan_id=888,
+                    ),
+                    dict(
+                        mtu=1500,
                         name="fddi-default",
                         shutdown="enabled",
                         state="active",
@@ -211,6 +218,13 @@ class TestIosVlansModule(TestIosModule):
                     ),
                     dict(
                         mtu=1500,
+                        name="a_very_long_vlan_name_a_very_long_vlan_name",
+                        shutdown="disabled",
+                        state="active",
+                        vlan_id=888,
+                    ),
+                    dict(
+                        mtu=1500,
                         name="fddi-default",
                         shutdown="enabled",
                         state="active",
@@ -262,6 +276,7 @@ class TestIosVlansModule(TestIosModule):
         commands = [
             "no vlan 123",
             "no vlan 150",
+            "no vlan 888",
             "vlan 200",
             "name test_vlan_200",
             "state active",
@@ -296,6 +311,13 @@ class TestIosVlansModule(TestIosModule):
                         shutdown="disabled",
                         state="active",
                         vlan_id=150,
+                    ),
+                    dict(
+                        mtu=1500,
+                        name="a_very_long_vlan_name_a_very_long_vlan_name",
+                        shutdown="disabled",
+                        state="active",
+                        vlan_id=888,
                     ),
                     dict(
                         mtu=1500,


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
To fix the traceback issue for longer vlan name having more than 32 characters. Fixes issue raised in #63 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios_vlans

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
