### PR TITLE
Fix interface VLAN creation if it does not exist

### DIFF
--- a/plugins/module_utils/network/ios/config/l3_interfaces/l3_interfaces.py
+++ b/plugins/module_utils/network/ios/config/l3_interfaces/l3_interfaces.py
@@ -177,7 +177,7 @@ class L3_Interfaces(ConfigBase):
                 if each["name"] == interface["name"]:
                     break
             else:
-                if "." in interface["name"]:
+                if any(x in interface['name'] for x in [".", "Vlan"]):
                     commands.extend(
                         self._set_config(interface, dict(), module)
                     )
@@ -230,7 +230,7 @@ class L3_Interfaces(ConfigBase):
                 if each["name"] == interface["name"]:
                     break
             else:
-                if "." in interface["name"]:
+                if any(x in interface['name'] for x in [".", "Vlan"]):
                     commands.extend(
                         self._set_config(interface, dict(), module)
                     )

--- a/tests/integration/targets/ios_l3_interfaces/tests/cli/merged.yaml
+++ b/tests/integration/targets/ios_l3_interfaces/tests/cli/merged.yaml
@@ -14,6 +14,9 @@
           - name: Loopback999
             ipv4:
               - address: 192.0.2.1/24
+          - name: Vlan10
+            ipv4:
+              - address: 198.51.0.1/24
           - name: GigabitEthernet0/1
             ipv4:
               - address: dhcp

--- a/tests/integration/targets/ios_l3_interfaces/tests/cli/replaced.yaml
+++ b/tests/integration/targets/ios_l3_interfaces/tests/cli/replaced.yaml
@@ -19,6 +19,10 @@
 
               - address: 203.0.114.1/24
 
+          - name: Vlan10
+            ipv4:
+              - address: 198.51.0.1/24
+
           - name: GigabitEthernet0/2
             ipv4:
 

--- a/tests/integration/targets/ios_l3_interfaces/vars/main.yaml
+++ b/tests/integration/targets/ios_l3_interfaces/vars/main.yaml
@@ -37,6 +37,9 @@ merged:
       ipv6:
         - address: 2001:db8:0:3::/64
       name: GigabitEthernet0/2
+    - ipv4:
+        - address: 198.51.0.1 255.255.255.0
+      name: Vlan10
 replaced:
   before:
     - name: loopback888
@@ -79,6 +82,9 @@ replaced:
       ipv6:
         - address: 2001:db8:1:1::/64
       name: GigabitEthernet0/2
+    - ipv4:
+        - address: 198.51.0.1 255.255.255.0
+      name: Vlan10
 overridden:
   before:
     - name: loopback888


### PR DESCRIPTION
##### SUMMARY
Create vlan interface if interface is not present.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ios_l3_interfaces

##### ADDITIONAL INFORMATION
Before this change, each interface vlan must exist on the switch. This can be done using the module ios_interfaces to enable the interface and then using the module ios_l3_interfaces to configure ip address.

After this change, you can only use ios_l3_interfaces to create and configure a vlan interface.

