### PR TITLE
Support cisco ios 12.2

### DIFF
--- a/changelogs/fragments/support_ios_12.2_configuration_mode.yaml
+++ b/changelogs/fragments/support_ios_12.2_configuration_mode.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Support ios 12.2 by using regex instead of the ios section command

--- a/plugins/module_utils/network/ios/facts/lacp_interfaces/lacp_interfaces.py
+++ b/plugins/module_utils/network/ios/facts/lacp_interfaces/lacp_interfaces.py
@@ -27,6 +27,7 @@ from ansible_collections.cisco.ios.plugins.module_utils.network.ios.utils.utils 
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.argspec.lacp_interfaces.lacp_interfaces import (
     Lacp_InterfacesArgs,
 )
+from ansible.module_utils.connection import ConnectionError
 
 
 class Lacp_InterfacesFacts(object):
@@ -61,7 +62,14 @@ class Lacp_InterfacesFacts(object):
 
         objs = []
         if not data:
-            data = connection.get("show running-config | section ^interface")
+            try:
+                data = connection.get("show running-config | section ^interface")
+            except ConnectionError as e:
+                if "Invalid input detected at" in e.message:
+                    data = connection.get("sh running-config | begin ^interface")
+                    data = "\n".join(re.findall(r'^interface.+?(?<=\n\!)$',data, re.S|re.M))
+                else:
+                    raise
         # operate on a collection of resource x
         config = ("\n" + data).split("\ninterface ")
 


### PR DESCRIPTION
##### SUMMARY
Basic support of IOS 12.2 devices. Configuration is fetched with begin statement instead of section and parsed with regular expressions.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
cisco.ios

##### ADDITIONAL INFORMATION
Currently only cisco devices with ios > 15.0 are supported. This change shall support also older releases of ios. 
Only basic commands have been tested (l2 interface, l3 interface, static routes and vlan configuration).

