### PR TITLE
Support cisco ios 12.2

### DIFF
--- a/plugins/module_utils/network/ios/facts/bgp_global/bgp_global.py
+++ b/plugins/module_utils/network/ios/facts/bgp_global/bgp_global.py
@@ -24,6 +24,7 @@ from ansible_collections.cisco.ios.plugins.module_utils.network.ios.rm_templates
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.argspec.bgp_global.bgp_global import (
     Bgp_globalArgs,
 )
+from ansible.module_utils.connection import ConnectionError
 
 
 class Bgp_globalFacts(object):
@@ -45,7 +46,13 @@ class Bgp_globalFacts(object):
         self.generated_spec = utils.generate_dict(facts_argument_spec)
 
     def get_bgp_global_data(self, connection):
-        return connection.get("sh running-config | section ^router bgp")
+        try:
+            return connection.get("sh running-config | section ^router bgp")
+        if "Invalid input detected at" in e.message:
+            data = connection.get("sh running-config | begin ^router bgp")
+            return "\n".join(re.findall(r'router bgp [^!]*!', data))
+        else:
+            raise
 
     def populate_facts(self, connection, ansible_facts, data=None):
         """ Populate the facts for Bgp_global network resource

--- a/plugins/module_utils/network/ios/facts/interfaces/interfaces.py
+++ b/plugins/module_utils/network/ios/facts/interfaces/interfaces.py
@@ -27,6 +27,7 @@ from ansible_collections.cisco.ios.plugins.module_utils.network.ios.utils.utils 
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.argspec.interfaces.interfaces import (
     InterfacesArgs,
 )
+from ansible.module_utils.connection import ConnectionError
 
 
 class InterfacesFacts(object):
@@ -48,7 +49,14 @@ class InterfacesFacts(object):
         self.generated_spec = utils.generate_dict(facts_argument_spec)
 
     def get_interfaces_data(self, connection):
-        return connection.get("sh running-config | section ^interface")
+        try:
+            return connection.get("sh running-config | section ^interface")
+        except ConnectionError as e:
+            if "Invalid input detected at" in e.message:
+                data = connection.get("sh running-config | begin ^interface")
+                return "\n".join(re.findall(r'^interface [^!]*!$',data))
+            else:
+                raise
 
     def populate_facts(self, connection, ansible_facts, data=None):
         """ Populate the facts for interfaces

--- a/plugins/module_utils/network/ios/facts/l2_interfaces/l2_interfaces.py
+++ b/plugins/module_utils/network/ios/facts/l2_interfaces/l2_interfaces.py
@@ -26,6 +26,7 @@ from ansible_collections.cisco.ios.plugins.module_utils.network.ios.utils.utils 
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.argspec.l2_interfaces.l2_interfaces import (
     L2_InterfacesArgs,
 )
+from ansible.module_utils.connection import ConnectionError
 
 
 class L2_InterfacesFacts(object):
@@ -47,7 +48,14 @@ class L2_InterfacesFacts(object):
         self.generated_spec = utils.generate_dict(facts_argument_spec)
 
     def get_l2_interfaces_data(self, connection):
-        return connection.get("show running-config | section ^interface")
+                try:
+            return connection.get("sh running-config | section ^interface")
+        except Exception as e:
+            if "Invalid input detected at" in e.message:
+                data = connection.get("sh running-config | begin ^interface")
+                return = "\n".join(re.findall(r'interface [^!]*!',data))
+            else
+                raise
 
     def populate_facts(self, connection, ansible_facts, data=None):
         """ Populate the facts for interfaces

--- a/plugins/module_utils/network/ios/facts/l3_interfaces/l3_interfaces.py
+++ b/plugins/module_utils/network/ios/facts/l3_interfaces/l3_interfaces.py
@@ -27,6 +27,7 @@ from ansible_collections.cisco.ios.plugins.module_utils.network.ios.utils.utils 
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.argspec.l3_interfaces.l3_interfaces import (
     L3_InterfacesArgs,
 )
+from ansible.module_utils.connection import ConnectionError
 
 
 class L3_InterfacesFacts(object):
@@ -58,7 +59,14 @@ class L3_InterfacesFacts(object):
         objs = []
 
         if not data:
-            data = connection.get("show running-config | section ^interface")
+            try:
+                data = connection.get("sh running-config | section ^interface")
+            except ConnectionError as e:
+                if "Invalid input detected at" in e.message:
+                    data = connection.get("sh running-config | begin ^interface")
+                    data = "\n".join(re.findall(r'^interface [^!]*!$',data))
+                else:
+                    raise
         # operate on a collection of resource x
         config = ("\n" + data).split("\ninterface ")
         for conf in config:

--- a/plugins/module_utils/network/ios/facts/lag_interfaces/lag_interfaces.py
+++ b/plugins/module_utils/network/ios/facts/lag_interfaces/lag_interfaces.py
@@ -28,6 +28,7 @@ from ansible_collections.cisco.ios.plugins.module_utils.network.ios.utils.utils 
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.argspec.lag_interfaces.lag_interfaces import (
     Lag_interfacesArgs,
 )
+from ansible.module_utils.connection import ConnectionError
 
 
 class Lag_interfacesFacts(object):
@@ -59,7 +60,15 @@ class Lag_interfacesFacts(object):
         objs = []
 
         if not data:
-            data = connection.get("show running-config | section ^interface")
+            try:
+                data = connection.get("show running-config | section ^interface")
+            except ConnectionError as e:
+                if "Invalid input detected at" in e.message:
+                    data = connection.get("sh running-config | begin ^interface")
+                    data = "\n".join(re.findall(r'^interface [^!]*!$',data))
+                else:
+                    raise
+
         # operate on a collection of resource x
         config = ("\n" + data).split("\ninterface ")
         for conf in config:

--- a/plugins/module_utils/network/ios/facts/lldp_global/lldp_global.py
+++ b/plugins/module_utils/network/ios/facts/lldp_global/lldp_global.py
@@ -22,6 +22,7 @@ from ansible_collections.ansible.netcommon.plugins.module_utils.network.common i
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.argspec.lldp_global.lldp_global import (
     Lldp_globalArgs,
 )
+from ansible.module_utils.connection import ConnectionError
 
 
 class Lldp_globalFacts(object):
@@ -43,7 +44,14 @@ class Lldp_globalFacts(object):
         self.generated_spec = utils.generate_dict(facts_argument_spec)
 
     def get_lldp_global_data(self, connection):
-        return connection.get("show running-config | section ^lldp")
+        try:
+            return connection.get("show running-config | section ^lldp")
+        except ConnectionError as e:
+            if "Invalid input detected at" in e.message:
+                data = connection.get("sh running-config | begin ^lldp")
+                return "\n".join(re.findall(r'^lldp [^!]*!$',data))
+            else:
+                raise
 
     def populate_facts(self, connection, ansible_facts, data=None):
         """ Populate the facts for lldp_global

--- a/plugins/module_utils/network/ios/facts/ospf_interfaces/ospf_interfaces.py
+++ b/plugins/module_utils/network/ios/facts/ospf_interfaces/ospf_interfaces.py
@@ -26,6 +26,7 @@ from ansible_collections.cisco.ios.plugins.module_utils.network.ios.rm_templates
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.argspec.ospf_interfaces.ospf_interfaces import (
     Ospf_InterfacesArgs,
 )
+from ansible.module_utils.connection import ConnectionError
 
 
 class Ospf_InterfacesFacts(object):
@@ -47,7 +48,14 @@ class Ospf_InterfacesFacts(object):
         self.generated_spec = utils.generate_dict(facts_argument_spec)
 
     def get_ospf_interfaces_data(self, connection):
-        return connection.get("sh running-config | section ^interface")
+        try:
+            return connection.get("sh running-config | section ^interface")
+        except Exception as e:
+            if "Invalid input detected at" in e.message:
+                data = connection.get("sh running-config | begin ^interface")
+                return = "\n".join(re.findall(r'interface [^!]*!',data))
+            else
+                raise
 
     def populate_facts(self, connection, ansible_facts, data=None):
         """ Populate the facts for Ospf_interfaces network resource

--- a/plugins/module_utils/network/ios/facts/ospfv2/ospfv2.py
+++ b/plugins/module_utils/network/ios/facts/ospfv2/ospfv2.py
@@ -26,6 +26,7 @@ from ansible_collections.cisco.ios.plugins.module_utils.network.ios.rm_templates
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.network_template import (
     NetworkTemplate,
 )
+from ansible.module_utils.connection import ConnectionError
 
 
 class Ospfv2Facts(object):
@@ -47,7 +48,14 @@ class Ospfv2Facts(object):
         self.generated_spec = utils.generate_dict(facts_argument_spec)
 
     def get_ospfv2_data(self, connection):
-        return connection.get("sh running-config | section ^router ospf")
+        try:
+            return connection.get("sh running-config | section ^router ospf")
+        except Exception as e:
+            if "Invalid input detected at" in e.message:
+                data = connection.get("sh running-config | ^router ospf")
+                return = "\n".join(re.findall(r'router ospf[^!]*!',data))
+            else
+                raise
 
     def populate_facts(self, connection, ansible_facts, data=None):
         """ Populate the facts for ospfv2


### PR DESCRIPTION
##### SUMMARY
Cisco IOS 12.2 is not officially supported in ansible. 

During testing with IOS12.2 it was recognized that the facts fetching from the config is failing as ios 12.2 does not support 
`show running config | section xyz`. The section command was introduced in cisco ios 15. As a workaround the config fetching part was adapted so ios facts are working also with cisco ios 12.2.

Instead of using the block command a section command was used and the correct config section was filtered. 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME

##### ADDITIONAL INFORMATION
Additional information about filtering in ios can be found here: https://www.cisco.com/c/en/us/td/docs/ios-xml/ios/fundamentals/configuration/15_sy/fundamentals-15-sy-book/cf-cli-search.html

