### PR TITLE
fix bgp_address_family prefix-list

### DIFF
--- a/changelogs/fragments/fix_bgp_address_family_prefix-list.yaml
+++ b/changelogs/fragments/fix_bgp_address_family_prefix-list.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - update "prefix_list" typo in "plugins/module_utils/network/ios/rm_templates/bgp_address_family.py"

--- a/plugins/module_utils/network/ios/rm_templates/bgp_address_family.py
+++ b/plugins/module_utils/network/ios/rm_templates/bgp_address_family.py
@@ -471,7 +471,7 @@ def _tmplt_af_neighbor(config_data):
                 self_cmd += " allpaths"
             commands.append(self_cmd)
         if "prefix_list" in config_data["neighbor"]:
-            self_cmd = "{0} prefix_list {name}".format(
+            self_cmd = "{0} prefix-list {name}".format(
                 cmd, **config_data["neighbor"]["prefix_list"]
             )
             if config_data["neighbor"]["prefix_list"].get("in"):

--- a/tests/unit/modules/network/ios/fixtures/ios_bgp_address_family.cfg
+++ b/tests/unit/modules/network/ios/fixtures/ios_bgp_address_family.cfg
@@ -28,5 +28,4 @@ router bgp 65000
   neighbor 198.51.100.1 route-server-client
   neighbor 198.51.100.1 slow-peer detection threshold 150
   neighbor 198.51.100.1 route-map test-route out
-  neighbor 198.51.100.1 prefix-list test-prefix out
  exit-address-family

--- a/tests/unit/modules/network/ios/fixtures/ios_bgp_address_family.cfg
+++ b/tests/unit/modules/network/ios/fixtures/ios_bgp_address_family.cfg
@@ -28,4 +28,5 @@ router bgp 65000
   neighbor 198.51.100.1 route-server-client
   neighbor 198.51.100.1 slow-peer detection threshold 150
   neighbor 198.51.100.1 route-map test-route out
+  neighbor 198.51.100.1 prefix-list test-prefix out
  exit-address-family


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Ansible playbook is failing while using the prefix_list parameter. 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
cisco.ios.ios_bgp_address_family

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Ansible playbook is failing with following error:

```paste below
"/tmp/ansible_cisco.ios.ios_bgp_address_family_payload_h0q6rq3b/ansible_cisco.ios.ios_bgp_address_family_payload.zip/ansible/module_utils/connection.py", line 185, in __rpc__
    ansible.module_utils.connection.ConnectionError: neighbor 192.168.100.100 prefix_list AS65100-PREFIX-IN in
    neighbor 192.168.100.100 prefix_list AS65100-PREFIX-IN in
                                   ^
    % Invalid input detected at '^' marker.
```
```paste below
---
- hosts: routers-test
  gather_facts: no
  vars_files:
    - "../secrets/vault.yml"

  tasks:
  - name: Merge provided configuration with device configuration
    cisco.ios.ios_bgp_address_family:
      config:
        as_number: 65000
        address_family:
          - afi: ipv4
            safi: unicast
            bgp:
            neighbor:
              - address: 192.168.100.100
                remote_as: 65100
                route_map:
                  name: test-route
                  out: true
                prefix_list:
                  name: AS65100-PREFIX-IN
                  in: true
            network:
              - address: 100.100.100.0
                mask: 255.255.255.0
      state: merged
```

The actual command would be "neighbor 192.168.100.100 prefix-list AS65100-PREFIX-IN in" not "neighbor 192.168.100.100 prefix_list AS65100-PREFIX-IN in"

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before the change:
```paste below
linux@command-server:~/nac_ansible$ ansible-playbook temp_scripts/bgp_test_addrfamily.yml --vault-password-file secrets/vault_password.yml  -vvv
ansible-playbook 2.9.17
  config file = /home/linux/nac_ansible/ansible.cfg
  configured module search path = [u'/home/linux/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible-playbook
  python version = 2.7.17 (default, Feb 25 2021, 14:02:55) [GCC 7.5.0]
Using /home/linux/nac_ansible/ansible.cfg as config file
host_list declined parsing /home/linux/nac_ansible/hosts as it did not pass its verify_file() method
script declined parsing /home/linux/nac_ansible/hosts as it did not pass its verify_file() method
auto declined parsing /home/linux/nac_ansible/hosts as it did not pass its verify_file() method
[WARNING]: Invalid characters were found in group names but not replaced, use -vvvv to see details
Parsed /home/linux/nac_ansible/hosts inventory source with ini plugin
Skipping callback 'actionable', as we already have a stdout callback.
Skipping callback 'counter_enabled', as we already have a stdout callback.
Skipping callback 'debug', as we already have a stdout callback.
Skipping callback 'dense', as we already have a stdout callback.
Skipping callback 'dense', as we already have a stdout callback.
Skipping callback 'full_skip', as we already have a stdout callback.
Skipping callback 'json', as we already have a stdout callback.
Skipping callback 'minimal', as we already have a stdout callback.
Skipping callback 'null', as we already have a stdout callback.
Skipping callback 'oneline', as we already have a stdout callback.
Skipping callback 'selective', as we already have a stdout callback.
Skipping callback 'skippy', as we already have a stdout callback.
Skipping callback 'stderr', as we already have a stdout callback.
Skipping callback 'unixy', as we already have a stdout callback.
Skipping callback 'yaml', as we already have a stdout callback.

PLAYBOOK: bgp_test_addrfamily.yml ***********************************************************************************************************************
1 plays in temp_scripts/bgp_test_addrfamily.yml
Read vars_file '../secrets/vault.yml'
Read vars_file '../secrets/vault.yml'
Read vars_file '../secrets/vault.yml'

PLAY [routers-test] *************************************************************************************************************************************
META: ran handlers
Read vars_file '../secrets/vault.yml'

TASK [Merge provided configuration with device configuration] *******************************************************************************************
task path: /home/linux/nac_ansible/temp_scripts/bgp_test_addrfamily.yml:8
<100.100.250.250> ESTABLISH LOCAL CONNECTION FOR USER: linux
<100.100.250.250> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/linux/.ansible/tmp/ansible-local-36591ckUgX `"&& mkdir "` echo /home/linux/.ansible/tmp/ansible-local-36591ckUgX/ansible-tmp-1614811118.86-3666-276785490798883 `" && echo ansible-tmp-1614811118.86-3666-276785490798883="` echo /home/linux/.ansible/tmp/ansible-local-36591ckUgX/ansible-tmp-1614811118.86-3666-276785490798883 `" ) && sleep 0'
Using module file /home/linux/.ansible/collections/ansible_collections/cisco/ios/plugins/modules/ios_bgp_address_family.py
<100.100.250.250> PUT /home/linux/.ansible/tmp/ansible-local-36591ckUgX/tmpyAZpNI TO /home/linux/.ansible/tmp/ansible-local-36591ckUgX/ansible-tmp-1614811118.86-3666-276785490798883/AnsiballZ_ios_bgp_address_family.py
<100.100.250.250> EXEC /bin/sh -c 'chmod u+x /home/linux/.ansible/tmp/ansible-local-36591ckUgX/ansible-tmp-1614811118.86-3666-276785490798883/ /home/linux/.ansible/tmp/ansible-local-36591ckUgX/ansible-tmp-1614811118.86-3666-276785490798883/AnsiballZ_ios_bgp_address_family.py && sleep 0'
<100.100.250.250> EXEC /bin/sh -c 'python3 /home/linux/.ansible/tmp/ansible-local-36591ckUgX/ansible-tmp-1614811118.86-3666-276785490798883/AnsiballZ_ios_bgp_address_family.py && sleep 0'
<100.100.250.250> EXEC /bin/sh -c 'rm -f -r /home/linux/.ansible/tmp/ansible-local-36591ckUgX/ansible-tmp-1614811118.86-3666-276785490798883/ > /dev/null 2>&1 && sleep 0'
The full traceback is:
Traceback (most recent call last):
  File "/home/linux/.ansible/tmp/ansible-local-36591ckUgX/ansible-tmp-1614811118.86-3666-276785490798883/AnsiballZ_ios_bgp_address_family.py", line 102, in <module>
    _ansiballz_main()
  File "/home/linux/.ansible/tmp/ansible-local-36591ckUgX/ansible-tmp-1614811118.86-3666-276785490798883/AnsiballZ_ios_bgp_address_family.py", line 94, in _ansiballz_main
    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
  File "/home/linux/.ansible/tmp/ansible-local-36591ckUgX/ansible-tmp-1614811118.86-3666-276785490798883/AnsiballZ_ios_bgp_address_family.py", line 40, in invoke_module
    runpy.run_module(mod_name='ansible_collections.cisco.ios.plugins.modules.ios_bgp_address_family', init_globals=None, run_name='__main__', alter_sys=True)
  File "/usr/lib/python3.6/runpy.py", line 205, in run_module
    return _run_module_code(code, init_globals, run_name, mod_spec)
  File "/usr/lib/python3.6/runpy.py", line 96, in _run_module_code
    mod_name, mod_spec, pkg_name, script_name)
  File "/usr/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/tmp/ansible_cisco.ios.ios_bgp_address_family_payload_h0q6rq3b/ansible_cisco.ios.ios_bgp_address_family_payload.zip/ansible_collections/cisco/ios/plugins/modules/ios_bgp_address_family.py", line 2152, in <module>
  File "/tmp/ansible_cisco.ios.ios_bgp_address_family_payload_h0q6rq3b/ansible_cisco.ios.ios_bgp_address_family_payload.zip/ansible_collections/cisco/ios/plugins/modules/ios_bgp_address_family.py", line 2147, in main
  File "/tmp/ansible_cisco.ios.ios_bgp_address_family_payload_h0q6rq3b/ansible_cisco.ios.ios_bgp_address_family_payload.zip/ansible_collections/cisco/ios/plugins/module_utils/network/ios/config/bgp_address_family/bgp_address_family.py", line 68, in execute_module
  File "/tmp/ansible_cisco.ios.ios_bgp_address_family_payload_h0q6rq3b/ansible_cisco.ios.ios_bgp_address_family_payload.zip/ansible_collections/ansible/netcommon/plugins/module_utils/network/common/rm_base/resource_module.py", line 154, in run_commands
  File "/tmp/ansible_cisco.ios.ios_bgp_address_family_payload_h0q6rq3b/ansible_cisco.ios.ios_bgp_address_family_payload.zip/ansible/module_utils/connection.py", line 185, in __rpc__
ansible.module_utils.connection.ConnectionError: neighbor 192.168.100.100 prefix_list AS65100-PREFIX-IN in
neighbor 192.168.100.100 prefix_list AS65100-PREFIX-IN in
                               ^
% Invalid input detected at '^' marker.

router-test(config-router-af)#
fatal: [router-test]: FAILED! => changed=false
  module_stderr: |-
    Traceback (most recent call last):
      File "/home/linux/.ansible/tmp/ansible-local-36591ckUgX/ansible-tmp-1614811118.86-3666-276785490798883/AnsiballZ_ios_bgp_address_family.py", line 102, in <module>
        _ansiballz_main()
      File "/home/linux/.ansible/tmp/ansible-local-36591ckUgX/ansible-tmp-1614811118.86-3666-276785490798883/AnsiballZ_ios_bgp_address_family.py", line 94, in _ansiballz_main
        invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
      File "/home/linux/.ansible/tmp/ansible-local-36591ckUgX/ansible-tmp-1614811118.86-3666-276785490798883/AnsiballZ_ios_bgp_address_family.py", line 40, in invoke_module
        runpy.run_module(mod_name='ansible_collections.cisco.ios.plugins.modules.ios_bgp_address_family', init_globals=None, run_name='__main__', alter_sys=True)
      File "/usr/lib/python3.6/runpy.py", line 205, in run_module
        return _run_module_code(code, init_globals, run_name, mod_spec)
      File "/usr/lib/python3.6/runpy.py", line 96, in _run_module_code
        mod_name, mod_spec, pkg_name, script_name)
      File "/usr/lib/python3.6/runpy.py", line 85, in _run_code
        exec(code, run_globals)
      File "/tmp/ansible_cisco.ios.ios_bgp_address_family_payload_h0q6rq3b/ansible_cisco.ios.ios_bgp_address_family_payload.zip/ansible_collections/cisco/ios/plugins/modules/ios_bgp_address_family.py", line 2152, in <module>
      File "/tmp/ansible_cisco.ios.ios_bgp_address_family_payload_h0q6rq3b/ansible_cisco.ios.ios_bgp_address_family_payload.zip/ansible_collections/cisco/ios/plugins/modules/ios_bgp_address_family.py", line 2147, in main
      File "/tmp/ansible_cisco.ios.ios_bgp_address_family_payload_h0q6rq3b/ansible_cisco.ios.ios_bgp_address_family_payload.zip/ansible_collections/cisco/ios/plugins/module_utils/network/ios/config/bgp_address_family/bgp_address_family.py", line 68, in execute_module
      File "/tmp/ansible_cisco.ios.ios_bgp_address_family_payload_h0q6rq3b/ansible_cisco.ios.ios_bgp_address_family_payload.zip/ansible_collections/ansible/netcommon/plugins/module_utils/network/common/rm_base/resource_module.py", line 154, in run_commands
      File "/tmp/ansible_cisco.ios.ios_bgp_address_family_payload_h0q6rq3b/ansible_cisco.ios.ios_bgp_address_family_payload.zip/ansible/module_utils/connection.py", line 185, in __rpc__
    ansible.module_utils.connection.ConnectionError: neighbor 192.168.100.100 prefix_list AS65100-PREFIX-IN in
    neighbor 192.168.100.100 prefix_list AS65100-PREFIX-IN in
                                   ^
    % Invalid input detected at '^' marker.

    router-test(config-router-af)#
  module_stdout: ''
  msg: |-
    MODULE FAILURE
    See stdout/stderr for the exact error
  rc: 1

PLAY RECAP **********************************************************************************************************************************************
router-test                : ok=0    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0
```

After the change:

```
linux@command-server:~/nac_ansible$ ansible-playbook temp_scripts/bgp_test_addrfamily.yml --vault-password-file secrets/vault_password.yml  -vvv
ansible-playbook 2.9.17
  config file = /home/linux/nac_ansible/ansible.cfg
  configured module search path = [u'/home/linux/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible-playbook
  python version = 2.7.17 (default, Feb 25 2021, 14:02:55) [GCC 7.5.0]
Using /home/linux/nac_ansible/ansible.cfg as config file
host_list declined parsing /home/linux/nac_ansible/hosts as it did not pass its verify_file() method
script declined parsing /home/linux/nac_ansible/hosts as it did not pass its verify_file() method
auto declined parsing /home/linux/nac_ansible/hosts as it did not pass its verify_file() method
[WARNING]: Invalid characters were found in group names but not replaced, use -vvvv to see details
Parsed /home/linux/nac_ansible/hosts inventory source with ini plugin
Skipping callback 'actionable', as we already have a stdout callback.
Skipping callback 'counter_enabled', as we already have a stdout callback.
Skipping callback 'debug', as we already have a stdout callback.
Skipping callback 'dense', as we already have a stdout callback.
Skipping callback 'dense', as we already have a stdout callback.
Skipping callback 'full_skip', as we already have a stdout callback.
Skipping callback 'json', as we already have a stdout callback.
Skipping callback 'minimal', as we already have a stdout callback.
Skipping callback 'null', as we already have a stdout callback.
Skipping callback 'oneline', as we already have a stdout callback.
Skipping callback 'selective', as we already have a stdout callback.
Skipping callback 'skippy', as we already have a stdout callback.
Skipping callback 'stderr', as we already have a stdout callback.
Skipping callback 'unixy', as we already have a stdout callback.
Skipping callback 'yaml', as we already have a stdout callback.

PLAYBOOK: bgp_test_addrfamily.yml ***********************************************************************************************************************
1 plays in temp_scripts/bgp_test_addrfamily.yml
Read vars_file '../secrets/vault.yml'
Read vars_file '../secrets/vault.yml'
Read vars_file '../secrets/vault.yml'

PLAY [routers-test] *************************************************************************************************************************************
META: ran handlers
Read vars_file '../secrets/vault.yml'

TASK [Merge provided configuration with device configuration] *******************************************************************************************
task path: /home/linux/nac_ansible/temp_scripts/bgp_test_addrfamily.yml:8
<100.100.250.250> ESTABLISH LOCAL CONNECTION FOR USER: linux
<100.100.250.250> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/linux/.ansible/tmp/ansible-local-4207IdN5yS `"&& mkdir "` echo /home/linux/.ansible/tmp/ansible-local-4207IdN5yS/ansible-tmp-1614811611.9-4214-74514161841996 `" && echo ansible-tmp-1614811611.9-4214-74514161841996="` echo /home/linux/.ansible/tmp/ansible-local-4207IdN5yS/ansible-tmp-1614811611.9-4214-74514161841996 `" ) && sleep 0'
Using module file /home/linux/.ansible/collections/ansible_collections/cisco/ios/plugins/modules/ios_bgp_address_family.py
<100.100.250.250> PUT /home/linux/.ansible/tmp/ansible-local-4207IdN5yS/tmpEBSwrZ TO /home/linux/.ansible/tmp/ansible-local-4207IdN5yS/ansible-tmp-1614811611.9-4214-74514161841996/AnsiballZ_ios_bgp_address_family.py
<100.100.250.250> EXEC /bin/sh -c 'chmod u+x /home/linux/.ansible/tmp/ansible-local-4207IdN5yS/ansible-tmp-1614811611.9-4214-74514161841996/ /home/linux/.ansible/tmp/ansible-local-4207IdN5yS/ansible-tmp-1614811611.9-4214-74514161841996/AnsiballZ_ios_bgp_address_family.py && sleep 0'
<100.100.250.250> EXEC /bin/sh -c 'python3 /home/linux/.ansible/tmp/ansible-local-4207IdN5yS/ansible-tmp-1614811611.9-4214-74514161841996/AnsiballZ_ios_bgp_address_family.py && sleep 0'
<100.100.250.250> EXEC /bin/sh -c 'rm -f -r /home/linux/.ansible/tmp/ansible-local-4207IdN5yS/ansible-tmp-1614811611.9-4214-74514161841996/ > /dev/null 2>&1 && sleep 0'
[WARNING]: The value 65000 (type int) in a string field was converted to '65000' (type string). If this does not look like what you expect, quote the
entire value to ensure it does not change.
changed: [router-test] => changed=true
  after:
    address_family:
    - afi: ipv4
      neighbor:
      - activate: true
        address: 192.168.100.100
        prefix_list:
          in: true
          name: AS65100-PREFIX-IN
        route_map:
          name: test-route
          out: true
      network:
      - address: 100.100.100.0
        mask: 255.255.255.0
    as_number: '65000'
  before:
    address_family:
    - afi: ipv4
      neighbor:
      - activate: true
        address: 192.168.100.100
    as_number: '65000'
  commands:
  - router bgp 65000
  - address-family ipv4 unicast
  - neighbor 192.168.100.100 remote-as 65100
  - neighbor 192.168.100.100 prefix-list AS65100-PREFIX-IN in
  - neighbor 192.168.100.100 route-map test-route out
  - network 100.100.100.0 mask 255.255.255.0
  invocation:
    module_args:
      config:
        address_family:
        - afi: ipv4
          aggregate_address: null
          auto_summary: null
          bgp: null
          default: null
          default_information: null
          default_metric: null
          distance: null
          neighbor:
          - activate: null
            additional_paths: null
            address: 192.168.100.100
            advertise: null
            advertise_map: null
            advertisement_interval: null
            aigp: null
            allow_policy: null
            allowas_in: null
            as_override: null
            bmp_activate: null
            capability: null
            cluster_id: null
            default_originate: null
            description: null
            disable_connected_check: null
            distribute_list: null
            dmzlink_bw: null
            ebgp_multihop: null
            fall_over: null
            filter_list: null
            ha_mode: null
            inherit: null
            internal_vpn_client: null
            ipv6_adddress: null
            local_as: null
            log_neighbor_changes: null
            maximum_prefix: null
            next_hop_self: null
            next_hop_unchanged: null
            password: null
            path_attribute: null
            peer_group: null
            prefix_list:
              in: true
              name: AS65100-PREFIX-IN
              out: null
            remote_as: 65100
            remove_private_as: null
            route_map:
              in: null
              name: test-route
              out: true
            route_reflector_client: null
            route_server_client: null
            send_community: null
            shutdown: null
            slow_peer: null
            soft_reconfiguration: null
            soo: null
            tag: null
            timers: null
            transport: null
            ttl_security: null
            unsuppress_map: null
            version: null
            weight: null
          network:
          - address: 100.100.100.0
            backdoor: null
            mask: 255.255.255.0
            route_map: null
          redistribute: null
          safi: unicast
          snmp: null
          table_map: null
          vrf: null
        as_number: '65000'
      running_config: null
      state: merged
META: ran handlers
META: ran handlers

PLAY RECAP **********************************************************************************************************************************************
router-test                : ok=1    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```