### PR TITLE
Idempotency fix for default values in IOS logging module 

### DIFF
--- a/changelogs/fragments/110_fix_idempotency_issue_logging.yaml
+++ b/changelogs/fragments/110_fix_idempotency_issue_logging.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - This fixes IOS logging for default values with configuration causing idemotency issue (https://github.com/ansible-collections/cisco.ios/pull/283).

--- a/plugins/modules/ios_logging.py
+++ b/plugins/modules/ios_logging.py
@@ -207,31 +207,6 @@ def validate_size(value, module):
         else:
             return value
 
-def is_command_present(w, have):
-    flag = False
-    combined_have = dict()
-
-    for h in have:
-        for k, v in h.items():
-            if v:
-                if combined_have.__contains__(k):
-                    combined_have[k].append(v)
-                else:
-                    combined_have[k] = [v]
-
-    for k, v in w.items():
-        if v:
-            if combined_have.get(k):
-                if v in combined_have.get(k):
-                    flag = True
-                else:
-                    flag = False
-                    break
-            else:
-                flag = False
-                break
-
-    return flag
 
 def map_obj_to_commands(updates, module, os_version):
     dest_group = "console", "monitor", "buffered", "on", "trap"
@@ -245,8 +220,6 @@ def map_obj_to_commands(updates, module, os_version):
         level = w["level"]
         state = w["state"]
         del w["state"]
-        if is_command_present(w, have):
-            continue
         if facility:
             w["dest"] = "facility"
         if state == "absent" and w in have:

--- a/plugins/modules/ios_logging.py
+++ b/plugins/modules/ios_logging.py
@@ -207,6 +207,31 @@ def validate_size(value, module):
         else:
             return value
 
+def is_command_present(w, have):
+    flag = False
+    combined_have = dict()
+
+    for h in have:
+        for k, v in h.items():
+            if v:
+                if combined_have.__contains__(k):
+                    combined_have[k].append(v)
+                else:
+                    combined_have[k] = [v]
+
+    for k, v in w.items():
+        if v:
+            if combined_have.get(k):
+                if v in combined_have.get(k):
+                    flag = True
+                else:
+                    flag = False
+                    break
+            else:
+                flag = False
+                break
+
+    return flag
 
 def map_obj_to_commands(updates, module, os_version):
     dest_group = "console", "monitor", "buffered", "on", "trap"
@@ -220,6 +245,8 @@ def map_obj_to_commands(updates, module, os_version):
         level = w["level"]
         state = w["state"]
         del w["state"]
+        if is_command_present(w, have):
+            continue
         if facility:
             w["dest"] = "facility"
         if state == "absent" and w in have:

--- a/plugins/modules/ios_logging.py
+++ b/plugins/modules/ios_logging.py
@@ -350,7 +350,7 @@ def map_config_to_obj(module):
         "facility",
         "trap",
     )
-    data = get_config(module, flags=["| include logging"])
+    data = get_config(module, flags=["all | include ^logging"])
     for line in data.split("\n"):
         match = re.search("^logging (\\S+)", line, re.M)
         if match:

--- a/tests/unit/modules/network/ios/test_ios_logging.py
+++ b/tests/unit/modules/network/ios/test_ios_logging.py
@@ -86,6 +86,11 @@ class TestIosLoggingModule(TestIosModule):
         commands = []
         self.execute_module(changed=False, commands=commands)
 
+    def test_ios_logging_dest_on_idempotent(self):
+        set_module_args(dict(dest="on"))
+        commands = []
+        self.execute_module(changed=False, commands=commands)
+
     def test_ios_logging_delete_non_exist_host(self):
         set_module_args(dict(dest="host", name="192.168.1.1", state="absent"))
         commands = []
@@ -147,6 +152,11 @@ class TestIosLoggingModuleIOS12(TestIosModule):
 
     def test_ios_logging_host_idempotent(self):
         set_module_args(dict(dest="host", name="2.3.4.5"))
+        commands = []
+        self.execute_module(changed=False, commands=commands)
+
+    def test_ios_logging_dest_on_idempotent(self):
+        set_module_args(dict(dest="on"))
         commands = []
         self.execute_module(changed=False, commands=commands)
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #110 as default values were not being considered as per the previous filter command

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
cisco.ios.ios_logging

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

for commands like 
```
logging on 
logging facility local7
```
as these are default values `show running-config | include logging` does not produce these as the configuration while execution and hence resulting in idempotency issue
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
show running-config | include logging 
To
show running-config all | include ^logging
```
