### PR TITLE
fix become for privilege level < 15

### DIFF
--- a/changelogs/fragments/199_become_not_working.yaml
+++ b/changelogs/fragments/199_become_not_working.yaml
@@ -1,3 +1,3 @@
 ---
-bugfix:
+bugfixes:
   - fixed become functionality on privilege level not 15.

--- a/changelogs/fragments/199_become_not_working.yaml
+++ b/changelogs/fragments/199_become_not_working.yaml
@@ -1,0 +1,3 @@
+---
+bugfix:
+  - fixed become functionality on privilege level not 15.

--- a/plugins/terminal/ios.py
+++ b/plugins/terminal/ios.py
@@ -65,18 +65,18 @@ class TerminalModule(TerminalBase):
             result = self._exec_cli_command(
                 to_bytes(json.dumps(cmd), errors="surrogate_or_strict")
             )
-
-            prompt = self.privilege_level_re.match(result)
-            if not prompt:
-                raise AnsibleConnectionFailure(
-                    "unable to check privilege level [%s]" % result
-                )
-
-            return int(prompt.group(1))
         except AnsibleConnectionFailure as e:
             raise AnsibleConnectionFailure(
                 "unable to fetch privilege, with error: %s" % (e.message)
             )
+
+        prompt = self.privilege_level_re.match(result)
+        if not prompt:
+            raise AnsibleConnectionFailure(
+                "unable to check privilege level [%s]" % result
+            )
+
+        return int(prompt.group(1))
 
     def on_open_shell(self):
         try:

--- a/plugins/terminal/ios.py
+++ b/plugins/terminal/ios.py
@@ -37,6 +37,8 @@ class TerminalModule(TerminalBase):
         re.compile(br"[\r\n]?[\w\+\-\.:\/\[\]]+(?:\([^\)]+\)){0,3}(?:[>#]) ?$")
     ]
 
+    privilege_level_re = re.compile(r"Current privilege level is (\d+)$")
+
     terminal_stderr_re = [
         re.compile(br"% ?Error"),
         # re.compile(br"^% \w+", re.M),
@@ -57,6 +59,25 @@ class TerminalModule(TerminalBase):
 
     terminal_config_prompt = re.compile(r"^.+\(config(-.*)?\)#$")
 
+    def get_privilege_level(self):
+        try:
+            cmd = {u"command": u"show privilege"}
+            result = self._exec_cli_command(
+                to_bytes(json.dumps(cmd), errors="surrogate_or_strict")
+            )
+
+            prompt = self.privilege_level_re.match(result)
+            if not prompt:
+                raise AnsibleConnectionFailure(
+                    "unable to check privilege level [%s]" % result
+                )
+
+            return int(prompt.group(1))
+        except AnsibleConnectionFailure as e:
+            raise AnsibleConnectionFailure(
+                "unable to fetch privilege, with error: %s" % (e.message)
+            )
+
     def on_open_shell(self):
         try:
             self._exec_cli_command(b"terminal length 0")
@@ -75,7 +96,10 @@ class TerminalModule(TerminalBase):
             )
 
     def on_become(self, passwd=None):
-        if self._get_prompt().endswith(b"#"):
+        if (
+            self._get_prompt().endswith(b"#")
+            and self.get_privilege_level() == 15
+        ):
             return
 
         cmd = {u"command": u"enable"}
@@ -92,7 +116,11 @@ class TerminalModule(TerminalBase):
                 to_bytes(json.dumps(cmd), errors="surrogate_or_strict")
             )
             prompt = self._get_prompt()
-            if prompt is None or not prompt.endswith(b"#"):
+            if (
+                prompt is None
+                or not prompt.endswith(b"#")
+                or self.get_privilege_level() != 15
+            ):
                 raise AnsibleConnectionFailure(
                     "failed to elevate privilege to enable mode still at prompt [%s]"
                     % prompt
@@ -108,6 +136,9 @@ class TerminalModule(TerminalBase):
         prompt = self._get_prompt()
         if prompt is None:
             # if prompt is None most likely the terminal is hung up at a prompt
+            return
+
+        if self.get_privilege_level() != 15:
             return
 
         if b"(config" in prompt:

--- a/plugins/terminal/ios.py
+++ b/plugins/terminal/ios.py
@@ -122,8 +122,7 @@ class TerminalModule(TerminalBase):
                 or self.get_privilege_level() != 15
             ):
                 raise AnsibleConnectionFailure(
-                    "failed to elevate privilege to enable mode still at prompt [%s]"
-                    % prompt
+                    "failed to elevate privilege to enable mode still at prompt"
                 )
         except AnsibleConnectionFailure as e:
             prompt = self._get_prompt()

--- a/plugins/terminal/ios.py
+++ b/plugins/terminal/ios.py
@@ -96,7 +96,10 @@ class TerminalModule(TerminalBase):
             )
 
     def on_become(self, passwd=None):
-        if self._get_prompt().endswith(b"#") and self.get_privilege_level() == 15:
+        if (
+            self._get_prompt().endswith(b"#")
+            and self.get_privilege_level() == 15
+        ):
             return
 
         cmd = {u"command": u"enable"}
@@ -121,7 +124,11 @@ class TerminalModule(TerminalBase):
                 % (prompt, e.message)
             )
 
-        if prompt is None or not prompt.endswith(b"#") or privilege_level != 15:
+        if (
+            prompt is None
+            or not prompt.endswith(b"#")
+            or privilege_level != 15
+        ):
             raise AnsibleConnectionFailure(
                 "failed to elevate privilege to enable mode, still at level [%d] and prompt [%s]"
                 % (privilege_level, prompt)

--- a/plugins/terminal/ios.py
+++ b/plugins/terminal/ios.py
@@ -96,10 +96,7 @@ class TerminalModule(TerminalBase):
             )
 
     def on_become(self, passwd=None):
-        if (
-            self._get_prompt().endswith(b"#")
-            and self.get_privilege_level() == 15
-        ):
+        if self._get_prompt().endswith(b"#") and self.get_privilege_level() == 15:
             return
 
         cmd = {u"command": u"enable"}
@@ -116,19 +113,18 @@ class TerminalModule(TerminalBase):
                 to_bytes(json.dumps(cmd), errors="surrogate_or_strict")
             )
             prompt = self._get_prompt()
-            if (
-                prompt is None
-                or not prompt.endswith(b"#")
-                or self.get_privilege_level() != 15
-            ):
-                raise AnsibleConnectionFailure(
-                    "failed to elevate privilege to enable mode still at prompt"
-                )
+            privilege_level = self.get_privilege_level()
         except AnsibleConnectionFailure as e:
             prompt = self._get_prompt()
             raise AnsibleConnectionFailure(
-                "unable to elevate privilege to enable mode, at prompt [%s] with error: %s"
+                "failed to elevate privilege to enable mode, at prompt [%s] with error: %s"
                 % (prompt, e.message)
+            )
+
+        if prompt is None or not prompt.endswith(b"#") or privilege_level != 15:
+            raise AnsibleConnectionFailure(
+                "failed to elevate privilege to enable mode, still at level [%d] and prompt [%s]"
+                % (privilege_level, prompt)
             )
 
     def on_unbecome(self):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
fix become,  when user privilege < 15 on use of become - privilege should be 15
extra checks added as the prompt checks for `#` that is common for all privilege level.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
terminal/ios.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
user privilege
```paste below
an-iosl2-02#show privilege 
Current privilege level is 5
```
before -
```
  tasks:
    - ios_command:
        commands: show privilege
      register: privilege
      become: yes
```
result - 
```
    "stdout_lines": [
        [
            "Current privilege level is 5"
        ]
```
now-
```
    "stdout_lines": [
        [
            "Current privilege level is 15"
        ]
```