### PR TITLE
Facts issue fix - Vlan to break for l3 devices

### DIFF
--- a/changelogs/fragments/facts_vlan_issue.yaml
+++ b/changelogs/fragments/facts_vlan_issue.yaml
@@ -1,3 +1,5 @@
 ---
 bugfixes:
-  - facts won't break for devices which have no support for vlan.
+  - ios_facts - fix for devices which have no support for VLANs, such as L3 devices.
+  - ios_vlans - for playbook execution module fails with an error when target device
+    does not support VLANs, The offline states rendered and parsed will work as expected.

--- a/changelogs/fragments/facts_vlan_issue.yaml
+++ b/changelogs/fragments/facts_vlan_issue.yaml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - facts fixed for handling l2 devices.
+  - facts won't break for devices which have no support for vlan.

--- a/changelogs/fragments/facts_vlan_issue.yaml
+++ b/changelogs/fragments/facts_vlan_issue.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - facts fixed for handling l2 devices.

--- a/docs/cisco.ios.ios_facts_module.rst
+++ b/docs/cisco.ios.ios_facts_module.rst
@@ -644,4 +644,3 @@ Authors
 
 - Peter Sprygada (@privateip)
 - Sumit Jaiswal (@justjais)
-- Sagar Paul (@KB-perByte)

--- a/docs/cisco.ios.ios_facts_module.rst
+++ b/docs/cisco.ios.ios_facts_module.rst
@@ -249,6 +249,7 @@ Notes
 
 .. note::
    - Tested against IOS 15.6
+   - Facts gathering for L3 devices are supposed to produce blank output for unsupported resources like vlan.
    - For more information on using Ansible to manage network devices see the :ref:`Ansible Network Guide <network_guide>`
    - For more information on using Ansible to manage Cisco devices see the `Cisco integration page <https://www.ansible.com/integrations/networks/cisco>`_.
 
@@ -643,3 +644,4 @@ Authors
 
 - Peter Sprygada (@privateip)
 - Sumit Jaiswal (@justjais)
+- Sagar Paul (@KB-perByte)

--- a/docs/cisco.ios.ios_vlans_module.rst
+++ b/docs/cisco.ios.ios_vlans_module.rst
@@ -215,7 +215,7 @@ Notes
 
 .. note::
    - Tested against Cisco IOSl2 device with Version 15.2 on VIRL.
-   - This RM works only with Cisco IOS L2 switch.
+   - Starting from v2.5.0, this module will fail when run against Cisco IOS devices that do not support VLANs. The offline states (``rendered`` and ``parsed``) will work as expected.
 
 
 

--- a/plugins/cliconf/ios.py
+++ b/plugins/cliconf/ios.py
@@ -282,7 +282,7 @@ class Cliconf(CliconfBase):
         device_type = "L2"
         try:
             self.get(command="show vlan")
-        except Exception as e:
+        except Exception:
             device_type = "L3"
         return device_type
 

--- a/plugins/cliconf/ios.py
+++ b/plugins/cliconf/ios.py
@@ -278,6 +278,14 @@ class Cliconf(CliconfBase):
             check_all=check_all,
         )
 
+    def check_device_type(self):
+        device_type = "L2"
+        try:
+            self.get(command="show vlan")
+        except Exception as e:
+            device_type = "L3"
+        return device_type
+
     def get_device_info(self):
         if not self._device_info:
             device_info = {}
@@ -307,7 +315,7 @@ class Cliconf(CliconfBase):
             match = re.search(r'image file is "(.+)"', data)
             if match:
                 device_info["network_os_image"] = match.group(1)
-
+            device_info["network_os_type"] = self.check_device_type()
             self._device_info = device_info
 
         return self._device_info

--- a/plugins/module_utils/network/ios/facts/vlans/vlans.py
+++ b/plugins/module_utils/network/ios/facts/vlans/vlans.py
@@ -42,15 +42,11 @@ class VlansFacts(object):
 
         self.generated_spec = utils.generate_dict(facts_argument_spec)
 
-    def get_vlans_data(self, connection):
-        try:
-            return connection.get("show vlan")
-        except Exception as ex:
-            self._module.fail_json(
-                "'show vlan' doesn't seems to be supported on the IOS box and failed with error: {0}. Please make sure it's an L2 switch".format(
-                    ex
-                )
-            )
+    def get_vlans_data(self, connection, ansible_facts):
+        check_me = connection.get_device_info()
+        if check_me.get("network_os_type") == "L3":  # will not work
+            return ""
+        return connection.get("show vlan")
 
     def populate_facts(self, connection, ansible_facts, data=None):
         """ Populate the facts for vlans
@@ -66,7 +62,7 @@ class VlansFacts(object):
         remote_objs = []
         final_objs = []
         if not data:
-            data = self.get_vlans_data(connection)
+            data = self.get_vlans_data(connection, ansible_facts)
         # operate on a collection of resource x
         config = data.split("\n")
         # Get individual vlan configs separately

--- a/plugins/module_utils/network/ios/facts/vlans/vlans.py
+++ b/plugins/module_utils/network/ios/facts/vlans/vlans.py
@@ -42,9 +42,12 @@ class VlansFacts(object):
 
         self.generated_spec = utils.generate_dict(facts_argument_spec)
 
-    def get_vlans_data(self, connection, ansible_facts):
-        check_me = connection.get_device_info()
-        if check_me.get("network_os_type") == "L3":  # will not work
+    def get_vlans_data(self, connection):
+        """ Checks device is L2/L3 and returns
+        facts gracefully. Does not fail module.
+        """
+        check_os_type = connection.get_device_info()
+        if check_os_type.get("network_os_type") == "L3":
             return ""
         return connection.get("show vlan")
 
@@ -62,7 +65,7 @@ class VlansFacts(object):
         remote_objs = []
         final_objs = []
         if not data:
-            data = self.get_vlans_data(connection, ansible_facts)
+            data = self.get_vlans_data(connection)
         # operate on a collection of resource x
         config = data.split("\n")
         # Get individual vlan configs separately

--- a/plugins/modules/ios_facts.py
+++ b/plugins/modules/ios_facts.py
@@ -23,7 +23,6 @@ module: ios_facts
 author:
 - Peter Sprygada (@privateip)
 - Sumit Jaiswal (@justjais)
-- Sagar Paul (@KB-perByte)
 short_description: Collect facts from remote devices running Cisco IOS
 description:
 - Collects a base set of device facts from a remote device that is running IOS.  This

--- a/plugins/modules/ios_facts.py
+++ b/plugins/modules/ios_facts.py
@@ -23,6 +23,7 @@ module: ios_facts
 author:
 - Peter Sprygada (@privateip)
 - Sumit Jaiswal (@justjais)
+- Sagar Paul (@KB-perByte)
 short_description: Collect facts from remote devices running Cisco IOS
 description:
 - Collects a base set of device facts from a remote device that is running IOS.  This
@@ -34,6 +35,8 @@ extends_documentation_fragment:
 - cisco.ios.ios
 notes:
 - Tested against IOS 15.6
+- Facts gathering for L3 devices are supposed to produce blank output for unsupported
+  resources like vlan.
 options:
   gather_subset:
     description:

--- a/plugins/modules/ios_vlans.py
+++ b/plugins/modules/ios_vlans.py
@@ -30,7 +30,8 @@ version_added: 1.0.0
 author: Sumit Jaiswal (@justjais)
 notes:
 - Tested against Cisco IOSl2 device with Version 15.2 on VIRL.
-- This RM works only with Cisco IOS L2 switch.
+- Starting from v2.5.0, this module will fail when run against Cisco IOS devices that do
+  not support VLANs. The offline states (C(rendered) and C(parsed)) will work as expected.
 options:
   config:
     description: A dictionary of VLANs options
@@ -764,6 +765,7 @@ def main():
         mutually_exclusive=mutually_exclusive,
         supports_check_mode=True,
     )
+
     if _is_l2_device(module) or module.params.get("state") in [
         "rendered",
         "parsed",

--- a/plugins/modules/ios_vlans.py
+++ b/plugins/modules/ios_vlans.py
@@ -772,8 +772,7 @@ def main():
         module.exit_json(**result)
     else:
         module.fail_json(
-            """Resource vlan is not supported for devices other than l2 switches.
-          As command 'show vlan' is not a valid command for the device."""
+            """Resource VLAN is not valid for the target device."""
         )
 
 

--- a/plugins/modules/ios_vlans.py
+++ b/plugins/modules/ios_vlans.py
@@ -728,6 +728,17 @@ from ansible_collections.cisco.ios.plugins.module_utils.network.ios.argspec.vlan
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.config.vlans.vlans import (
     Vlans,
 )
+from ansible_collections.cisco.ios.plugins.module_utils.network.ios.ios import (
+    get_connection,
+)
+
+
+def check_device(module):
+    connection = get_connection(module)
+    check_me = connection.get_device_info()
+    if check_me.get("network_os_type") == "L3":
+        return False
+    return True
 
 
 def main():
@@ -751,8 +762,13 @@ def main():
         mutually_exclusive=mutually_exclusive,
         supports_check_mode=True,
     )
-    result = Vlans(module).execute_module()
-    module.exit_json(**result)
+    if check_device(module):
+        result = Vlans(module).execute_module()
+        module.exit_json(**result)
+    else:
+        module.fail_json(
+            "'show vlan' doesn't seems to be supported on the IOS box. Please make sure it's an L2 switch"
+        )
 
 
 if __name__ == "__main__":

--- a/tests/unit/modules/network/ios/test_ios_vlans.py
+++ b/tests/unit/modules/network/ios/test_ios_vlans.py
@@ -57,6 +57,10 @@ class TestIosVlansModule(TestIosModule):
             "VlansFacts.get_vlans_data"
         )
         self.execute_show_command = self.mock_execute_show_command.start()
+        self.mock_l2_device_command = patch(
+            "ansible_collections.cisco.ios.plugins.modules.ios_vlans._is_l2_device"
+        )
+        self._l2_device_command = self.mock_l2_device_command.start()
 
     def tearDown(self):
         super(TestIosVlansModule, self).tearDown()
@@ -66,11 +70,13 @@ class TestIosVlansModule(TestIosModule):
         self.mock_get_config.stop()
         self.mock_load_config.stop()
         self.mock_execute_show_command.stop()
+        self.mock_l2_device_command.stop()
 
     def load_fixtures(self, commands=None, transport="cli"):
         def load_from_file(*args, **kwargs):
             return load_fixture("ios_vlans_config.cfg")
 
+        self.mock_l2_device_command.side_effect = True
         self.execute_show_command.side_effect = load_from_file
 
     def test_ios_vlans_merged(self):

--- a/tests/unit/plugins/cliconf/test_ios.py
+++ b/tests/unit/plugins/cliconf/test_ios.py
@@ -84,6 +84,7 @@ class TestPluginCLIConfIOS(unittest.TestCase):
             "network_os_version": "16.06.01",
             "network_os_hostname": "an-csr-01",
             "network_os_image": "bootflash:packages.conf",
+            "network_os_type": "L2",
         }
 
         self.assertEqual(device_info, mock_device_info)
@@ -125,6 +126,7 @@ class TestPluginCLIConfIOS(unittest.TestCase):
                 "network_os_model": "CSR1000V",
                 "network_os_version": "16.06.01",
                 "network_os": "ios",
+                "network_os_type": "L2",
             },
             "format": ["text"],
             "diff_match": ["line", "strict", "exact", "none"],


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #356 
ios_facts:
won't break for l2 or l3 devices rather have VLAN resource module facts data empty for devices other than l2
ios_vlans:
for a playbook run other than the `rendered`/`parsed` state, the playbook is supposed to fail with an exception.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

#TODO fix vlan unit tests
##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios_fact
ios_vlans

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
---
- name: Test VLANs
  hosts: router
  gather_facts: no
  tasks:
    - name: gather IOS facts for l3 device
      cisco.ios.facts:
        gather_subset: config
        gather_network_resources:
          - vlans
```
the above play won't get an exception while run against l3 device ^
