### PR TITLE
Initial support for tox -eansible-lint

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,7 @@
+---
+# TODO(pabelanger): Remove the following warnings once our playbooks have been
+# updated.
+warn_list:
+  - meta-no-info
+  - unnamed-task
+

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,20 @@
 [tox]
 minversion = 1.4.2
-envlist = linters
+envlist = ansible-lint,linters
 skipsdist = True
 
 [testenv]
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
+
+[testenv:ansible-lint]
+# NOTE(pabelanger): Because ansible-lint depends on ansible-core we create
+# its own entrypoint.
+deps =
+  ansible-core
+  ansible-lint
+commands =
+  ansible-lint --nocolor
 
 [testenv:black]
 install_command = pip install {opts} {packages}


### PR DESCRIPTION
Create a new entrypoint so we can enforce ansible-lint style guide.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>