### PR TITLE
Idempotency issue fix for ios logging

### DIFF
--- a/plugins/modules/ios_logging.py
+++ b/plugins/modules/ios_logging.py
@@ -207,6 +207,31 @@ def validate_size(value, module):
         else:
             return value
 
+def is_command_present(w, have):
+    flag = False
+    combined_have = dict()
+
+    for h in have:
+        for k, v in h.items():
+            if v:
+                if combined_have.__contains__(k):
+                    combined_have[k].append(v)
+                else:
+                    combined_have[k] = [v]
+
+    for k, v in w.items():
+        if v:
+            if combined_have.get(k):
+                if v in combined_have.get(k):
+                    flag = True
+                else:
+                    flag = False
+                    break
+            else:
+                flag = False
+                break
+
+    return flag
 
 def map_obj_to_commands(updates, module, os_version):
     dest_group = "console", "monitor", "buffered", "on", "trap"
@@ -220,6 +245,8 @@ def map_obj_to_commands(updates, module, os_version):
         level = w["level"]
         state = w["state"]
         del w["state"]
+        if is_command_present(w, have):
+            continue
         if facility:
             w["dest"] = "facility"
         if state == "absent" and w in have:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios_logging module

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Before this ios_logging module was failing the idempotent behaviour of Ansible while using facility as a parameter within it
Fix for #111 
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
