### PR TITLE
Fixes ios_user tests when options are directly set

### DIFF
--- a/changelogs/fragments/ios_user_test_fix.yaml
+++ b/changelogs/fragments/ios_user_test_fix.yaml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - fix ios_user intergration tests with network-ee.

--- a/tests/integration/targets/ios_user/tests/cli/auth.yaml
+++ b/tests/integration/targets/ios_user/tests/cli/auth.yaml
@@ -9,7 +9,7 @@
         state: present
         configured_password: pass123
 
-    - name: reset connection with {{ ansible_user }
+    - name: reset connection with {{ ansible_user }}
       meta: reset_connection
 
     - name: test login for {{ ansible_user }} user with password
@@ -19,8 +19,9 @@
       vars:
         ansible_user: auth_user
         ansible_password: pass123
+        ansible_private_key_file: ""
 
-    - name: reset connection with {{ ansible_user }
+    - name: reset connection with {{ ansible_user }}
       meta: reset_connection
 
     - name: test login with invalid password (should fail)
@@ -32,9 +33,7 @@
       vars:
         ansible_user: auth_user
         ansible_password: badpass
-
-    - name: reset connection with {{ ansible_user }
-      meta: reset_connection
+        ansible_private_key_file: ""
 
     - name: check that attempt failed
       assert:
@@ -42,14 +41,14 @@
           - results.failed
   always:
 
+    - name: reset connection with {{ ansible_user }}
+      meta: reset_connection
+
     - name: delete user
       register: result
       cisco.ios.ios_user:
         name: auth_user
         state: absent
-
-    - name: reset connection
-      meta: reset_connection
 
 - block:
 
@@ -66,7 +65,7 @@
         state: present
         sshkey: "{{ lookup('file', 'files/test_rsa.pub') }}"
 
-    - name: reset connection with {{ ansible_user }
+    - name: reset connection with {{ ansible_user }}
       meta: reset_connection
 
     - name: test sshkey login for {{ ansible_user }} user
@@ -90,20 +89,17 @@
         ansible_user: ssh_user
         ansible_private_key_file: ""
 
-    - name: reset connection with {{ ansible_user }}
-      meta: reset_connection
-
     - name: check that attempt failed
       assert:
         that:
           - results.failed
   always:
 
+    - name: reset connection with {{ ansible_user }}
+      meta: reset_connection
+
     - name: delete user
       register: result
       cisco.ios.ios_user:
         name: ssh_user
         state: absent
-
-    - name: reset connection
-      meta: reset_connection


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Depends-on: https://github.com/ansible-collections/ansible.netcommon/pull/271

ios devices have trouble recovering when paramiko fails to authenticate with a private key.
As we are connecting with password only on these tests, clear the private_key_file var for these tests

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios_user