### PR TITLE
fix doc ios_acl_interfaces

### DIFF
--- a/changelogs/fragments/ios_acl_interfaces_doc_fix.yaml
+++ b/changelogs/fragments/ios_acl_interfaces_doc_fix.yaml
@@ -1,0 +1,3 @@
+---
+doc_changes:
+  - Doc fix for ios_acl_interfaces.

--- a/docs/cisco.ios.ios_acl_interfaces_module.rst
+++ b/docs/cisco.ios.ios_acl_interfaces_module.rst
@@ -276,7 +276,6 @@ Examples
     #  ipv6 traffic-filter temp_v6 in
     # interface GigabitEthernet0/2
     #  ip access-group 100 in
-    #  ip access-group 123 out
 
 
     # After state:

--- a/plugins/modules/ios_acl_interfaces.py
+++ b/plugins/modules/ios_acl_interfaces.py
@@ -160,7 +160,6 @@ EXAMPLES = """
 #  ipv6 traffic-filter temp_v6 in
 # interface GigabitEthernet0/2
 #  ip access-group 100 in
-#  ip access-group 123 out
 
 
 # After state:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
fix doc ios_acl_interfaces example.

In `state: merged`, `ip access-group 123 out` should not be executed for `GigabitEthernet0/2`.
Because it is already set at Before State.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

- `ios_acl_interfaces`
