### PR TITLE
IOS_CONFIG - incorrectly claims success when 'Command Rejected'

### DIFF
--- a/changelogs/fragments/216_fix_command_rejected_issue.yml
+++ b/changelogs/fragments/216_fix_command_rejected_issue.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - To provide support return for "Command Rejected" (https://github.com/ansible-collections/cisco.ios/issues/216)

--- a/plugins/terminal/ios.py
+++ b/plugins/terminal/ios.py
@@ -52,6 +52,7 @@ class TerminalModule(TerminalBase):
         re.compile(br"[%\S] ?Error: ?[\s]+", re.I),
         re.compile(br"[%\S] ?Informational: ?[\s]+", re.I),
         re.compile(br"Command authorization failed"),
+        re.compile(br"Command Rejected: ?[\s]+", re.I),
     ]
 
     def on_open_shell(self):

--- a/tests/integration/targets/ios_config/tests/cli/defaults.yaml
+++ b/tests/integration/targets/ios_config/tests/cli/defaults.yaml
@@ -52,4 +52,16 @@
       - result.changed == false
       - result.stdout is defined
 
+- name: Validate Terminal Error Regex
+  ios_config:
+    lines:
+      - switchport private-vlan mapping 10 6000
+    parents: interface GigabitEthernet0/1
+  register: result
+  ignore_errors: True
+
+- assert:
+    that:
+      - result.failed == True
+      
 - debug: msg="END cli/defaults.yaml on connection={{ ansible_connection }}"

--- a/tests/integration/targets/ios_config/tests/cli/defaults.yaml
+++ b/tests/integration/targets/ios_config/tests/cli/defaults.yaml
@@ -58,10 +58,10 @@
       - switchport private-vlan mapping 10 6000
     parents: interface GigabitEthernet0/1
   register: result
-  ignore_errors: True
+  ignore_errors: true
 
 - assert:
     that:
       - result.failed == True
-      
+
 - debug: msg="END cli/defaults.yaml on connection={{ ansible_connection }}"


### PR DESCRIPTION
##### SUMMARY

Hi all, allow check "Command Reject" on config mode.
Resolves: #216 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME

##### ADDITIONAL INFORMATION

In the current implementation, configuring with "ios_config" not check if command is rejected and ansible still reports "changed", comes back and reports success, and ignores the fact they were rejected.

```
# Before :
# -------------

SWITCH#sh run int gigabitEthernet 1/3
Building configuration...

Current configuration : 378 bytes
!
interface GigabitEthernet1/3
 switchport trunk encapsulation dot1q
 switchport trunk native vlan 4094
 switchport mode trunk
 mtu 9198
 load-interval 30
 media-type rj45
 negotiation auto
 no keepalive
 no lldp transmit
 no lldp receive
 no cdp enable
 spanning-tree portfast network
 spanning-tree bpdufilter enable
end

# Task 

- name: "COMMAND"
  ios_config:
    lines:
      - switchport private-vlan mapping 10 6000
    parents: interface GigabitEthernet1/3
    save_when: modified
  register: output
  ignore_errors: yes

- name: debug
  debug:
    var: output

# Output

PLAY [SW-TEST] **********************************************************************************************************************

TASK [test : COMMAND] ***************************************************************************************************
changed: [SW-TEST]

TASK [test : debug] *****************************************************************************************************
ok: [SW-TEST] => {
    "output": {
        "banners": {},
        "changed": true,
        "commands": [
            "interface GigabitEthernet1/3",
            "switchport private-vlan mapping 10 6000"
        ],
        "failed": false,
        "updates": [
            "interface GigabitEthernet1/3",
            "switchport private-vlan mapping 10 6000"
        ]
    }
}

PLAY RECAP **************************************************************************************************************************
SW-TEST                    : ok=2    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0

# AFTER

SWITCH#sh run int gigabitEthernet 1/3
Building configuration...

Current configuration : 378 bytes
!
interface GigabitEthernet1/3
 description COLLECTE: COVAGE BPEA [5Gbps] {CN001427}
 switchport trunk encapsulation dot1q
 switchport trunk native vlan 4094
 switchport mode trunk
 mtu 9198
 load-interval 30
 media-type rj45
 negotiation auto
 no keepalive
 no lldp transmit
 no lldp receive
 no cdp enable
 spanning-tree portfast network
 spanning-tree bpdufilter enable
end

# TEST ON DEVICE

SWITCH#conf t
Enter configuration commands, one per line.  End with CNTL/Z.
SWITCH(config)#interface GigabitEthernet1/3
SWITCH(config-if)#switchport private-vlan mapping 10 6000
Command Rejected: invalid VLAN list
```

With this PR : 
```
# Restart Playbook

PLAY [SW-TEST] **********************************************************************************************************************

TASK [test : COMMAND] ***************************************************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: SWITCH(config-if)#
fatal: [SW-TEST]: FAILED! => {"changed": false, "module_stderr": "Traceback (most recent call last):\n  File \"<stdin>\", line 102, in <module>\n  File \"<stdin>\", line 94, in _ansiballz_main\n  File \"<stdin>\", line 40, in invoke_module\n  File \"/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py\", line 188, in run_module\n    fname, loader, pkg_name)\n  File \"/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py\", line 82, in _run_module_code\n    mod_name, mod_fname, mod_loader, pkg_name)\n  File \"/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py\", line 72, in _run_code\n    exec code in run_globals\n  File \"/var/folders/ml/p19wycf153nc0t30ppcshlrh0000gn/T/ansible_ios_config_payload_JjWHPV/ansible_ios_config_payload.zip/ansible_collections/cisco/ios/plugins/modules/ios_config.py\", line 577, in <module>\n  File \"/var/folders/ml/p19wycf153nc0t30ppcshlrh0000gn/T/ansible_ios_config_payload_JjWHPV/ansible_ios_config_payload.zip/ansible_collections/cisco/ios/plugins/modules/ios_config.py\", line 502, in main\n  File \"/var/folders/ml/p19wycf153nc0t30ppcshlrh0000gn/T/ansible_ios_config_payload_JjWHPV/ansible_ios_config_payload.zip/ansible_collections/cisco/ios/plugins/modules/ios_config.py\", line 376, in edit_config_or_macro\n  File \"/var/folders/ml/p19wycf153nc0t30ppcshlrh0000gn/T/ansible_ios_config_payload_JjWHPV/ansible_ios_config_payload.zip/ansible/module_utils/connection.py\", line 195, in __rpc__\nansible.module_utils.connection.ConnectionError: switchport private-vlan mapping 10 6000\r\nCommand Rejected: invalid VLAN list\r\n\r\nSWITCH(config-if)#\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}
...ignoring

TASK [test : debug] *****************************************************************************************************
ok: [SW-TEST] => {
    "output": {
        "changed": false,
        "exception": "Traceback (most recent call last):\n  File \"<stdin>\", line 102, in <module>\n  File \"<stdin>\", line 94, in _ansiballz_main\n  File \"<stdin>\", line 40, in invoke_module\n  File \"/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py\", line 188, in run_module\n    fname, loader, pkg_name)\n  File \"/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py\", line 82, in _run_module_code\n    mod_name, mod_fname, mod_loader, pkg_name)\n  File \"/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py\", line 72, in _run_code\n    exec code in run_globals\n  File \"/var/folders/ml/p19wycf153nc0t30ppcshlrh0000gn/T/ansible_ios_config_payload_JjWHPV/ansible_ios_config_payload.zip/ansible_collections/cisco/ios/plugins/modules/ios_config.py\", line 577, in <module>\n  File \"/var/folders/ml/p19wycf153nc0t30ppcshlrh0000gn/T/ansible_ios_config_payload_JjWHPV/ansible_ios_config_payload.zip/ansible_collections/cisco/ios/plugins/modules/ios_config.py\", line 502, in main\n  File \"/var/folders/ml/p19wycf153nc0t30ppcshlrh0000gn/T/ansible_ios_config_payload_JjWHPV/ansible_ios_config_payload.zip/ansible_collections/cisco/ios/plugins/modules/ios_config.py\", line 376, in edit_config_or_macro\n  File \"/var/folders/ml/p19wycf153nc0t30ppcshlrh0000gn/T/ansible_ios_config_payload_JjWHPV/ansible_ios_config_payload.zip/ansible/module_utils/connection.py\", line 195, in __rpc__\nansible.module_utils.connection.ConnectionError: switchport private-vlan mapping 10 6000\r\nCommand Rejected: invalid VLAN list\r\n\r\nSWITCH(config-if)#\n",
        "failed": true,
        "module_stderr": "Traceback (most recent call last):\n  File \"<stdin>\", line 102, in <module>\n  File \"<stdin>\", line 94, in _ansiballz_main\n  File \"<stdin>\", line 40, in invoke_module\n  File \"/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py\", line 188, in run_module\n    fname, loader, pkg_name)\n  File \"/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py\", line 82, in _run_module_code\n    mod_name, mod_fname, mod_loader, pkg_name)\n  File \"/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py\", line 72, in _run_code\n    exec code in run_globals\n  File \"/var/folders/ml/p19wycf153nc0t30ppcshlrh0000gn/T/ansible_ios_config_payload_JjWHPV/ansible_ios_config_payload.zip/ansible_collections/cisco/ios/plugins/modules/ios_config.py\", line 577, in <module>\n  File \"/var/folders/ml/p19wycf153nc0t30ppcshlrh0000gn/T/ansible_ios_config_payload_JjWHPV/ansible_ios_config_payload.zip/ansible_collections/cisco/ios/plugins/modules/ios_config.py\", line 502, in main\n  File \"/var/folders/ml/p19wycf153nc0t30ppcshlrh0000gn/T/ansible_ios_config_payload_JjWHPV/ansible_ios_config_payload.zip/ansible_collections/cisco/ios/plugins/modules/ios_config.py\", line 376, in edit_config_or_macro\n  File \"/var/folders/ml/p19wycf153nc0t30ppcshlrh0000gn/T/ansible_ios_config_payload_JjWHPV/ansible_ios_config_payload.zip/ansible/module_utils/connection.py\", line 195, in __rpc__\nansible.module_utils.connection.ConnectionError: switchport private-vlan mapping 10 6000\r\nCommand Rejected: invalid VLAN list\r\n\r\nSWITCH(config-if)#\n",
        "module_stdout": "",
        "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error",
        "rc": 1
    }
}

PLAY RECAP **************************************************************************************************************************
SW-TEST                    : ok=2    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=1
```

