### PR TITLE
Add support for autoconfig and dhcp keywords for IPv6 addresses in l3_interfaces

### DIFF
--- a/changelogs/fragments/add-autoconfig-dhcp-to-l3_interfaces.yaml
+++ b/changelogs/fragments/add-autoconfig-dhcp-to-l3_interfaces.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Add support for autoconfig and dhcp keywords for IPv6 addresses in l3_interfaces (https://github.com/ansible-collections/cisco.ios/pull/269).

--- a/plugins/module_utils/network/ios/config/l3_interfaces/l3_interfaces.py
+++ b/plugins/module_utils/network/ios/config/l3_interfaces/l3_interfaces.py
@@ -401,8 +401,11 @@ class L3_Interfaces(ConfigBase):
             if ipv6:
                 for each in ipv6:
                     ipv6_dict = dict(each)
-                    validate_ipv6(ipv6_dict.get("address"), module)
-                    cmd = "ipv6 address {0}".format(ipv6_dict.get("address"))
+                    if ipv6_dict.get("address") in ("dhcp", "autoconfig"):
+                        cmd = "ipv6 address {0}".format(ipv6_dict.get("address"))
+                    else:
+                        validate_ipv6(ipv6_dict.get("address"), module)
+                        cmd = "ipv6 address {0}".format(ipv6_dict.get("address"))
                     add_command_to_config_list(interface, cmd, commands)
 
         return commands

--- a/plugins/module_utils/network/ios/config/l3_interfaces/l3_interfaces.py
+++ b/plugins/module_utils/network/ios/config/l3_interfaces/l3_interfaces.py
@@ -401,11 +401,9 @@ class L3_Interfaces(ConfigBase):
             if ipv6:
                 for each in ipv6:
                     ipv6_dict = dict(each)
-                    if ipv6_dict.get("address") in ("dhcp", "autoconfig"):
-                        cmd = "ipv6 address {0}".format(ipv6_dict.get("address"))
-                    else:
+                    if ipv6_dict.get("address") not in ("dhcp", "autoconfig"):
                         validate_ipv6(ipv6_dict.get("address"), module)
-                        cmd = "ipv6 address {0}".format(ipv6_dict.get("address"))
+                    cmd = "ipv6 address {0}".format(ipv6_dict.get("address"))
                     add_command_to_config_list(interface, cmd, commands)
 
         return commands

--- a/plugins/module_utils/network/ios/facts/l3_interfaces/l3_interfaces.py
+++ b/plugins/module_utils/network/ios/facts/l3_interfaces/l3_interfaces.py
@@ -137,10 +137,6 @@ class L3_InterfacesFacts(object):
         ipv6_all = re.findall(r"ipv6 address (\S+)", conf)
         for each in ipv6_all:
             each_ipv6 = dict()
-            if "autoconfig" in each:
-                each_ipv6["autoconfig"] = True
-            if "dhcp" in each:
-                each_ipv6["dhcp"] = True
             each_ipv6["address"] = each.lower()
             ipv6.append(each_ipv6)
         config["ipv6"] = ipv6

--- a/plugins/modules/ios_l3_interfaces.py
+++ b/plugins/modules/ios_l3_interfaces.py
@@ -75,6 +75,7 @@ options:
         - IPv6 address to be set for the Layer-3 interface mentioned in I(name) option.
         - The address format is <ipv6 address>/<mask>, the mask is number in range
           0-128 eg. fd5d:12c9:2201:1::1/64
+        - Can be 'dhcp' for DHCP or 'autoconfig' for SLAAC.
         type: list
         elements: dict
         suboptions:

--- a/tests/integration/targets/ios_l3_interfaces/tests/cli/_parsed.cfg
+++ b/tests/integration/targets/ios_l3_interfaces/tests/cli/_parsed.cfg
@@ -3,4 +3,5 @@ interface GigabitEthernet0/1
 interface GigabitEthernet0/2
  ip address 198.51.100.1 255.255.255.0 secondary
  ip address 198.51.100.2 255.255.255.0
+ ipv6 address autoconfig
  ipv6 address 2001:db8:0:3::/64

--- a/tests/integration/targets/ios_l3_interfaces/tests/cli/_populate_config.yaml
+++ b/tests/integration/targets/ios_l3_interfaces/tests/cli/_populate_config.yaml
@@ -3,6 +3,7 @@
   vars:
     lines: "interface GigabitEthernet 0/1\nip address 203.0.113.27 255.255.255.0\n\
       interface GigabitEthernet 0/2\nip address 192.0.2.1 255.255.255.0 secondary\n\
-      ip address 192.0.2.2 255.255.255.0\nipv6 address 2001:db8:0:3::/64\n"
+      ip address 192.0.2.2 255.255.255.0\nipv6 address autoconfig\n\
+      ipv6 address 2001:db8:0:3::/64\n"
   ansible.netcommon.cli_config:
     config: '{{ lines }}'

--- a/tests/integration/targets/ios_l3_interfaces/tests/cli/merged.yaml
+++ b/tests/integration/targets/ios_l3_interfaces/tests/cli/merged.yaml
@@ -19,12 +19,15 @@
               - address: dhcp
                 dhcp_client: 0
                 dhcp_hostname: test.com
+            ipv6:
+              - address: autoconfig
           - name: GigabitEthernet0/2
             ipv4:
               - address: 198.51.100.1/24
                 secondary: true
               - address: 198.51.100.2/24
             ipv6:
+              - address: dhcp
               - address: 2001:db8:0:3::/64
         state: merged
 

--- a/tests/integration/targets/ios_l3_interfaces/tests/cli/rendered.yaml
+++ b/tests/integration/targets/ios_l3_interfaces/tests/cli/rendered.yaml
@@ -18,12 +18,15 @@
               - address: dhcp
                 dhcp_client: 0
                 dhcp_hostname: test.com
+            ipv6:
+              - address: autoconfig
           - name: GigabitEthernet0/2
             ipv4:
               - address: 198.51.100.1/24
                 secondary: true
               - address: 198.51.100.2/24
             ipv6:
+              - address: dhcp
               - address: 2001:db8:0:3::/64
         state: rendered
 

--- a/tests/integration/targets/ios_l3_interfaces/vars/main.yaml
+++ b/tests/integration/targets/ios_l3_interfaces/vars/main.yaml
@@ -29,12 +29,15 @@ merged:
         - address: dhcp
           dhcp_client: 0
           dhcp_hostname: test.com
+    - ipv6:
+        - address: autoconfig
       name: GigabitEthernet0/1
     - ipv4:
         - address: 198.51.100.1 255.255.255.0
           secondary: true
         - address: 198.51.100.2 255.255.255.0
       ipv6:
+        - address: dhcp
         - address: 2001:db8:0:3::/64
       name: GigabitEthernet0/2
 replaced:

--- a/tests/integration/targets/ios_l3_interfaces/vars/main.yaml
+++ b/tests/integration/targets/ios_l3_interfaces/vars/main.yaml
@@ -13,9 +13,11 @@ merged:
     - ip address 192.0.2.1 255.255.255.0
     - interface GigabitEthernet0/1
     - ip address dhcp client-id GigabitEthernet0/0 hostname test.com
+    - ipv6 address autoconfig
     - interface GigabitEthernet0/2
     - ip address 198.51.100.1 255.255.255.0 secondary
     - ip address 198.51.100.2 255.255.255.0
+    - ipv6 address dhcp
     - ipv6 address 2001:db8:0:3::/64
   after:
     - name: loopback888
@@ -29,7 +31,7 @@ merged:
         - address: dhcp
           dhcp_client: 0
           dhcp_hostname: test.com
-    - ipv6:
+      ipv6:
         - address: autoconfig
       name: GigabitEthernet0/1
     - ipv4:

--- a/tests/integration/targets/ios_l3_interfaces/vars/main.yaml
+++ b/tests/integration/targets/ios_l3_interfaces/vars/main.yaml
@@ -41,7 +41,6 @@ merged:
       ipv6:
         - address: dhcp
         - address: 2001:db8:0:3::/64
-        - address: autoconfig
       name: GigabitEthernet0/2
 replaced:
   before:

--- a/tests/integration/targets/ios_l3_interfaces/vars/main.yaml
+++ b/tests/integration/targets/ios_l3_interfaces/vars/main.yaml
@@ -39,9 +39,9 @@ merged:
           secondary: true
         - address: 198.51.100.2 255.255.255.0
       ipv6:
-        - address: autoconfig
         - address: dhcp
         - address: 2001:db8:0:3::/64
+        - address: autoconfig
       name: GigabitEthernet0/2
 replaced:
   before:
@@ -58,8 +58,8 @@ replaced:
           secondary: true
         - address: 192.0.2.2 255.255.255.0
       ipv6:
-        - address: autoconfig
         - address: 2001:db8:0:3::/64
+        - address: autoconfig
       name: GigabitEthernet0/2
   commands:
     - interface GigabitEthernet0/1
@@ -101,8 +101,8 @@ overridden:
           secondary: true
         - address: 192.0.2.2 255.255.255.0
       ipv6:
-        - address: autoconfig
         - address: 2001:db8:0:3::/64
+        - address: autoconfig
       name: GigabitEthernet0/2
   commands:
     - interface GigabitEthernet0/1
@@ -139,8 +139,8 @@ deleted:
           secondary: true
         - address: 192.0.2.2 255.255.255.0
       ipv6:
-        - address: autoconfig
         - address: 2001:db8:0:3::/64
+        - address: autoconfig
       name: GigabitEthernet0/2
   commands:
     - interface GigabitEthernet0/1
@@ -171,8 +171,8 @@ gathered:
           secondary: true
         - address: 192.0.2.2 255.255.255.0
       ipv6:
-        - address: autoconfig
         - address: 2001:db8:0:3::/64
+        - address: autoconfig
       name: GigabitEthernet0/2
 parsed:
   config:
@@ -186,8 +186,8 @@ parsed:
           secondary: true
         - address: 198.51.100.2 255.255.255.0
       ipv6:
-        - address: autoconfig
         - address: 2001:db8:0:3::/64
+        - address: autoconfig
       name: GigabitEthernet0/2
 rtt:
   commands:

--- a/tests/integration/targets/ios_l3_interfaces/vars/main.yaml
+++ b/tests/integration/targets/ios_l3_interfaces/vars/main.yaml
@@ -186,8 +186,8 @@ parsed:
           secondary: true
         - address: 198.51.100.2 255.255.255.0
       ipv6:
-        - address: 2001:db8:0:3::/64
         - address: autoconfig
+        - address: 2001:db8:0:3::/64
       name: GigabitEthernet0/2
 rtt:
   commands:

--- a/tests/integration/targets/ios_l3_interfaces/vars/main.yaml
+++ b/tests/integration/targets/ios_l3_interfaces/vars/main.yaml
@@ -39,6 +39,7 @@ merged:
           secondary: true
         - address: 198.51.100.2 255.255.255.0
       ipv6:
+        - address: autoconfig
         - address: dhcp
         - address: 2001:db8:0:3::/64
       name: GigabitEthernet0/2
@@ -57,6 +58,7 @@ replaced:
           secondary: true
         - address: 192.0.2.2 255.255.255.0
       ipv6:
+        - address: autoconfig
         - address: 2001:db8:0:3::/64
       name: GigabitEthernet0/2
   commands:
@@ -99,6 +101,7 @@ overridden:
           secondary: true
         - address: 192.0.2.2 255.255.255.0
       ipv6:
+        - address: autoconfig
         - address: 2001:db8:0:3::/64
       name: GigabitEthernet0/2
   commands:
@@ -136,6 +139,7 @@ deleted:
           secondary: true
         - address: 192.0.2.2 255.255.255.0
       ipv6:
+        - address: autoconfig
         - address: 2001:db8:0:3::/64
       name: GigabitEthernet0/2
   commands:
@@ -167,6 +171,7 @@ gathered:
           secondary: true
         - address: 192.0.2.2 255.255.255.0
       ipv6:
+        - address: autoconfig
         - address: 2001:db8:0:3::/64
       name: GigabitEthernet0/2
 parsed:
@@ -181,6 +186,7 @@ parsed:
           secondary: true
         - address: 198.51.100.2 255.255.255.0
       ipv6:
+        - address: autoconfig
         - address: 2001:db8:0:3::/64
       name: GigabitEthernet0/2
 rtt:


### PR DESCRIPTION
##### SUMMARY
Add support for autoconfig and dhcp keywords for IPv6 addresses in l3_interfaces.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
l3_interfaces

##### ADDITIONAL INFORMATION
Tested with IOS 15.2(2a)E1. Resubmit of #15 
