### PR TITLE
I guess we aren't testing XE right now?

### DIFF
--- a/changelogs/fragments/317-authorize.yaml
+++ b/changelogs/fragments/317-authorize.yaml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - remove "authorize" from prepare_ios_tests as it is not a valid parameter anymore

--- a/tests/integration/targets/prepare_ios_tests/tasks/main.yml
+++ b/tests/integration/targets/prepare_ios_tests/tasks/main.yml
@@ -40,7 +40,7 @@
         lines:
           - no negotiation auto
         parents: int GigabitEthernet2
-        authorize: true
+      become: true
 
     - name: Set test interface 2 to GigabitEthernet3 as we are on Cisco IOS-XE
       set_fact: test_interface2=GigabitEthernet3
@@ -50,5 +50,5 @@
         lines:
           - no negotiation auto
         parents: int GigabitEthernet3
-        authorize: true
+      become: true
   when: "'Cisco IOS-XE' in result.stdout[0]"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
`authorize` was removed from `ios_config` a while ago, but is still in the setup tasks when `show version` contains "IOS-XE" 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Tests Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
prepare_ios_tests