### PR TITLE
Updating collection_prep pre-commit hook to 0.9.4

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,6 @@ repos:
       - id: black
         args: [-l, "79"]
   - repo: https://github.com/ansible-network/collection_prep
-    rev: 0.9.3
+    rev: 0.9.4
     hooks:
       - id: update-docs


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos