### PR TITLE
Fix IOS bgp global RM tracback while there's no bestpath/nopeerup_delay configured

### DIFF
--- a/changelogs/fragments/310-311-fix-bgp-global-traceback-error.yaml
+++ b/changelogs/fragments/310-311-fix-bgp-global-traceback-error.yaml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - Fix IOS bgp global RM tracback while there's no bestpath/nopeerup_delay configured (https://github.com/ansible-collections/cisco.ios/issues/310,
+  https://github.com/ansible-collections/cisco.ios/issues/311).

--- a/plugins/module_utils/network/ios/argspec/bgp_address_family/bgp_address_family.py
+++ b/plugins/module_utils/network/ios/argspec/bgp_address_family/bgp_address_family.py
@@ -31,9 +31,6 @@ class Bgp_AddressFamilyArgs(object):
     """The arg spec for the cisco.ios_bgp_address_family module
     """
 
-    def __init__(self, **kwargs):
-        pass
-
     argument_spec = {
         "config": {
             "type": "dict",

--- a/plugins/module_utils/network/ios/argspec/bgp_global/bgp_global.py
+++ b/plugins/module_utils/network/ios/argspec/bgp_global/bgp_global.py
@@ -31,9 +31,6 @@ class Bgp_globalArgs(object):  # pylint: disable=R0903
     """The arg spec for the cisco.ios_bgp_global module
     """
 
-    def __init__(self, **kwargs):
-        pass
-
     argument_spec = {
         "config": {
             "type": "dict",

--- a/plugins/module_utils/network/ios/config/bgp_global/bgp_global.py
+++ b/plugins/module_utils/network/ios/config/bgp_global/bgp_global.py
@@ -254,84 +254,85 @@ class Bgp_global(ResourceModule):
                 if every == "bgp":
                     for each in ["bestpath", "nopeerup_delay"]:
                         set_have = True
-                        for k, v in iteritems(param_want.get(each)):
-                            if (
-                                param_have
-                                and k in param_have.get(each)
-                                and self.state == "merged"
-                            ):
-                                if k in param_have.get(each):
+                        if param_want.get(each):
+                            for k, v in iteritems(param_want.get(each)):
+                                if (
+                                    param_have
+                                    and k in param_have.get(each)
+                                    and self.state == "merged"
+                                ):
+                                    if k in param_have.get(each):
+                                        self.compare(
+                                            parsers=[every + "." + each],
+                                            want={"bgp": {each: {k: v}}},
+                                            have={
+                                                "bgp": {
+                                                    each: {
+                                                        k: param_have.get(
+                                                            each, {}
+                                                        )[k]
+                                                    }
+                                                }
+                                            },
+                                        )
+
+                                elif param_have and self.state == "replaced":
+                                    if set_have and param_have.get(each):
+                                        if isinstance(each, dict):
+                                            for key_have, val_have in iteritems(
+                                                param_have.get(each)
+                                            ):
+                                                multi_compare(
+                                                    parser=every,
+                                                    want=dict(),
+                                                    have=val_have,
+                                                )
+                                        else:
+                                            temp = {}
+                                            for i in list(param_have[each]):
+                                                if i not in param_want[each]:
+                                                    temp.update(
+                                                        {
+                                                            each: {
+                                                                i: param_have[
+                                                                    each
+                                                                ][i]
+                                                            }
+                                                        }
+                                                    )
+                                            temp_have = temp
+                                            temp = {}
+                                            for i in list(param_want[each]):
+                                                if i not in param_have[each]:
+                                                    temp.update(
+                                                        {
+                                                            each: {
+                                                                i: param_want[
+                                                                    each
+                                                                ][i]
+                                                            }
+                                                        }
+                                                    )
+                                            temp_want = temp
+                                            if temp_have:
+                                                self.compare(
+                                                    parsers=[every + "." + each],
+                                                    want=dict(),
+                                                    have={"bgp": temp_have},
+                                                )
+                                            if temp_want:
+                                                self.compare(
+                                                    parsers=[every + "." + each],
+                                                    want={"bgp": temp_want},
+                                                    have=dict(),
+                                                )
+                                        set_have = False
+                                else:
                                     self.compare(
                                         parsers=[every + "." + each],
                                         want={"bgp": {each: {k: v}}},
-                                        have={
-                                            "bgp": {
-                                                each: {
-                                                    k: param_have.get(
-                                                        each, {}
-                                                    )[k]
-                                                }
-                                            }
-                                        },
+                                        have=dict(),
                                     )
-
-                            elif param_have and self.state == "replaced":
-                                if set_have and param_have.get(each):
-                                    if isinstance(each, dict):
-                                        for key_have, val_have in iteritems(
-                                            param_have.get(each)
-                                        ):
-                                            multi_compare(
-                                                parser=every,
-                                                want=dict(),
-                                                have=val_have,
-                                            )
-                                    else:
-                                        temp = {}
-                                        for i in list(param_have[each]):
-                                            if i not in param_want[each]:
-                                                temp.update(
-                                                    {
-                                                        each: {
-                                                            i: param_have[
-                                                                each
-                                                            ][i]
-                                                        }
-                                                    }
-                                                )
-                                        temp_have = temp
-                                        temp = {}
-                                        for i in list(param_want[each]):
-                                            if i not in param_have[each]:
-                                                temp.update(
-                                                    {
-                                                        each: {
-                                                            i: param_want[
-                                                                each
-                                                            ][i]
-                                                        }
-                                                    }
-                                                )
-                                        temp_want = temp
-                                        if temp_have:
-                                            self.compare(
-                                                parsers=[every + "." + each],
-                                                want=dict(),
-                                                have={"bgp": temp_have},
-                                            )
-                                        if temp_want:
-                                            self.compare(
-                                                parsers=[every + "." + each],
-                                                want={"bgp": temp_want},
-                                                have=dict(),
-                                            )
-                                    set_have = False
-                            else:
-                                self.compare(
-                                    parsers=[every + "." + each],
-                                    want={"bgp": {each: {k: v}}},
-                                    have=dict(),
-                                )
                 if every == "neighbor" or every == "redistribute":
                     for k, v in iteritems(param_want):
                         if every == "neighbor":
@@ -409,12 +410,13 @@ class Bgp_global(ResourceModule):
                     for k, v in iteritems(param_have):
                         if every == "bgp" and del_config_have:
                             for each in ["bestpath", "nopeerup_delay"]:
-                                for k, v in iteritems(param_have.get(each)):
-                                    self.compare(
-                                        parsers=[every + "." + each],
-                                        want=dict(),
-                                        have={"bgp": {each: {k: v}}},
-                                    )
+                                if param_have.get(each):
+                                    for k, v in iteritems(param_have.get(each)):
+                                        self.compare(
+                                            parsers=[every + "." + each],
+                                            want=dict(),
+                                            have={"bgp": {each: {k: v}}},
+                                        )
                             del_config_have = False
                         elif every == "neighbor":
                             multi_compare(parser=every, want=dict(), have=v)

--- a/plugins/module_utils/network/ios/facts/bgp_address_family/bgp_address_family.py
+++ b/plugins/module_utils/network/ios/facts/bgp_address_family/bgp_address_family.py
@@ -35,16 +35,6 @@ class Bgp_AddressFamilyFacts(object):
     def __init__(self, module, subspec="config", options="options"):
         self._module = module
         self.argument_spec = Bgp_AddressFamilyArgs.argument_spec
-        spec = deepcopy(self.argument_spec)
-        if subspec:
-            if options:
-                facts_argument_spec = spec[subspec][options]
-            else:
-                facts_argument_spec = spec[subspec]
-        else:
-            facts_argument_spec = spec
-
-        self.generated_spec = utils.generate_dict(facts_argument_spec)
 
     def get_bgp_address_family_data(self, connection):
         return connection.get("sh running-config | section ^router bgp")

--- a/plugins/module_utils/network/ios/facts/bgp_global/bgp_global.py
+++ b/plugins/module_utils/network/ios/facts/bgp_global/bgp_global.py
@@ -33,16 +33,6 @@ class Bgp_globalFacts(object):
     def __init__(self, module, subspec="config", options="options"):
         self._module = module
         self.argument_spec = Bgp_globalArgs.argument_spec
-        spec = deepcopy(self.argument_spec)
-        if subspec:
-            if options:
-                facts_argument_spec = spec[subspec][options]
-            else:
-                facts_argument_spec = spec[subspec]
-        else:
-            facts_argument_spec = spec
-
-        self.generated_spec = utils.generate_dict(facts_argument_spec)
 
     def get_bgp_global_data(self, connection):
         return connection.get("sh running-config | section ^router bgp")


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fix IOS bgp global RM tracback while there's no bestpath/nopeerup_delay configured. Also, remove unwanted line from bgp* RM. Fixes #310, #311
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios_bgp_global

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
