### PR TITLE
Remove ansible from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-ansible
 ansible-pylibssh
 paramiko


### PR DESCRIPTION
Due to how ansible / ansible-base works, devel jobs are pulling in
ansible 2.10, making our testing invalid.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>