### PR TITLE
To add support for TwoGigabitEthernet interface option from IOS standpoint

### DIFF
--- a/changelogs/fragments/217_added_support_for_new_ios_interfaces.yml
+++ b/changelogs/fragments/217_added_support_for_new_ios_interfaces.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Added support for new ios interface i.e. TwoGigabitEthernet (https://github.com/ansible-collections/cisco.ios/issues/217).

--- a/plugins/module_utils/network/ios/ios.py
+++ b/plugins/module_utils/network/ios/ios.py
@@ -168,6 +168,8 @@ def normalize_interface(name):
 
     if name.lower().startswith("gi"):
         if_type = "GigabitEthernet"
+    elif name.lower().startswith("tw"):
+        if_type = "TwoGigabitEthernet"
     elif name.lower().startswith("te"):
         if_type = "TenGigabitEthernet"
     elif name.lower().startswith("fa"):

--- a/plugins/module_utils/network/ios/utils/utils.py
+++ b/plugins/module_utils/network/ios/utils/utils.py
@@ -306,6 +306,8 @@ def normalize_interface(name):
 
     if name.lower().startswith("gi"):
         if_type = "GigabitEthernet"
+    elif name.lower().startswith("tw"):
+        if_type = "TwoGigabitEthernet"
     elif name.lower().startswith("te"):
         if_type = "TenGigabitEthernet"
     elif name.lower().startswith("fa"):
@@ -355,6 +357,8 @@ def get_interface_type(interface):
 
     if interface.upper().startswith("GI"):
         return "GigabitEthernet"
+    elif interface.upper().startswith("TW"):
+        return "TwoGigabitEthernet"
     elif interface.upper().startswith("TE"):
         return "TenGigabitEthernet"
     elif interface.upper().startswith("FA"):

--- a/tests/unit/modules/network/ios/fixtures/ios_l2_interfaces.cfg
+++ b/tests/unit/modules/network/ios/fixtures/ios_l2_interfaces.cfg
@@ -7,3 +7,6 @@ interface GigabitEthernet0/2
  switchport trunk native vlan 10
  switchport trunk pruning vlan 10,20
  switchport mode trunk
+interface TwoGigabitEthernet1/0/1
+ switchport mode access
+ switchport access vlan 20

--- a/tests/unit/modules/network/ios/test_ios_l2_interfaces.py
+++ b/tests/unit/modules/network/ios/test_ios_l2_interfaces.py
@@ -93,6 +93,11 @@ class TestIosL2InterfacesModule(TestIosModule):
                             pruning_vlans=["9-15", "20"],
                         ),
                     ),
+                    dict(
+                        access=dict(vlan=20),
+                        mode="access",
+                        name="TwoGigabitEthernet1/0/1",
+                    ),
                 ],
                 state="merged",
             )
@@ -182,6 +187,11 @@ class TestIosL2InterfacesModule(TestIosModule):
                             pruning_vlans=["10", "20"],
                         ),
                     ),
+                    dict(
+                        access=dict(vlan=20),
+                        mode="access",
+                        name="TwoGigabitEthernet1/0/1",
+                    ),
                 ],
                 state="replaced",
             )
@@ -214,6 +224,9 @@ class TestIosL2InterfacesModule(TestIosModule):
             "switchport access vlan 10",
             "switchport voice vlan 20",
             "switchport mode access",
+            "interface TwoGigabitEthernet1/0/1",
+            "no switchport mode",
+            "no switchport access vlan",
         ]
         result = self.execute_module(changed=True)
         self.assertEqual(result["commands"], commands)
@@ -236,6 +249,11 @@ class TestIosL2InterfacesModule(TestIosModule):
                             native_vlan=10,
                             pruning_vlans=["10", "20"],
                         ),
+                    ),
+                    dict(
+                        access=dict(vlan=20),
+                        mode="access",
+                        name="TwoGigabitEthernet1/0/1",
                     ),
                 ],
                 state="overridden",
@@ -266,6 +284,9 @@ class TestIosL2InterfacesModule(TestIosModule):
             "no switchport trunk native vlan",
             "no switchport trunk allowed vlan",
             "no switchport trunk pruning vlan",
+            "interface TwoGigabitEthernet1/0/1",
+            "no switchport mode",
+            "no switchport access vlan",
         ]
         result = self.execute_module(changed=True)
         self.assertEqual(result["commands"], commands)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
To add support for `TwoGigabitEthernet` interface option from an IOS standpoint. Fixes #217 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios_*_interfaces

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
