### PR TITLE
Fix logging commands for v12 versions

### DIFF
--- a/changelogs/fragments/207-fix-v12-logging-cmds.yaml
+++ b/changelogs/fragments/207-fix-v12-logging-cmds.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - ios_logging - Fix check for v12 in the os_version string (https://github.com/ansible-collections/cisco.ios/issues/207).

--- a/plugins/modules/ios_logging.py
+++ b/plugins/modules/ios_logging.py
@@ -227,7 +227,7 @@ def map_obj_to_commands(updates, module, os_version):
         if state == "absent" and w in have:
             if dest:
                 if dest == "host":
-                    if "12." in os_version:
+                    if os_version.startswith("12."):
                         commands.append("no logging {0}".format(name))
                     else:
                         commands.append("no logging host {0}".format(name))
@@ -251,7 +251,7 @@ def map_obj_to_commands(updates, module, os_version):
                 if not present:
                     commands.append("logging facility {0}".format(facility))
             if dest == "host":
-                if "12." in os_version:
+                if os_version.startswith("12."):
                     commands.append("logging {0}".format(name))
                 else:
                     commands.append("logging host {0}".format(name))


### PR DESCRIPTION
##### SUMMARY
Fixes #207 

Checks the start of the os_version string for v12 version instead of anywhere in the string. Otherwise it will match versions like 16.12.4.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios_logging
