### PR TITLE
To fix ios_acls Nonetype error when aces are empty

### DIFF
--- a/changelogs/fragments/257_ios_acls_throwing_nonetype.yml
+++ b/changelogs/fragments/257_ios_acls_throwing_nonetype.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - IOS acls module throwing nonetype error when aces were empty (https://github.com/ansible-collections/cisco.ios/issues/257).

--- a/plugins/module_utils/network/ios/config/acls/acls.py
+++ b/plugins/module_utils/network/ios/config/acls/acls.py
@@ -90,29 +90,30 @@ class Acls(ResourceModule):
                             for each_have_acls in each_have.get("acls"):
                                 if each_acls["name"] == each_have_acls["name"]:
                                     aces = []
-                                    for each_ace in each_acls["aces"]:
-                                        each_ace_sequence = each_ace.get(
-                                            "sequence"
-                                        )
-                                        if each_ace_sequence:
-                                            for (
-                                                each_have_ace
-                                            ) in each_have_acls["aces"]:
-                                                if (
-                                                    each_ace_sequence
-                                                    == each_have_ace.get(
-                                                        "sequence"
-                                                    )
-                                                ):
-                                                    aces.append(
-                                                        dict(
-                                                            dict_merge(
-                                                                each_have_ace,
-                                                                each_ace,
+                                    if each_acls.get("aces"):
+                                        for each_ace in each_acls["aces"]:
+                                            each_ace_sequence = each_ace.get(
+                                                "sequence"
+                                            )
+                                            if each_ace_sequence:
+                                                for (
+                                                    each_have_ace
+                                                ) in each_have_acls["aces"]:
+                                                    if (
+                                                        each_ace_sequence
+                                                        == each_have_ace.get(
+                                                            "sequence"
+                                                        )
+                                                    ):
+                                                        aces.append(
+                                                            dict(
+                                                                dict_merge(
+                                                                    each_have_ace,
+                                                                    each_ace,
+                                                                )
                                                             )
                                                         )
-                                                    )
-                                                    break
+                                                        break
                                     if aces:
                                         temp_acls["acls"].append(
                                             {

--- a/plugins/module_utils/network/ios/facts/acls/acls.py
+++ b/plugins/module_utils/network/ios/facts/acls/acls.py
@@ -82,38 +82,42 @@ class AclsFacts(object):
             temp_v4 = sorted(temp_v4, key=lambda i: str(i["name"]))
             temp_v6 = sorted(temp_v6, key=lambda i: str(i["name"]))
             for each in temp_v4:
-                for each_ace in each.get("aces"):
-                    if each["acl_type"] == "standard":
-                        each_ace["source"] = each_ace.pop("std_source")
-                    if each_ace.get("icmp_igmp_tcp_protocol"):
-                        each_ace["protocol_options"] = {
-                            each_ace["protocol"]: {
-                                each_ace.pop("icmp_igmp_tcp_protocol").replace(
-                                    "-", "_"
-                                ): True
+                aces_ipv4 = each.get("aces")
+                if aces_ipv4:
+                    for each_ace in each.get("aces"):
+                        if each["acl_type"] == "standard":
+                            each_ace["source"] = each_ace.pop("std_source")
+                        if each_ace.get("icmp_igmp_tcp_protocol"):
+                            each_ace["protocol_options"] = {
+                                each_ace["protocol"]: {
+                                    each_ace.pop(
+                                        "icmp_igmp_tcp_protocol"
+                                    ).replace("-", "_"): True
+                                }
                             }
-                        }
-                    if each_ace.get("std_source") == {}:
-                        del each_ace["std_source"]
+                        if each_ace.get("std_source") == {}:
+                            del each_ace["std_source"]
             for each in temp_v6:
-                for each_ace in each.get("aces"):
-                    if each_ace.get("std_source") == {}:
-                        del each_ace["std_source"]
-                    if each_ace.get("icmp_igmp_tcp_protocol"):
-                        each_ace["protocol_options"] = {
-                            each_ace["protocol"]: {
-                                each_ace.pop("icmp_igmp_tcp_protocol").replace(
-                                    "-", "_"
-                                ): True
+                aces_ipv6 = each.get("aces")
+                if aces_ipv6:
+                    for each_ace in each.get("aces"):
+                        if each_ace.get("std_source") == {}:
+                            del each_ace["std_source"]
+                        if each_ace.get("icmp_igmp_tcp_protocol"):
+                            each_ace["protocol_options"] = {
+                                each_ace["protocol"]: {
+                                    each_ace.pop(
+                                        "icmp_igmp_tcp_protocol"
+                                    ).replace("-", "_"): True
+                                }
                             }
-                        }
 
         objs = []
         if temp_v4:
             objs.append({"afi": "ipv4", "acls": temp_v4})
         if temp_v6:
             objs.append({"afi": "ipv6", "acls": temp_v6})
-        # objs['ipv6'] = {'acls': temp_v6}
+
         facts = {}
         if objs:
             facts["acls"] = []

--- a/tests/unit/modules/network/ios/fixtures/ios_acls_config.cfg
+++ b/tests/unit/modules/network/ios/fixtures/ios_acls_config.cfg
@@ -1,3 +1,4 @@
+Standard IP access list test_acl
 Extended IP access list 110
     10 deny icmp 192.0.2.0 0.0.0.255 192.0.3.0 0.0.0.255 echo dscp ef ttl eq 10
 IPv6 access list R1_TRAFFIC

--- a/tests/unit/modules/network/ios/test_ios_acls.py
+++ b/tests/unit/modules/network/ios/test_ios_acls.py
@@ -141,6 +141,10 @@ class TestIosAclsModule(TestIosModule):
                 config=[
                     dict(
                         afi="ipv4",
+                        acls=[dict(acl_type="standard", name="test_acl")],
+                    ),
+                    dict(
+                        afi="ipv4",
                         acls=[
                             dict(
                                 name="110",
@@ -246,6 +250,10 @@ class TestIosAclsModule(TestIosModule):
                 config=[
                     dict(
                         afi="ipv4",
+                        acls=[dict(acl_type="standard", name="test_acl")],
+                    ),
+                    dict(
+                        afi="ipv4",
                         acls=[
                             dict(
                                 name="110",
@@ -270,7 +278,7 @@ class TestIosAclsModule(TestIosModule):
                                 ],
                             )
                         ],
-                    )
+                    ),
                 ],
                 state="replaced",
             )
@@ -316,6 +324,7 @@ class TestIosAclsModule(TestIosModule):
         result = self.execute_module(changed=True)
         commands = [
             "no ip access-list extended 110",
+            "no ip access-list standard test_acl",
             "no ipv6 access-list R1_TRAFFIC",
             "ip access-list extended 150",
             "deny tcp 198.51.100.0 0.0.0.255 eq telnet 198.51.110.0 0.0.0.255 eq telnet syn dscp ef ttl eq 10",
@@ -326,6 +335,10 @@ class TestIosAclsModule(TestIosModule):
         set_module_args(
             dict(
                 config=[
+                    dict(
+                        afi="ipv4",
+                        acls=[dict(acl_type="standard", name="test_acl")],
+                    ),
                     dict(
                         afi="ipv4",
                         acls=[
@@ -388,7 +401,10 @@ class TestIosAclsModule(TestIosModule):
     def test_ios_acls_deleted_afi_based(self):
         set_module_args(dict(config=[dict(afi="ipv4")], state="deleted"))
         result = self.execute_module(changed=True)
-        commands = ["no ip access-list extended 110"]
+        commands = [
+            "no ip access-list extended 110",
+            "no ip access-list standard test_acl",
+        ]
         self.assertEqual(result["commands"], commands)
 
     def test_ios_acls_deleted_acl_based(self):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
To fix ios_acls Nonetype error when aces are empty. Fixes #257
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios_acls

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
