### PR TITLE
To fix IOS ACLs and Prefix Lists RM to not negate config when using merge state

### DIFF
--- a/changelogs/fragments/345_update_prefix_list_and_acls_merge_behaviour.yaml
+++ b/changelogs/fragments/345_update_prefix_list_and_acls_merge_behaviour.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - To update prefix list and acls merge behaviour and update prefix list description position in model (https://github.com/ansible-collections/cisco.ios/issues/345).

--- a/plugins/module_utils/network/ios/argspec/prefix_lists/prefix_lists.py
+++ b/plugins/module_utils/network/ios/argspec/prefix_lists/prefix_lists.py
@@ -42,6 +42,7 @@ class Prefix_listsArgs(object):
                     "elements": "dict",
                     "options": {
                         "name": {"type": "str"},
+                        "description": {"type": "str"},
                         "entries": {
                             "type": "list",
                             "elements": "dict",
@@ -50,7 +51,6 @@ class Prefix_listsArgs(object):
                                     "type": "str",
                                     "choices": ["deny", "permit"],
                                 },
-                                "description": {"type": "str"},
                                 "sequence": {"type": "int"},
                                 "prefix": {"type": "str"},
                                 "ge": {"type": "int"},

--- a/plugins/module_utils/network/ios/argspec/prefix_lists/prefix_lists.py
+++ b/plugins/module_utils/network/ios/argspec/prefix_lists/prefix_lists.py
@@ -52,6 +52,7 @@ class Prefix_listsArgs(object):
                                     "choices": ["deny", "permit"],
                                 },
                                 "sequence": {"type": "int"},
+                                "description": {"type": "str"},
                                 "prefix": {"type": "str"},
                                 "ge": {"type": "int"},
                                 "le": {"type": "int"},

--- a/plugins/module_utils/network/ios/config/acls/acls.py
+++ b/plugins/module_utils/network/ios/config/acls/acls.py
@@ -143,6 +143,13 @@ class Acls(ResourceModule):
                                     ):
                                         have_ace.pop("protocol")
                                 if have_ace and val != have_ace:
+                                    if self.state == "merged" and have_ace.get(
+                                        "sequence"
+                                    ) == val.get("sequence"):
+                                        self._module.fail_json(
+                                            "Merge state cannot merge on the ACL"
+                                            + " pre-existing ACE sequence, it can only add ACE over a new sequence!"
+                                        )
                                     self.compare(
                                         parsers=self.parsers,
                                         want=dict(),

--- a/plugins/module_utils/network/ios/config/acls/acls.py
+++ b/plugins/module_utils/network/ios/config/acls/acls.py
@@ -147,8 +147,10 @@ class Acls(ResourceModule):
                                         "sequence"
                                     ) == val.get("sequence"):
                                         self._module.fail_json(
-                                            "Merge state cannot merge on the ACL"
-                                            + " pre-existing ACE sequence, it can only add ACE over a new sequence!"
+                                            "Cannot update existing sequence {0} of ACLs {1} with state merged.".format(
+                                                val.get("sequence"), k
+                                            )
+                                            + " Please use state replaced or overridden."
                                         )
                                     self.compare(
                                         parsers=self.parsers,

--- a/plugins/module_utils/network/ios/config/prefix_lists/prefix_lists.py
+++ b/plugins/module_utils/network/ios/config/prefix_lists/prefix_lists.py
@@ -157,37 +157,56 @@ class Prefix_lists(ResourceModule):
                                 },
                             )
                         if have_prefix_param and val != have_prefix_param:
-                            if self.state == "merged" and have_prefix_param.get(
-                                "sequence"
-                            ) == val.get(
-                                "sequence"
-                            ):
-                                self._module.fail_json(
-                                    "Merge state cannot merge on the pre-existing Prefix-List sequence,"
-                                    + " it can only add Prefix-List entry over a new sequence!"
+                            if key == "description":
+                                # Code snippet should be removed when Description param is removed from
+                                # entries level as this supports deprecated level of Description
+                                self.compare(
+                                    parsers=self.parsers,
+                                    want={
+                                        "afi": want["afi"],
+                                        "name": k,
+                                        "prefix_list": {key: val},
+                                    },
+                                    have={
+                                        "afi": have["afi"],
+                                        "name": k,
+                                        "prefix_list": {
+                                            key: have_prefix_param
+                                        },
+                                    },
                                 )
-                            self.compare(
-                                parsers=self.parsers,
-                                want=dict(),
-                                have={
-                                    "afi": have["afi"],
-                                    "name": k,
-                                    "prefix_list": have_prefix_param,
-                                },
-                            )
-                            self.compare(
-                                parsers=self.parsers,
-                                want={
-                                    "afi": want["afi"],
-                                    "name": k,
-                                    "prefix_list": val,
-                                },
-                                have={
-                                    "afi": have["afi"],
-                                    "name": k,
-                                    "prefix_list": have_prefix_param,
-                                },
-                            )
+                            else:
+                                if self.state == "merged" and have_prefix_param.get(
+                                    "sequence"
+                                ) == val.get(
+                                    "sequence"
+                                ):
+                                    self._module.fail_json(
+                                        "Merge state cannot merge on the pre-existing Prefix-List sequence,"
+                                        + " it can only add Prefix-List entry over a new sequence!"
+                                    )
+                                self.compare(
+                                    parsers=self.parsers,
+                                    want=dict(),
+                                    have={
+                                        "afi": have["afi"],
+                                        "name": k,
+                                        "prefix_list": have_prefix_param,
+                                    },
+                                )
+                                self.compare(
+                                    parsers=self.parsers,
+                                    want={
+                                        "afi": want["afi"],
+                                        "name": k,
+                                        "prefix_list": val,
+                                    },
+                                    have={
+                                        "afi": have["afi"],
+                                        "name": k,
+                                        "prefix_list": have_prefix_param,
+                                    },
+                                )
                         elif val and val != have_prefix_param:
                             self.compare(
                                 parsers=self.parsers,
@@ -202,6 +221,8 @@ class Prefix_lists(ResourceModule):
                         self.state == "replaced" or self.state == "overridden"
                     ):
                         if have_prefix.get("description"):
+                            # Code snippet should be removed when Description param is removed from
+                            # entries level as this supports deprecated level of Description
                             self.compare(
                                 parsers=self.parsers,
                                 want=dict(),

--- a/plugins/module_utils/network/ios/config/prefix_lists/prefix_lists.py
+++ b/plugins/module_utils/network/ios/config/prefix_lists/prefix_lists.py
@@ -264,7 +264,7 @@ class Prefix_lists(ResourceModule):
                         temp_prefix_list.update(
                             {
                                 each["name"]: {
-                                    "description": each["description"],
+                                    "description": each.get("description"),
                                     "entries": temp_entries,
                                 }
                             }

--- a/plugins/module_utils/network/ios/config/prefix_lists/prefix_lists.py
+++ b/plugins/module_utils/network/ios/config/prefix_lists/prefix_lists.py
@@ -182,8 +182,10 @@ class Prefix_lists(ResourceModule):
                                     "sequence"
                                 ):
                                     self._module.fail_json(
-                                        "Merge state cannot merge on the pre-existing Prefix-List sequence,"
-                                        + " it can only add Prefix-List entry over a new sequence!"
+                                        "Cannot update existing sequence {0} of Prefix Lists {1} with state merged.".format(
+                                            val.get("sequence"), k
+                                        )
+                                        + " Please use state replaced or overridden."
                                     )
                                 self.compare(
                                     parsers=self.parsers,

--- a/plugins/module_utils/network/ios/facts/prefix_lists/prefix_lists.py
+++ b/plugins/module_utils/network/ios/facts/prefix_lists/prefix_lists.py
@@ -89,7 +89,10 @@ class Prefix_listsFacts(object):
                 for each in v["prefix_lists"]:
                     if not temp_prefix_list.get("name"):
                         temp_prefix_list["name"] = each["name"]
-                    temp_prefix_list["entries"].append(each["entries"])
+                    if not temp_prefix_list.get("description"):
+                        temp_prefix_list["description"] = each["description"]
+                    if each["entries"]:
+                        temp_prefix_list["entries"].append(each["entries"])
                 temp["prefix_lists"].append(temp_prefix_list)
             if temp and temp["afi"]:
                 temp["prefix_lists"] = sorted(

--- a/plugins/module_utils/network/ios/facts/prefix_lists/prefix_lists.py
+++ b/plugins/module_utils/network/ios/facts/prefix_lists/prefix_lists.py
@@ -89,9 +89,13 @@ class Prefix_listsFacts(object):
                 for each in v["prefix_lists"]:
                     if not temp_prefix_list.get("name"):
                         temp_prefix_list["name"] = each["name"]
-                    if not temp_prefix_list.get("description"):
+                    if not temp_prefix_list.get("description") and each.get(
+                        "description"
+                    ):
                         temp_prefix_list["description"] = each["description"]
-                    if each["entries"]:
+                    if each["entries"] and not each["entries"].get(
+                        "description"
+                    ):
                         temp_prefix_list["entries"].append(each["entries"])
                 temp["prefix_lists"].append(temp_prefix_list)
             if temp and temp["afi"]:

--- a/plugins/module_utils/network/ios/rm_templates/prefix_lists.py
+++ b/plugins/module_utils/network/ios/rm_templates/prefix_lists.py
@@ -25,18 +25,19 @@ def _tmplt_set_prefix_lists(config_data):
         if config_data.get("afi") == "ipv4":
             config_data["afi"] = "ip"
         cmd = "{afi} prefix-list {name}".format(**config_data)
-        if config_data["prefix_list"].get("description"):
-            cmd += " description {description}".format(
-                **config_data["prefix_list"]
-            )
-        else:
-            cmd += " seq {sequence} {action} {prefix}".format(
-                **config_data["prefix_list"]
-            )
-            if config_data["prefix_list"].get("ge"):
-                cmd += " ge {ge}".format(**config_data["prefix_list"])
-            if config_data["prefix_list"].get("le"):
-                cmd += " le {le}".format(**config_data["prefix_list"])
+        if config_data.get("prefix_list"):
+            if config_data["prefix_list"].get("description"):
+                cmd += " description {description}".format(
+                    **config_data["prefix_list"]
+                )
+            else:
+                cmd += " seq {sequence} {action} {prefix}".format(
+                    **config_data["prefix_list"]
+                )
+                if config_data["prefix_list"].get("ge"):
+                    cmd += " ge {ge}".format(**config_data["prefix_list"])
+                if config_data["prefix_list"].get("le"):
+                    cmd += " le {le}".format(**config_data["prefix_list"])
         return cmd
 
 
@@ -68,8 +69,8 @@ class Prefix_listsTemplate(NetworkTemplate):
                     "prefix_lists": [
                         {
                             "name": "{{ name if name is defined }}",
+                            "description": "{{ description.split('description ')[1] if description is defined }}",
                             "entries": {
-                                "description": "{{ description.split('description ')[1] if description is defined }}",
                                 "sequence": "{{ sequence.split(' ')[1] if sequence is defined }}",
                                 "action": "{{ action if action is defined }}",
                                 "prefix": "{{ prefix if prefix is defined }}",

--- a/plugins/module_utils/network/ios/rm_templates/prefix_lists.py
+++ b/plugins/module_utils/network/ios/rm_templates/prefix_lists.py
@@ -71,6 +71,9 @@ class Prefix_listsTemplate(NetworkTemplate):
                             "name": "{{ name if name is defined }}",
                             "description": "{{ description.split('description ')[1] if description is defined }}",
                             "entries": {
+                                # Description at this level is deprecated, should be removed when we plan to remove the
+                                # Description from entries level
+                                "description": "{{ description.split('description ')[1] if description is defined }}",
                                 "sequence": "{{ sequence.split(' ')[1] if sequence is defined }}",
                                 "action": "{{ action if action is defined }}",
                                 "prefix": "{{ prefix if prefix is defined }}",

--- a/plugins/modules/ios_acls.py
+++ b/plugins/modules/ios_acls.py
@@ -660,8 +660,8 @@ EXAMPLES = """
 # ------------
 #
 # Play Execution fails, with error:
-# Merge state cannot merge on the ACL pre-existing ACE sequence,
-# it can only add ACE over a new sequence!
+# Cannot update existing sequence 10 of ACLs 100 with state merged.
+# Please use state replaced or overridden.
 
 # Before state:
 # -------------

--- a/plugins/modules/ios_acls.py
+++ b/plugins/modules/ios_acls.py
@@ -612,6 +612,10 @@ options:
     default: merged
     description:
       - The state the configuration should be left in
+      - The states I(merged) is the default state which merges the want and have config, but
+        for ACL module as the IOS platform doesn't allow update of ACE over an pre-existing ACE
+        sequence in ACL, same way ACLs resource module will error out for respective scenario
+        and only addition of new ACE over new sequence will be allowed with merge state.
       - The states I(rendered), I(gathered) and I(parsed) does not perform any change
         on the device.
       - The state I(rendered) will transform the configuration in C(config) option to
@@ -631,6 +635,33 @@ options:
 """
 EXAMPLES = """
 # Using merged
+
+# Before state:
+# -------------
+#
+# vios#sh access-lists
+# Extended IP access list 100
+#    10 deny icmp 192.0.2.0 0.0.0.255 192.0.3.0 0.0.0.255 echo dscp ef ttl eq 10
+
+- name: Merge provided configuration with device configuration
+  cisco.ios.ios_acls:
+    config:
+    - afi: ipv4
+      acls:
+      - name: 100
+        aces:
+        - sequence: 10
+          protocol_options:
+            icmp:
+              traceroute: true
+    state: merged
+
+# After state:
+# ------------
+#
+# Play Execution fails, with error:
+# Merge state cannot merge on the ACL pre-existing ACE sequence,
+# it can only add ACE over a new sequence!
 
 # Before state:
 # -------------
@@ -746,7 +777,6 @@ EXAMPLES = """
 # - deny 192.168.1.200
 # - deny 192.168.2.0 0.0.0.255
 # - ip access-list extended 110
-# - no 10
 # - 10 deny icmp 192.0.2.0 0.0.0.255 192.0.3.0 0.0.0.255 traceroute dscp ef ttl eq 10
 # - deny tcp host 198.51.100.0 host 198.51.110.0 eq telnet ack
 # - ip access-list extended test
@@ -764,6 +794,8 @@ EXAMPLES = """
 # Standard IP access list std_acl
 #    10 deny   192.168.1.200
 #    20 deny   192.168.2.0, wildcard bits 0.0.0.255
+# Extended IP access list 100
+#    10 deny icmp 192.0.2.0 0.0.0.255 192.0.3.0 0.0.0.255 echo dscp ef ttl eq 10
 # Extended IP access list 110
 #    10 deny icmp 192.0.2.0 0.0.0.255 192.0.3.0 0.0.0.255 traceroute dscp ef ttl eq 10
 #    20 deny tcp host 198.51.100.0 host 198.51.110.0 eq telnet ack

--- a/plugins/modules/ios_prefix_lists.py
+++ b/plugins/modules/ios_prefix_lists.py
@@ -42,6 +42,9 @@ options:
           name:
             description: Name of a prefix-list
             type: str
+          description:
+            description:  Prefix-list specific description
+            type: str
           entries:
             description: Prefix-lists supported params.
             type: list
@@ -54,9 +57,6 @@ options:
               sequence:
                 description: sequence number of an entry
                 type: int
-              description:
-                description:  Prefix-list specific description
-                type: str
               prefix:
                 description:
                   - IPv4 prefix <network>/<length>, e.g., A.B.C.D/nn
@@ -80,6 +80,11 @@ options:
   state:
     description:
       - The state the configuration should be left in
+      - The states I(merged) is the default state which merges the want and have config, but
+        for Prefix-List module as the IOS platform doesn't allow update of Prefix-List over an
+        pre-existing Prefix-List, same way Prefix-Lists resource module will error out for
+        respective scenario and only addition of new Prefix-List over new sequence will be
+        allowed with merge state.
       - The states I(rendered), I(gathered) and I(parsed) does not perform any change
         on the device.
       - The state I(rendered) will transform the configuration in C(config) option to
@@ -242,11 +247,40 @@ EXAMPLES = """
 - name: Merge provided Prefix lists configuration
   cisco.ios.ios_prefix_lists:
     config:
+      - afi: ipv6
+        prefix_lists:
+          - name: test_ipv6
+            description: this is ipv6 merge test
+            entries:
+              - action: deny
+                prefix: 2001:DB8:0:4::/64
+                ge: 80
+                le: 100
+                sequence: 10
+    state: merged
+
+# After state:
+# -------------
+#
+# Play Execution fails, with error:
+# Merge state cannot merge on the pre-existing Prefix-List sequence,
+# it can only add Prefix-List entry over a new sequence!
+
+# Before state:
+# -------------
+#
+# router-ios#sh running-config | section ^ip prefix-list|^ipv6 prefix-list
+# ipv6 prefix-list test_ipv6 description this is ipv6
+# ipv6 prefix-list test_ipv6 seq 10 deny 2001:DB8:0:4::/64 ge 80
+
+- name: Merge provided Prefix lists configuration
+  cisco.ios.ios_prefix_lists:
+    config:
       - afi: ipv4
         prefix_lists:
           - name: 10
+            description: this is new merge test
             entries:
-              - description: this is new merge test
               - action: deny
                 prefix: 1.0.0.0/8
                 le: 15
@@ -265,15 +299,15 @@ EXAMPLES = """
                 le: 21
                 sequence: 20
           - name: test
+            description: this is merge test
             entries:
-              - description: this is merge test
               - action: deny
                 prefix: 12.0.0.0/8
                 ge: 15
                 sequence: 50
           - name: test_prefix
+            description: this is for prefix-list
             entries:
-              - description: this is for prefix-list
               - action: deny
                 prefix: 35.0.0.0/8
                 ge: 10
@@ -286,13 +320,13 @@ EXAMPLES = """
       - afi: ipv6
         prefix_lists:
           - name: test_ipv6
+            description: this is ipv6 merge test
             entries:
-              - description: this is ipv6 merge test
               - action: deny
                 prefix: 2001:DB8:0:4::/64
                 ge: 80
                 le: 100
-                sequence: 10
+                sequence: 20
     state: merged
 
 #  Commands Fired:
@@ -309,8 +343,7 @@ EXAMPLES = """
 #         "ip prefix-list test_prefix seq 10 deny 35.0.0.0/8 ge 20",
 #         "ip prefix-list test_prefix seq 5 deny 35.0.0.0/8 ge 10 le 15",
 #         "ip prefix-list test_prefix description this is for prefix-list",
-#         "no ipv6 prefix-list test_ipv6 seq 10 deny 2001:DB8:0:4::/64 ge 80",
-#         "ipv6 prefix-list test_ipv6 seq 10 deny 2001:DB8:0:4::/64 ge 80 le 100",
+#         "ipv6 prefix-list test_ipv6 seq 20 deny 2001:DB8:0:4::/64 ge 80 le 100",
 #         "ipv6 prefix-list test_ipv6 description this is ipv6 merge test"
 #     ]
 
@@ -356,8 +389,8 @@ EXAMPLES = """
       - afi: ipv4
         prefix_lists:
           - name: 10
+            description: this is override test
             entries:
-              - description: this is override test
               - action: deny
                 prefix: 12.0.0.0/8
                 ge: 15
@@ -368,8 +401,8 @@ EXAMPLES = """
                 le: 21
                 sequence: 20
           - name: test_override
+            description: this is override test
             entries:
-              - description: this is override test
               - action: deny
                 prefix: 35.0.0.0/8
                 ge: 20
@@ -377,8 +410,8 @@ EXAMPLES = """
       - afi: ipv6
         prefix_lists:
           - name: test_ipv6
+            description: this is ipv6 override test
             entries:
-              - description: this is ipv6 override test
               - action: deny
                 prefix: 2001:DB8:0:4::/64
                 ge: 80
@@ -439,8 +472,8 @@ EXAMPLES = """
       - afi: ipv4
         prefix_lists:
           - name: 10
+            description: this is replace test
             entries:
-              - description: this is replace test
               - action: deny
                 prefix: 12.0.0.0/8
                 ge: 15
@@ -451,8 +484,8 @@ EXAMPLES = """
                 le: 21
                 sequence: 20
           - name: test_replace
+            description: this is replace test
             entries:
-              - description: this is replace test
               - action: deny
                 prefix: 35.0.0.0/8
                 ge: 20
@@ -460,8 +493,8 @@ EXAMPLES = """
       - afi: ipv6
         prefix_lists:
           - name: test_ipv6
+            description: this is ipv6 replace test
             entries:
-              - description: this is ipv6 replace test
               - action: deny
                 prefix: 2001:DB8:0:4::/64
                 ge: 80
@@ -531,10 +564,8 @@ EXAMPLES = """
 #             "afi": "ipv4",
 #             "prefix_lists": [
 #                 {
+#                     "description": "this is test description"
 #                     "entries": [
-#                         {
-#                             "description": "this is test description"
-#                         },
 #                         {
 #                             "action": "deny",
 #                             "le": 15,
@@ -564,10 +595,8 @@ EXAMPLES = """
 #                     "name": "10"
 #                 },
 #                 {
+#                     "description": "this is test"
 #                     "entries": [
-#                         {
-#                             "description": "this is test"
-#                         },
 #                         {
 #                             "action": "deny",
 #                             "ge": 15,
@@ -578,10 +607,8 @@ EXAMPLES = """
 #                     "name": "test"
 #                 },
 #                 {
+#                     "description": "this is for prefix-list"
 #                     "entries": [
-#                         {
-#                             "description": "this is for prefix-list"
-#                         },
 #                         {
 #                             "action": "deny",
 #                             "ge": 10,
@@ -604,10 +631,8 @@ EXAMPLES = """
 #             "afi": "ipv6",
 #             "prefix_lists": [
 #                 {
+#                     "description": "this is ipv6 prefix-list"
 #                     "entries": [
-#                         {
-#                             "description": "this is ipv6 prefix-list"
-#                         },
 #                         {
 #                             "action": "deny",
 #                             "ge": 80,
@@ -646,8 +671,8 @@ EXAMPLES = """
       - afi: ipv4
         prefix_lists:
           - name: 10
+            description: this is new merge test
             entries:
-              - description: this is new merge test
               - action: deny
                 prefix: 1.0.0.0/8
                 le: 15
@@ -666,15 +691,15 @@ EXAMPLES = """
                 le: 21
                 sequence: 20
           - name: test
+            description: this is merge test
             entries:
-              - description: this is merge test
               - action: deny
                 prefix: 12.0.0.0/8
                 ge: 15
                 sequence: 50
           - name: test_prefix
+            description: this is for prefix-list
             entries:
-              - description: this is for prefix-list
               - action: deny
                 prefix: 35.0.0.0/8
                 ge: 10
@@ -687,8 +712,8 @@ EXAMPLES = """
       - afi: ipv6
         prefix_lists:
           - name: test_ipv6
+            description: this is ipv6 merge test
             entries:
-              - description: this is ipv6 merge test
               - action: deny
                 prefix: 2001:DB8:0:4::/64
                 ge: 80
@@ -745,10 +770,8 @@ EXAMPLES = """
 #             "afi": "ipv4",
 #             "prefix_lists": [
 #                 {
+#                     "description": "this is test description"
 #                     "entries": [
-#                         {
-#                             "description": "this is test description"
-#                         },
 #                         {
 #                             "action": "deny",
 #                             "le": 15,
@@ -778,10 +801,8 @@ EXAMPLES = """
 #                     "name": "10"
 #                 },
 #                 {
+#                     "description": "this is test"
 #                     "entries": [
-#                         {
-#                             "description": "this is test"
-#                         },
 #                         {
 #                             "action": "deny",
 #                             "ge": 15,
@@ -792,10 +813,8 @@ EXAMPLES = """
 #                     "name": "test"
 #                 },
 #                 {
+#                     "description": "this is for prefix-list"
 #                     "entries": [
-#                         {
-#                             "description": "this is for prefix-list"
-#                         },
 #                         {
 #                             "action": "deny",
 #                             "ge": 10,
@@ -818,10 +837,8 @@ EXAMPLES = """
 #             "afi": "ipv6",
 #             "prefix_lists": [
 #                 {
+#                     "description": "this is ipv6 prefix-list"
 #                     "entries": [
-#                         {
-#                             "description": "this is ipv6 prefix-list"
-#                         },
 #                         {
 #                             "action": "deny",
 #                             "ge": 80,

--- a/plugins/modules/ios_prefix_lists.py
+++ b/plugins/modules/ios_prefix_lists.py
@@ -272,8 +272,8 @@ EXAMPLES = """
 # -------------
 #
 # Play Execution fails, with error:
-# Merge state cannot merge on the pre-existing Prefix-List sequence,
-# it can only add Prefix-List entry over a new sequence!
+# Cannot update existing sequence 10 of Prefix Lists test_ipv6 with state merged.
+# Please use state replaced or overridden.
 
 # Before state:
 # -------------

--- a/plugins/modules/ios_prefix_lists.py
+++ b/plugins/modules/ios_prefix_lists.py
@@ -57,6 +57,15 @@ options:
               sequence:
                 description: sequence number of an entry
                 type: int
+              description:
+                description:
+                  - Prefix-list specific description
+                  - Description param at entries level is DEPRECATED
+                  - New Description is introduced at prefix_lists level, please
+                    use the Description param defined at prefix_lists level instead of
+                    Description param at entries level, as at this level description option
+                    will get removed in a future release.
+                type: str
               prefix:
                 description:
                   - IPv4 prefix <network>/<length>, e.g., A.B.C.D/nn

--- a/tests/integration/targets/ios_acls/tests/cli/merged.yaml
+++ b/tests/integration/targets/ios_acls/tests/cli/merged.yaml
@@ -133,7 +133,7 @@
 
     - assert:
         that:
-          - result.commands|length == 11
+          - result.commands|length == 9
           - result.changed == true
           - result.commands|symmetric_difference(merged.commands) == []
 

--- a/tests/integration/targets/ios_acls/tests/cli/merged.yaml
+++ b/tests/integration/targets/ios_acls/tests/cli/merged.yaml
@@ -133,7 +133,7 @@
 
     - assert:
         that:
-          - result.commands|length == 12
+          - result.commands|length == 11
           - result.changed == true
           - result.commands|symmetric_difference(merged.commands) == []
 

--- a/tests/integration/targets/ios_acls/tests/cli/merged.yaml
+++ b/tests/integration/targets/ios_acls/tests/cli/merged.yaml
@@ -19,10 +19,10 @@
                       tcp:
                         fin: true
                     source:
-                      address: 192.0.2.0
+                      address: 192.0.4.0
                       wildcard_bits: 0.0.0.255
                     destination:
-                      address: 192.0.3.0
+                      address: 192.0.5.0
                       wildcard_bits: 0.0.0.255
                       port_protocol:
                         eq: www
@@ -48,13 +48,22 @@
               - name: test_acl
                 acl_type: extended
                 aces:
-                  - sequence: 10
+                  - grant: deny
+                    protocol_options:
+                      tcp:
+                        fin: true
                     source:
                       address: 192.0.4.0
                       wildcard_bits: 0.0.0.255
                     destination:
                       address: 192.0.5.0
                       wildcard_bits: 0.0.0.255
+                      port_protocol:
+                        eq: www
+                    option:
+                      traceroute: true
+                    ttl:
+                      eq: 10
               - name: 110
                 aces:
                   - grant: deny

--- a/tests/integration/targets/ios_acls/vars/main.yaml
+++ b/tests/integration/targets/ios_acls/vars/main.yaml
@@ -19,9 +19,6 @@ merged:
   commands:
     - ip access-list standard std_acl
     - deny 192.0.2.0 0.0.0.255
-    - ip access-list extended test_acl
-    - 10 deny tcp 192.0.4.0 0.0.0.255 192.0.5.0 0.0.0.255 eq www fin option traceroute
-      ttl eq 10
     - ip access-list extended 110
     - 10 deny icmp 192.0.2.0 0.0.0.255 192.0.3.0 0.0.0.255 echo dscp ef ttl eq 10
     - ip access-list extended 123

--- a/tests/integration/targets/ios_acls/vars/main.yaml
+++ b/tests/integration/targets/ios_acls/vars/main.yaml
@@ -20,7 +20,6 @@ merged:
     - ip access-list standard std_acl
     - deny 192.0.2.0 0.0.0.255
     - ip access-list extended test_acl
-    - no 10 deny tcp 192.0.2.0 0.0.0.255 192.0.3.0 0.0.0.255 eq www fin option traceroute ttl eq 10
     - 10 deny tcp 192.0.4.0 0.0.0.255 192.0.5.0 0.0.0.255 eq www fin option traceroute
       ttl eq 10
     - ip access-list extended 110

--- a/tests/integration/targets/ios_prefix_lists/tests/cli/_populate_config.yaml
+++ b/tests/integration/targets/ios_prefix_lists/tests/cli/_populate_config.yaml
@@ -5,8 +5,8 @@
       - afi: ipv4
         prefix_lists:
           - name: 10
+            description: this is test description
             entries:
-              - description: this is test description
               - action: deny
                 prefix: 1.0.0.0/8
                 le: 15
@@ -25,15 +25,15 @@
                 le: 21
                 sequence: 20
           - name: test
+            description: this is test
             entries:
-              - description: this is test
               - action: deny
                 prefix: 12.0.0.0/8
                 ge: 15
                 sequence: 50
           - name: test_prefix
+            description: this is for prefix-list
             entries:
-              - description: this is for prefix-list
               - action: deny
                 prefix: 35.0.0.0/8
                 ge: 10
@@ -46,8 +46,8 @@
       - afi: ipv6
         prefix_lists:
           - name: test_ipv6
+            description: this is ipv6 prefix-list
             entries:
-              - description: this is ipv6 prefix-list
               - action: deny
                 prefix: 2001:DB8:0:4::/64
                 ge: 80

--- a/tests/integration/targets/ios_prefix_lists/tests/cli/deleted.yaml
+++ b/tests/integration/targets/ios_prefix_lists/tests/cli/deleted.yaml
@@ -7,7 +7,7 @@
     - include_tasks: _remove_config.yaml
     - include_tasks: _populate_config.yaml
 
-    - name: Delete prefix list based on prefix ame configured
+    - name: Delete prefix list based on prefix name configured
       register: result
       cisco.ios.ios_prefix_lists: &id001
         config:

--- a/tests/integration/targets/ios_prefix_lists/tests/cli/merged.yaml
+++ b/tests/integration/targets/ios_prefix_lists/tests/cli/merged.yaml
@@ -13,8 +13,8 @@
           - afi: ipv4
             prefix_lists:
               - name: 10
+                description: this is test description
                 entries:
-                  - description: this is test description
                   - action: deny
                     prefix: 1.0.0.0/8
                     le: 15
@@ -33,15 +33,15 @@
                     le: 21
                     sequence: 20
               - name: test
+                description: this is test
                 entries:
-                  - description: this is test
                   - action: deny
                     prefix: 12.0.0.0/8
                     ge: 15
                     sequence: 50
               - name: test_prefix
+                description: this is for prefix-list
                 entries:
-                  - description: this is for prefix-list
                   - action: deny
                     prefix: 35.0.0.0/8
                     ge: 10
@@ -54,8 +54,8 @@
           - afi: ipv6
             prefix_lists:
               - name: test_ipv6
+                description: this is ipv6 prefix-list
                 entries:
-                  - description: this is ipv6 prefix-list
                   - action: deny
                     prefix: 2001:DB8:0:4::/64
                     ge: 80

--- a/tests/integration/targets/ios_prefix_lists/tests/cli/overridden.yaml
+++ b/tests/integration/targets/ios_prefix_lists/tests/cli/overridden.yaml
@@ -15,8 +15,8 @@
           - afi: ipv4
             prefix_lists:
               - name: 10
+                description: this is override test
                 entries:
-                  - description: this is override test
                   - action: deny
                     prefix: 12.0.0.0/8
                     ge: 15
@@ -27,8 +27,8 @@
                     le: 21
                     sequence: 20
               - name: test_override
+                description: this is override test
                 entries:
-                  - description: this is override test
                   - action: deny
                     prefix: 35.0.0.0/8
                     ge: 20
@@ -36,8 +36,8 @@
           - afi: ipv6
             prefix_lists:
               - name: test_ipv6
+                description: this is ipv6 override test
                 entries:
-                  - description: this is ipv6 override test
                   - action: deny
                     prefix: 2001:DB8:0:4::/64
                     ge: 80

--- a/tests/integration/targets/ios_prefix_lists/tests/cli/rendered.yaml
+++ b/tests/integration/targets/ios_prefix_lists/tests/cli/rendered.yaml
@@ -11,8 +11,8 @@
           - afi: ipv4
             prefix_lists:
               - name: 10
+                description: this is test description
                 entries:
-                  - description: this is test description
                   - action: deny
                     prefix: 1.0.0.0/8
                     le: 15
@@ -31,15 +31,15 @@
                     le: 21
                     sequence: 20
               - name: test
+                description: this is test
                 entries:
-                  - description: this is test
                   - action: deny
                     prefix: 12.0.0.0/8
                     ge: 15
                     sequence: 50
               - name: test_prefix
+                description: this is for prefix-list
                 entries:
-                  - description: this is for prefix-list
                   - action: deny
                     prefix: 35.0.0.0/8
                     ge: 10
@@ -52,8 +52,8 @@
           - afi: ipv6
             prefix_lists:
               - name: test_ipv6
+                description: this is ipv6 prefix-list
                 entries:
-                  - description: this is ipv6 prefix-list
                   - action: deny
                     prefix: 2001:DB8:0:4::/64
                     ge: 80

--- a/tests/integration/targets/ios_prefix_lists/tests/cli/replaced.yaml
+++ b/tests/integration/targets/ios_prefix_lists/tests/cli/replaced.yaml
@@ -14,8 +14,8 @@
           - afi: ipv4
             prefix_lists:
               - name: 10
+                description: this is replace test
                 entries:
-                  - description: this is replace test
                   - action: deny
                     prefix: 12.0.0.0/8
                     ge: 15
@@ -26,8 +26,8 @@
                     le: 21
                     sequence: 20
               - name: test_replace
+                description: this is replace test
                 entries:
-                  - description: this is replace test
                   - action: deny
                     prefix: 35.0.0.0/8
                     ge: 20
@@ -35,8 +35,8 @@
           - afi: ipv6
             prefix_lists:
               - name: test_ipv6
+                description: this is ipv6 replace test
                 entries:
-                  - description: this is ipv6 replace test
                   - action: deny
                     prefix: 2001:DB8:0:4::/64
                     ge: 80

--- a/tests/integration/targets/ios_prefix_lists/vars/main.yaml
+++ b/tests/integration/targets/ios_prefix_lists/vars/main.yaml
@@ -19,8 +19,8 @@ merged:
   after:
     - afi: ipv4
       prefix_lists:
-        - entries:
-            - description: this is test description
+        - description: this is test description
+          entries:
             - action: deny
               le: 15
               prefix: 1.0.0.0/8
@@ -39,15 +39,15 @@ merged:
               prefix: 14.0.0.0/8
               sequence: 20
           name: "10"
-        - entries:
-            - description: this is test
+        - description: this is test
+          entries:
             - action: deny
               ge: 15
               prefix: 12.0.0.0/8
               sequence: 50
           name: test
-        - entries:
-            - description: this is for prefix-list
+        - description: this is for prefix-list
+          entries:
             - action: deny
               ge: 10
               le: 15
@@ -60,8 +60,8 @@ merged:
           name: test_prefix
     - afi: ipv6
       prefix_lists:
-        - entries:
-            - description: this is ipv6 prefix-list
+        - description: this is ipv6 prefix-list
+          entries:
             - action: deny
               ge: 80
               prefix: 2001:DB8:0:4::/64
@@ -84,8 +84,8 @@ overridden:
   after:
     - afi: ipv4
       prefix_lists:
-        - entries:
-            - description: this is override test
+        - description: this is override test
+          entries:
             - action: deny
               ge: 15
               prefix: 12.0.0.0/8
@@ -96,8 +96,8 @@ overridden:
               prefix: 14.0.0.0/8
               sequence: 20
           name: "10"
-        - entries:
-            - description: this is override test
+        - description: this is override test
+          entries:
             - action: deny
               ge: 20
               prefix: 35.0.0.0/8
@@ -105,8 +105,8 @@ overridden:
           name: test_override
     - afi: ipv6
       prefix_lists:
-        - entries:
-            - description: this is ipv6 override test
+        - description: this is ipv6 override test
+          entries:
             - action: deny
               ge: 80
               le: 100
@@ -128,8 +128,8 @@ replaced:
   after:
     - afi: ipv4
       prefix_lists:
-        - entries:
-            - description: this is replace test
+        - description: this is replace test
+          entries:
             - action: deny
               ge: 15
               prefix: 12.0.0.0/8
@@ -140,15 +140,15 @@ replaced:
               prefix: 14.0.0.0/8
               sequence: 20
           name: "10"
-        - entries:
-            - description: this is test
+        - description: this is test
+          entries:
             - action: deny
               ge: 15
               prefix: 12.0.0.0/8
               sequence: 50
           name: test
-        - entries:
-            - description: this is for prefix-list
+        - description: this is for prefix-list
+          entries:
             - action: deny
               ge: 10
               le: 15
@@ -159,8 +159,8 @@ replaced:
               prefix: 35.0.0.0/8
               sequence: 10
           name: test_prefix
-        - entries:
-            - description: this is replace test
+        - description: this is replace test
+          entries:
             - action: deny
               ge: 20
               prefix: 35.0.0.0/8
@@ -168,8 +168,8 @@ replaced:
           name: test_replace
     - afi: ipv6
       prefix_lists:
-        - entries:
-            - description: this is ipv6 replace test
+        - description: this is ipv6 replace test
+          entries:
             - action: deny
               ge: 80
               le: 100

--- a/tests/unit/modules/network/ios/test_ios_prefix_lists.py
+++ b/tests/unit/modules/network/ios/test_ios_prefix_lists.py
@@ -81,23 +81,21 @@ class TestIosPrefixListsModule(TestIosModule):
                         afi="ipv4",
                         prefix_lists=[
                             dict(
+                                description="this is merge test",
                                 entries=[
-                                    dict(description="this is merge test"),
                                     dict(
                                         action="deny",
                                         ge=10,
                                         le=15,
                                         prefix="25.0.0.0/8",
                                         sequence=25,
-                                    ),
+                                    )
                                 ],
                                 name="10",
                             ),
                             dict(
+                                description="this is for prefix-list",
                                 entries=[
-                                    dict(
-                                        description="this is for prefix-list"
-                                    ),
                                     dict(
                                         action="deny",
                                         ge=10,
@@ -120,17 +118,15 @@ class TestIosPrefixListsModule(TestIosModule):
                         afi="ipv6",
                         prefix_lists=[
                             dict(
+                                description="this is merged ipv6 prefix-list",
                                 entries=[
-                                    dict(
-                                        description="this is merged ipv6 prefix-list"
-                                    ),
                                     dict(
                                         action="deny",
                                         ge=80,
                                         le=100,
                                         prefix="2001:DB8:0:4::/64",
-                                        sequence=10,
-                                    ),
+                                        sequence=20,
+                                    )
                                 ],
                                 name="test_ipv6",
                             )
@@ -144,8 +140,7 @@ class TestIosPrefixListsModule(TestIosModule):
             "ip prefix-list 10 description this is merge test",
             "ip prefix-list 10 seq 25 deny 25.0.0.0/8 ge 10 le 15",
             "ipv6 prefix-list test_ipv6 description this is merged ipv6 prefix-list",
-            "no ipv6 prefix-list test_ipv6 seq 10 deny 2001:DB8:0:4::/64 ge 80",
-            "ipv6 prefix-list test_ipv6 seq 10 deny 2001:DB8:0:4::/64 ge 80 le 100",
+            "ipv6 prefix-list test_ipv6 seq 20 deny 2001:DB8:0:4::/64 ge 80 le 100",
         ]
         result = self.execute_module(changed=True)
         self.assertEqual(sorted(result["commands"]), sorted(commands))
@@ -158,10 +153,8 @@ class TestIosPrefixListsModule(TestIosModule):
                         afi="ipv4",
                         prefix_lists=[
                             dict(
+                                description="this is test description",
                                 entries=[
-                                    dict(
-                                        description="this is test description"
-                                    ),
                                     dict(
                                         action="deny",
                                         le=15,
@@ -191,22 +184,20 @@ class TestIosPrefixListsModule(TestIosModule):
                                 name="10",
                             ),
                             dict(
+                                description="this is test",
                                 entries=[
-                                    dict(description="this is test"),
                                     dict(
                                         action="deny",
                                         ge=15,
                                         prefix="12.0.0.0/8",
                                         sequence=50,
-                                    ),
+                                    )
                                 ],
                                 name="test",
                             ),
                             dict(
+                                description="this is for prefix-list",
                                 entries=[
-                                    dict(
-                                        description="this is for prefix-list"
-                                    ),
                                     dict(
                                         action="deny",
                                         ge=10,
@@ -229,16 +220,14 @@ class TestIosPrefixListsModule(TestIosModule):
                         afi="ipv6",
                         prefix_lists=[
                             dict(
+                                description="this is ipv6 prefix-list",
                                 entries=[
-                                    dict(
-                                        description="this is ipv6 prefix-list"
-                                    ),
                                     dict(
                                         action="deny",
                                         ge=80,
                                         prefix="2001:DB8:0:4::/64",
                                         sequence=10,
-                                    ),
+                                    )
                                 ],
                                 name="test_ipv6",
                             )
@@ -258,8 +247,8 @@ class TestIosPrefixListsModule(TestIosModule):
                         afi="ipv4",
                         prefix_lists=[
                             dict(
+                                description="this is replace test",
                                 entries=[
-                                    dict(description="this is replace test"),
                                     dict(
                                         action="deny",
                                         ge=15,
@@ -277,14 +266,14 @@ class TestIosPrefixListsModule(TestIosModule):
                                 name="10",
                             ),
                             dict(
+                                description="this is replace test",
                                 entries=[
-                                    dict(description="this is replace test"),
                                     dict(
                                         action="deny",
                                         ge=20,
                                         prefix="35.0.0.0/8",
                                         sequence=10,
-                                    ),
+                                    )
                                 ],
                                 name="test_replace",
                             ),
@@ -294,17 +283,15 @@ class TestIosPrefixListsModule(TestIosModule):
                         afi="ipv6",
                         prefix_lists=[
                             dict(
+                                description="this is ipv6 replace test",
                                 entries=[
-                                    dict(
-                                        description="this is ipv6 replace test"
-                                    ),
                                     dict(
                                         action="deny",
                                         ge=80,
                                         le=100,
                                         prefix="2001:DB8:0:4::/64",
                                         sequence=10,
-                                    ),
+                                    )
                                 ],
                                 name="test_ipv6",
                             )
@@ -335,10 +322,8 @@ class TestIosPrefixListsModule(TestIosModule):
                         afi="ipv4",
                         prefix_lists=[
                             dict(
+                                description="this is test description",
                                 entries=[
-                                    dict(
-                                        description="this is test description"
-                                    ),
                                     dict(
                                         action="deny",
                                         le=15,
@@ -368,22 +353,20 @@ class TestIosPrefixListsModule(TestIosModule):
                                 name="10",
                             ),
                             dict(
+                                description="this is test",
                                 entries=[
-                                    dict(description="this is test"),
                                     dict(
                                         action="deny",
                                         ge=15,
                                         prefix="12.0.0.0/8",
                                         sequence=50,
-                                    ),
+                                    )
                                 ],
                                 name="test",
                             ),
                             dict(
+                                description="this is for prefix-list",
                                 entries=[
-                                    dict(
-                                        description="this is for prefix-list"
-                                    ),
                                     dict(
                                         action="deny",
                                         ge=10,
@@ -406,23 +389,21 @@ class TestIosPrefixListsModule(TestIosModule):
                         afi="ipv6",
                         prefix_lists=[
                             dict(
+                                description="this is ipv6 prefix-list",
                                 entries=[
-                                    dict(
-                                        description="this is ipv6 prefix-list"
-                                    ),
                                     dict(
                                         action="deny",
                                         ge=80,
                                         prefix="2001:DB8:0:4::/64",
                                         sequence=10,
-                                    ),
+                                    )
                                 ],
                                 name="test_ipv6",
                             )
                         ],
                     ),
                 ],
-                state="merged",
+                state="replaced",
             )
         )
         self.execute_module(changed=False, commands=[])
@@ -435,8 +416,8 @@ class TestIosPrefixListsModule(TestIosModule):
                         afi="ipv4",
                         prefix_lists=[
                             dict(
+                                description="this is override test",
                                 entries=[
-                                    dict(description="this is override test"),
                                     dict(
                                         action="deny",
                                         ge=15,
@@ -454,14 +435,14 @@ class TestIosPrefixListsModule(TestIosModule):
                                 name="10",
                             ),
                             dict(
+                                description="this is override test",
                                 entries=[
-                                    dict(description="this is override test"),
                                     dict(
                                         action="deny",
                                         ge=20,
                                         prefix="35.0.0.0/8",
                                         sequence=10,
-                                    ),
+                                    )
                                 ],
                                 name="test_override",
                             ),
@@ -471,17 +452,15 @@ class TestIosPrefixListsModule(TestIosModule):
                         afi="ipv6",
                         prefix_lists=[
                             dict(
+                                description="this is ipv6 override test",
                                 entries=[
-                                    dict(
-                                        description="this is ipv6 override test"
-                                    ),
                                     dict(
                                         action="deny",
                                         ge=80,
                                         le=100,
                                         prefix="2001:DB8:0:4::/64",
                                         sequence=10,
-                                    ),
+                                    )
                                 ],
                                 name="test_ipv6",
                             )
@@ -514,10 +493,8 @@ class TestIosPrefixListsModule(TestIosModule):
                         afi="ipv4",
                         prefix_lists=[
                             dict(
+                                description="this is test description",
                                 entries=[
-                                    dict(
-                                        description="this is test description"
-                                    ),
                                     dict(
                                         action="deny",
                                         le=15,
@@ -547,22 +524,20 @@ class TestIosPrefixListsModule(TestIosModule):
                                 name="10",
                             ),
                             dict(
+                                description="this is test",
                                 entries=[
-                                    dict(description="this is test"),
                                     dict(
                                         action="deny",
                                         ge=15,
                                         prefix="12.0.0.0/8",
                                         sequence=50,
-                                    ),
+                                    )
                                 ],
                                 name="test",
                             ),
                             dict(
+                                description="this is for prefix-list",
                                 entries=[
-                                    dict(
-                                        description="this is for prefix-list"
-                                    ),
                                     dict(
                                         action="deny",
                                         ge=10,
@@ -585,23 +560,21 @@ class TestIosPrefixListsModule(TestIosModule):
                         afi="ipv6",
                         prefix_lists=[
                             dict(
+                                description="this is ipv6 prefix-list",
                                 entries=[
-                                    dict(
-                                        description="this is ipv6 prefix-list"
-                                    ),
                                     dict(
                                         action="deny",
                                         ge=80,
                                         prefix="2001:DB8:0:4::/64",
                                         sequence=10,
-                                    ),
+                                    )
                                 ],
                                 name="test_ipv6",
                             )
                         ],
                     ),
                 ],
-                state="merged",
+                state="overridden",
             )
         )
         self.execute_module(changed=False, commands=[])
@@ -625,23 +598,21 @@ class TestIosPrefixListsModule(TestIosModule):
                         afi="ipv4",
                         prefix_lists=[
                             dict(
+                                description="this is merge test",
                                 entries=[
-                                    dict(description="this is merge test"),
                                     dict(
                                         action="deny",
                                         ge=10,
                                         le=15,
                                         prefix="25.0.0.0/8",
                                         sequence=25,
-                                    ),
+                                    )
                                 ],
                                 name="10",
                             ),
                             dict(
+                                description="this is for prefix-list",
                                 entries=[
-                                    dict(
-                                        description="this is for prefix-list"
-                                    ),
                                     dict(
                                         action="deny",
                                         ge=10,
@@ -664,17 +635,15 @@ class TestIosPrefixListsModule(TestIosModule):
                         afi="ipv6",
                         prefix_lists=[
                             dict(
+                                description="this is ipv6 prefix-list",
                                 entries=[
-                                    dict(
-                                        description="this is ipv6 prefix-list"
-                                    ),
                                     dict(
                                         action="deny",
                                         ge=80,
                                         le=100,
                                         prefix="2001:DB8:0:4::/64",
                                         sequence=10,
-                                    ),
+                                    )
                                 ],
                                 name="test_ipv6",
                             )


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
To fix IOS ACLs and Prefix Lists RM to not negate config when using merge state, also fixes the Prefix-list model to accept `description` at the same level as `name`. Fixes #345 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios_acls, ios_prefix_lists

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
