### PR TITLE
Fix TwentyFive Gig matching

### DIFF
--- a/changelogs/fragments/313_reordering_interface.yaml
+++ b/changelogs/fragments/313_reordering_interface.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Reordering names of interafce for proper value assignment  

--- a/changelogs/fragments/313_reordering_interface.yaml
+++ b/changelogs/fragments/313_reordering_interface.yaml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - Reordering names of interafce for proper value assignment  
+  - Reordering names of interface for proper value assignment

--- a/plugins/module_utils/network/ios/ios.py
+++ b/plugins/module_utils/network/ios/ios.py
@@ -168,6 +168,8 @@ def normalize_interface(name):
 
     if name.lower().startswith("gi"):
         if_type = "GigabitEthernet"
+    elif name.lower().startswith("twe"):
+        if_type = "TwentyFiveGigE"
     elif name.lower().startswith("tw"):
         if_type = "TwoGigabitEthernet"
     elif name.lower().startswith("te"):
@@ -186,8 +188,6 @@ def normalize_interface(name):
         if_type = "port-channel"
     elif name.lower().startswith("nv"):
         if_type = "nve"
-    elif name.lower().startswith("twe"):
-        if_type = "TwentyFiveGigE"
     elif name.lower().startswith("hu"):
         if_type = "HundredGigE"
     else:

--- a/plugins/module_utils/network/ios/utils/utils.py
+++ b/plugins/module_utils/network/ios/utils/utils.py
@@ -306,6 +306,8 @@ def normalize_interface(name):
 
     if name.lower().startswith("gi"):
         if_type = "GigabitEthernet"
+    elif name.lower().startswith("twe"):
+        if_type = "TwentyFiveGigE"
     elif name.lower().startswith("tw"):
         if_type = "TwoGigabitEthernet"
     elif name.lower().startswith("te"):
@@ -326,8 +328,6 @@ def normalize_interface(name):
         if_type = "Port-channel"
     elif name.lower().startswith("nv"):
         if_type = "nve"
-    elif name.lower().startswith("twe"):
-        if_type = "TwentyFiveGigE"
     elif name.lower().startswith("hu"):
         if_type = "HundredGigE"
     elif name.lower().startswith("virtual-te"):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes a bug/regression introduced by PR 262 where the TwoGigabit(tw) interface was matching and the TwentyFive(twe) was never matched.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios_config

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
ansible.module_utils.connection.ConnectionError: interface TwoGigabitEthernet1/0/1\r
interface TwoGigabitEthernet1/0/1\r
            ^\r
% Invalid input detected at '^' marker.\r
\r
SWITCH-(config)#
failed: [SWITCH] (item={'name': 'TwentyFiveGigE1/0/1', 'description': 'PORT E1/23', 'ipv4': 'NA', 'enabled': 'TRUE', 'mtu': '1500', 'trusted': 'TRUE',
 'no_switchport': 'FALSE'}) => {
    "ansible_loop_var": "item",
    "changed": false,
    "item": {
        "description": "PORT E1/23",
        "enabled": "TRUE",
        "ipv4": "NA",
        "mtu": "1500",
        "name": "TwentyFiveGigE1/0/1",
        "no_switchport": "FALSE",
        "trusted": "TRUE"
    },


<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
