### PR TITLE
To fix ios_vlans traceback error when empty line with just Ports information is available in config

### DIFF
--- a/changelogs/fragments/268_ios_vlans_traceback_fix.yml
+++ b/changelogs/fragments/268_ios_vlans_traceback_fix.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - IOS Vlans module throws traceback with empty line config (https://github.com/ansible-collections/cisco.ios/issues/268).

--- a/plugins/module_utils/network/ios/facts/vlans/vlans.py
+++ b/plugins/module_utils/network/ios/facts/vlans/vlans.py
@@ -82,10 +82,17 @@ class VlansFacts(object):
             elif "VLAN AREHops" in conf or "STEHops" in conf:
                 vlan_info = "Hops"
                 vlan_name = False
+            elif "Primary Secondary" in conf:
+                vlan_info = "Primary"
+                vlan_name = False
             if temp:
                 conf = temp
                 temp = ""
-            if conf and " " not in filter(None, conf.split("-")):
+            if (
+                conf
+                and " " not in filter(None, conf.split("-"))
+                and not conf.split(" ")[0] == ""
+            ):
                 obj = self.render_config(self.generated_spec, conf, vlan_info)
                 if "mtu" in obj:
                     mtu_objs.append(obj)

--- a/tests/unit/modules/network/ios/fixtures/ios_vlans_config.cfg
+++ b/tests/unit/modules/network/ios/fixtures/ios_vlans_config.cfg
@@ -1,7 +1,11 @@
 VLAN Name                             Status    Ports
 ---- -------------------------------- --------- -------------------------------
 1    default                          active    Gi0/1, Gi0/2
-123  RemoteIsInMyName                 act/unsup
+123  RemoteIsInMyName                 act/unsup Fa0/1, Fa0/4, Fa0/5, Fa0/6, Fa0/7, Fa0/8, Fa0/9, Fa0/10, Fa0/11, Fa0/12
+                                                Fa0/13, Fa0/14, Fa0/15, Fa0/16, Fa0/17, Fa0/18, Fa0/19, Fa0/20, Fa0/21
+                                                Fa0/22, Fa0/23, Fa0/24, Fa0/25, Fa0/26, Fa0/27, Fa0/28, Fa0/29, Fa0/30
+                                                Fa0/31, Fa0/32, Fa0/33, Fa0/34, Fa0/35, Fa0/36, Fa0/37, Fa0/38, Fa0/39
+                                                Fa0/40, Fa0/41, Fa0/42, Fa0/43, Fa0/44, Fa0/45, Fa0/46, Fa0/47, Fa0/48
 150  VLAN0150                         active
 888  a_very_long_vlan_name_a_very_long_vlan_name
                                       active


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
To fix ios_vlans traceback error when the empty line with just Ports information is available in the config. Fixes #268 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios_vlans

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
