### PR TITLE
fix bgp address family to support multiple neighbours

### DIFF
--- a/changelogs/fragments/bgp_add_fam_issue.yaml
+++ b/changelogs/fragments/bgp_add_fam_issue.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Fixed bgp_address_family, for rendering multiple neighbours when available in config.

--- a/changelogs/fragments/bgp_add_fam_issue.yaml
+++ b/changelogs/fragments/bgp_add_fam_issue.yaml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - Fixed bgp_address_family, for rendering multiple neighbours when available in config.
+  - Fixed bgp_address_family, for rendering multiple neighbors when available in config.

--- a/docs/cisco.ios.ios_bgp_address_family_module.rst
+++ b/docs/cisco.ios.ios_bgp_address_family_module.rst
@@ -800,6 +800,7 @@ Parameters
                 </td>
                 <td>
                         <div>Nexthop triggering</div>
+                        <div style="font-size: small; color: darkgreen"><br/>aliases: slow_peers</div>
                 </td>
             </tr>
                                 <tr>
@@ -1121,7 +1122,7 @@ Parameters
                     <td class="elbow-placeholder"></td>
                 <td colspan="6">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
-                    <b>neighbors</b>
+                    <b>neighbor</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
                         <span style="color: purple">list</span>
@@ -1132,7 +1133,7 @@ Parameters
                 </td>
                 <td>
                         <div>Specify a neighbor router</div>
-                        <div style="font-size: small; color: darkgreen"><br/>aliases: neighbor</div>
+                        <div style="font-size: small; color: darkgreen"><br/>aliases: neighbors</div>
                 </td>
             </tr>
                                 <tr>
@@ -3962,6 +3963,7 @@ Parameters
                 </td>
                 <td>
                         <div>Configure slow-peer</div>
+                        <div style="font-size: small; color: darkgreen"><br/>aliases: slow_peers</div>
                 </td>
             </tr>
                                 <tr>
@@ -4588,7 +4590,7 @@ Parameters
                     <td class="elbow-placeholder"></td>
                 <td colspan="6">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
-                    <b>networks</b>
+                    <b>network</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
                         <span style="color: purple">list</span>
@@ -4599,7 +4601,7 @@ Parameters
                 </td>
                 <td>
                         <div>Specify a network to announce via BGP</div>
-                        <div style="font-size: small; color: darkgreen"><br/>aliases: network</div>
+                        <div style="font-size: small; color: darkgreen"><br/>aliases: networks</div>
                 </td>
             </tr>
                                 <tr>

--- a/docs/cisco.ios.ios_bgp_address_family_module.rst
+++ b/docs/cisco.ios.ios_bgp_address_family_module.rst
@@ -800,7 +800,6 @@ Parameters
                 </td>
                 <td>
                         <div>Nexthop triggering</div>
-                        <div style="font-size: small; color: darkgreen"><br/>aliases: slow_peers</div>
                 </td>
             </tr>
                                 <tr>
@@ -1133,7 +1132,6 @@ Parameters
                 </td>
                 <td>
                         <div>Specify a neighbor router</div>
-                        <div style="font-size: small; color: darkgreen"><br/>aliases: neighbors</div>
                 </td>
             </tr>
                                 <tr>
@@ -3963,7 +3961,6 @@ Parameters
                 </td>
                 <td>
                         <div>Configure slow-peer</div>
-                        <div style="font-size: small; color: darkgreen"><br/>aliases: slow_peers</div>
                 </td>
             </tr>
                                 <tr>
@@ -4601,7 +4598,6 @@ Parameters
                 </td>
                 <td>
                         <div>Specify a network to announce via BGP</div>
-                        <div style="font-size: small; color: darkgreen"><br/>aliases: networks</div>
                 </td>
             </tr>
                                 <tr>

--- a/docs/cisco.ios.ios_bgp_address_family_module.rst
+++ b/docs/cisco.ios.ios_bgp_address_family_module.rst
@@ -1121,7 +1121,7 @@ Parameters
                     <td class="elbow-placeholder"></td>
                 <td colspan="6">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
-                    <b>neighbor</b>
+                    <b>neighbors</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
                         <span style="color: purple">list</span>
@@ -1132,6 +1132,7 @@ Parameters
                 </td>
                 <td>
                         <div>Specify a neighbor router</div>
+                        <div style="font-size: small; color: darkgreen"><br/>aliases: neighbor</div>
                 </td>
             </tr>
                                 <tr>
@@ -4587,7 +4588,7 @@ Parameters
                     <td class="elbow-placeholder"></td>
                 <td colspan="6">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
-                    <b>network</b>
+                    <b>networks</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
                         <span style="color: purple">list</span>
@@ -4598,6 +4599,7 @@ Parameters
                 </td>
                 <td>
                         <div>Specify a network to announce via BGP</div>
+                        <div style="font-size: small; color: darkgreen"><br/>aliases: network</div>
                 </td>
             </tr>
                                 <tr>
@@ -6681,7 +6683,7 @@ Examples
                     - name: test-route-in
                       in: true
                   route_server_client: true
-              network:
+              networks:
                 - address: 198.51.110.10
                   mask: 255.255.255.255
                   backdoor: true
@@ -6713,7 +6715,7 @@ Examples
                 external: 10
                 internal: 10
                 local: 100
-              network:
+              networks:
                 - address: 198.51.111.11
                   mask: 255.255.255.255
                   route_map: test
@@ -6867,7 +6869,7 @@ Examples
                     - name: test-replaced-route
                       out: true
                   route_server_client: true
-              network:
+              networks:
                 - address: 198.51.110.10
                   mask: 255.255.255.255
                   backdoor: true
@@ -6883,7 +6885,7 @@ Examples
                 slow_peer:
                   - detection:
                       threshold: 200
-              network:
+              networks:
                 - address: 192.0.2.1
                   mask: 255.255.255.255
                   route_map: test
@@ -7580,15 +7582,15 @@ Common return values are documented `here <https://docs.ansible.com/ansible/late
                     <b>after</b>
                     <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
                     <div style="font-size: small">
-                      <span style="color: purple">list</span>
+                      <span style="color: purple">dictionary</span>
                     </div>
                 </td>
                 <td>when changed</td>
                 <td>
-                            <div>The configuration as structured data after module completion.</div>
+                            <div>The resulting configuration after module execution.</div>
                     <br/>
                         <div style="font-size: smaller"><b>Sample:</b></div>
-                        <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">The configuration returned will always be in the same format of the parameters above.</div>
+                        <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">This output will always be in the same format as the module argspec.</div>
                 </td>
             </tr>
             <tr>
@@ -7597,15 +7599,15 @@ Common return values are documented `here <https://docs.ansible.com/ansible/late
                     <b>before</b>
                     <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
                     <div style="font-size: small">
-                      <span style="color: purple">list</span>
+                      <span style="color: purple">dictionary</span>
                     </div>
                 </td>
-                <td>always</td>
+                <td>when <em>state</em> is <code>merged</code>, <code>replaced</code>, <code>overridden</code>, <code>deleted</code> or <code>purged</code></td>
                 <td>
-                            <div>The configuration as structured data prior to module invocation.</div>
+                            <div>The configuration prior to the module execution.</div>
                     <br/>
                         <div style="font-size: smaller"><b>Sample:</b></div>
-                        <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">The configuration returned will always be in the same format of the parameters above.</div>
+                        <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">This output will always be in the same format as the module argspec.</div>
                 </td>
             </tr>
             <tr>
@@ -7617,9 +7619,60 @@ Common return values are documented `here <https://docs.ansible.com/ansible/late
                       <span style="color: purple">list</span>
                     </div>
                 </td>
-                <td>always</td>
+                <td>when <em>state</em> is <code>merged</code>, <code>replaced</code>, <code>overridden</code>, <code>deleted</code> or <code>purged</code></td>
                 <td>
-                            <div>The set of commands pushed to the remote device</div>
+                            <div>The set of commands pushed to the remote device.</div>
+                    <br/>
+                        <div style="font-size: smaller"><b>Sample:</b></div>
+                        <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[&#x27;router bgp 65000&#x27;, &#x27;address-family ipv4 multicast&#x27;, &#x27;table-map test_tableMap filter&#x27;, &#x27;network 1.1.1.1 mask 255.255.255.255 route-map test&#x27;, &#x27;aggregate-address 192.0.3.1 255.255.255.255 as-confed-set&#x27;]</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>gathered</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">list</span>
+                    </div>
+                </td>
+                <td>when <em>state</em> is <code>gathered</code></td>
+                <td>
+                            <div>Facts about the network resource gathered from the remote device as structured data.</div>
+                    <br/>
+                        <div style="font-size: smaller"><b>Sample:</b></div>
+                        <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">This output will always be in the same format as the module argspec.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>parsed</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">list</span>
+                    </div>
+                </td>
+                <td>when <em>state</em> is <code>parsed</code></td>
+                <td>
+                            <div>The device native config provided in <em>running_config</em> option parsed into structured data as per module argspec.</div>
+                    <br/>
+                        <div style="font-size: smaller"><b>Sample:</b></div>
+                        <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">This output will always be in the same format as the module argspec.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>rendered</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">list</span>
+                    </div>
+                </td>
+                <td>when <em>state</em> is <code>rendered</code></td>
+                <td>
+                            <div>The provided configuration in the task rendered in device-native format (offline).</div>
                     <br/>
                         <div style="font-size: smaller"><b>Sample:</b></div>
                         <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[&#x27;router bgp 65000&#x27;, &#x27;address-family ipv4 multicast&#x27;, &#x27;table-map test_tableMap filter&#x27;, &#x27;network 1.1.1.1 mask 255.255.255.255 route-map test&#x27;, &#x27;aggregate-address 192.0.3.1 255.255.255.255 as-confed-set&#x27;]</div>

--- a/docs/cisco.ios.ios_bgp_address_family_module.rst
+++ b/docs/cisco.ios.ios_bgp_address_family_module.rst
@@ -6681,7 +6681,7 @@ Examples
                     - name: test-route-in
                       in: true
                   route_server_client: true
-              networks:
+              network:
                 - address: 198.51.110.10
                   mask: 255.255.255.255
                   backdoor: true
@@ -6713,7 +6713,7 @@ Examples
                 external: 10
                 internal: 10
                 local: 100
-              networks:
+              network:
                 - address: 198.51.111.11
                   mask: 255.255.255.255
                   route_map: test
@@ -6867,7 +6867,7 @@ Examples
                     - name: test-replaced-route
                       out: true
                   route_server_client: true
-              networks:
+              network:
                 - address: 198.51.110.10
                   mask: 255.255.255.255
                   backdoor: true
@@ -6883,7 +6883,7 @@ Examples
                 slow_peer:
                   - detection:
                       threshold: 200
-              networks:
+              network:
                 - address: 192.0.2.1
                   mask: 255.255.255.255
                   route_map: test

--- a/plugins/module_utils/network/ios/argspec/bgp_address_family/bgp_address_family.py
+++ b/plugins/module_utils/network/ios/argspec/bgp_address_family/bgp_address_family.py
@@ -128,6 +128,7 @@ class Bgp_address_familyArgs(object):  # pylint: disable=R0903
                                 "slow_peer": {
                                     "type": "list",
                                     "elements": "dict",
+                                    "aliases": ["slow_peers"],
                                     "options": {
                                         "detection": {
                                             "type": "dict",
@@ -160,10 +161,10 @@ class Bgp_address_familyArgs(object):  # pylint: disable=R0903
                                 "local": {"type": "int"},
                             },
                         },
-                        "neighbors": {
+                        "neighbor": {
                             "type": "list",
                             "elements": "dict",
-                            "aliases": ["neighbor"],
+                            "aliases": ["neighbors"],
                             "options": {
                                 "address": {"type": "str"},
                                 "tag": {"type": "str"},
@@ -449,6 +450,7 @@ class Bgp_address_familyArgs(object):  # pylint: disable=R0903
                                 "slow_peer": {
                                     "type": "list",
                                     "elements": "dict",
+                                    "aliases": ["slow_peers"],
                                     "options": {
                                         "detection": {
                                             "type": "dict",
@@ -516,10 +518,10 @@ class Bgp_address_familyArgs(object):  # pylint: disable=R0903
                                 "weight": {"type": "int"},
                             },
                         },
-                        "networks": {
+                        "network": {
                             "type": "list",
                             "elements": "dict",
-                            "aliases": ["network"],
+                            "aliases": ["networks"],
                             "options": {
                                 "address": {"type": "str"},
                                 "mask": {"type": "str"},

--- a/plugins/module_utils/network/ios/argspec/bgp_address_family/bgp_address_family.py
+++ b/plugins/module_utils/network/ios/argspec/bgp_address_family/bgp_address_family.py
@@ -386,17 +386,17 @@ class Bgp_address_familyArgs(object):  # pylint: disable=R0903
                                     },
                                 },
                                 "peer_group": {"type": "bool"},
-                                "prefix_lists": {
-                                    "type": "list",
-                                    "elements": "dict",
+                                "prefix_list": {
+                                    "type": "dict",
                                     "options": {
                                         "name": {"type": "str"},
                                         "in": {"type": "bool"},
                                         "out": {"type": "bool"},
                                     },
                                 },
-                                "prefix_list": {
-                                    "type": "dict",
+                                "prefix_lists": {
+                                    "type": "list",
+                                    "elements": "dict",
                                     "options": {
                                         "name": {"type": "str"},
                                         "in": {"type": "bool"},
@@ -412,17 +412,17 @@ class Bgp_address_familyArgs(object):  # pylint: disable=R0903
                                         "replace_as": {"type": "bool"},
                                     },
                                 },
-                                "route_maps": {
-                                    "type": "list",
-                                    "elements": "dict",
+                                "route_map": {
+                                    "type": "dict",
                                     "options": {
                                         "name": {"type": "str"},
                                         "in": {"type": "bool"},
                                         "out": {"type": "bool"},
                                     },
                                 },
-                                "route_map": {
-                                    "type": "dict",
+                                "route_maps": {
+                                    "type": "list",
+                                    "elements": "dict",
                                     "options": {
                                         "name": {"type": "str"},
                                         "in": {"type": "bool"},

--- a/plugins/module_utils/network/ios/argspec/bgp_address_family/bgp_address_family.py
+++ b/plugins/module_utils/network/ios/argspec/bgp_address_family/bgp_address_family.py
@@ -23,12 +23,12 @@ __metaclass__ = type
 #############################################
 
 """
-The arg spec for the cisco.ios_bgp_address_family module
+The arg spec for the ios_bgp_address_family module
 """
 
 
-class Bgp_AddressFamilyArgs(object):
-    """The arg spec for the cisco.ios_bgp_address_family module
+class Bgp_address_familyArgs(object):  # pylint: disable=R0903
+    """The arg spec for the ios_bgp_address_family module
     """
 
     argument_spec = {
@@ -160,9 +160,10 @@ class Bgp_AddressFamilyArgs(object):
                                 "local": {"type": "int"},
                             },
                         },
-                        "neighbor": {
+                        "neighbors": {
                             "type": "list",
                             "elements": "dict",
+                            "aliases": ["neighbor"],
                             "options": {
                                 "address": {"type": "str"},
                                 "tag": {"type": "str"},
@@ -515,9 +516,10 @@ class Bgp_AddressFamilyArgs(object):
                                 "weight": {"type": "int"},
                             },
                         },
-                        "network": {
+                        "networks": {
                             "type": "list",
                             "elements": "dict",
+                            "aliases": ["network"],
                             "options": {
                                 "address": {"type": "str"},
                                 "mask": {"type": "str"},
@@ -730,16 +732,16 @@ class Bgp_AddressFamilyArgs(object):
         },
         "running_config": {"type": "str"},
         "state": {
-            "type": "str",
             "choices": [
                 "merged",
                 "replaced",
                 "overridden",
                 "deleted",
                 "gathered",
-                "parsed",
                 "rendered",
+                "parsed",
             ],
             "default": "merged",
+            "type": "str",
         },
-    }
+    }  # pylint: disable=C0301

--- a/plugins/module_utils/network/ios/argspec/bgp_address_family/bgp_address_family.py
+++ b/plugins/module_utils/network/ios/argspec/bgp_address_family/bgp_address_family.py
@@ -128,7 +128,6 @@ class Bgp_address_familyArgs(object):  # pylint: disable=R0903
                                 "slow_peer": {
                                     "type": "list",
                                     "elements": "dict",
-                                    "aliases": ["slow_peers"],
                                     "options": {
                                         "detection": {
                                             "type": "dict",
@@ -164,7 +163,6 @@ class Bgp_address_familyArgs(object):  # pylint: disable=R0903
                         "neighbor": {
                             "type": "list",
                             "elements": "dict",
-                            "aliases": ["neighbors"],
                             "options": {
                                 "address": {"type": "str"},
                                 "tag": {"type": "str"},
@@ -450,7 +448,6 @@ class Bgp_address_familyArgs(object):  # pylint: disable=R0903
                                 "slow_peer": {
                                     "type": "list",
                                     "elements": "dict",
-                                    "aliases": ["slow_peers"],
                                     "options": {
                                         "detection": {
                                             "type": "dict",
@@ -521,7 +518,6 @@ class Bgp_address_familyArgs(object):  # pylint: disable=R0903
                         "network": {
                             "type": "list",
                             "elements": "dict",
-                            "aliases": ["networks"],
                             "options": {
                                 "address": {"type": "str"},
                                 "mask": {"type": "str"},

--- a/plugins/module_utils/network/ios/config/bgp_address_family/bgp_address_family.py
+++ b/plugins/module_utils/network/ios/config/bgp_address_family/bgp_address_family.py
@@ -28,11 +28,11 @@ from ansible_collections.cisco.ios.plugins.module_utils.network.ios.facts.facts 
     Facts,
 )
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.rm_templates.bgp_address_family import (
-    Bgp_AddressFamilyTemplate,
+    Bgp_address_familyTemplate,
 )
 
 
-class Bgp_AddressFamily(ResourceModule):
+class Bgp_address_family(ResourceModule):
     """
     The cisco.ios_bgp_address_family config class
     """
@@ -49,12 +49,12 @@ class Bgp_AddressFamily(ResourceModule):
     ]
 
     def __init__(self, module):
-        super(Bgp_AddressFamily, self).__init__(
+        super(Bgp_address_family, self).__init__(
             empty_fact_val={},
             facts_module=Facts(module),
             module=module,
             resource="bgp_address_family",
-            tmplt=Bgp_AddressFamilyTemplate(),
+            tmplt=Bgp_address_familyTemplate(),
         )
 
     def execute_module(self):

--- a/plugins/module_utils/network/ios/facts/bgp_address_family/bgp_address_family.py
+++ b/plugins/module_utils/network/ios/facts/bgp_address_family/bgp_address_family.py
@@ -82,7 +82,7 @@ class Bgp_AddressFamilyFacts(object):
                 neighbor = v.get("neighbor")
                 if neighbor:
 
-                    def _update_neighor_list(neighbor_list, temp):
+                    def _update_neighor_list(neighbor_list, temp, alter=None):
                         set = False
                         temp = utils.remove_empties(temp)
                         for each in neighbor_list:
@@ -90,13 +90,17 @@ class Bgp_AddressFamilyFacts(object):
                                 each.update(temp)
                                 set = True
                         if not neighbor_list or not set:
-                            neighbor_list.append(temp)
+                            if alter:
+                                neighbor_list.extend(list(alter.values()))
+                            else:
+                                neighbor_list.append(temp)
 
                     neighbor_list = []
                     temp_param_list = []
                     temp = {}
                     temp_param = None
                     neighbor_identifier = None
+                    al = {}
                     for each in neighbor:
                         if temp_param and not each.get(temp_param) and temp:
                             temp.update({temp_param: temp_param_list})
@@ -120,6 +124,10 @@ class Bgp_AddressFamilyFacts(object):
                             else:
                                 temp["tag"] = neighbor_identifier
                         temp.update(each)
+                        if not al.get(each.get("address")):
+                            al[each.get("address")] = each
+                        else:
+                            al.get(each.get("address")).update(each)
                         for param in [
                             "prefix_lists",
                             "route_maps",
@@ -133,7 +141,7 @@ class Bgp_AddressFamilyFacts(object):
                     if temp:
                         if temp_param:
                             temp.update({temp_param: temp_param_list})
-                        _update_neighor_list(neighbor_list, temp)
+                        _update_neighor_list(neighbor_list, temp, al)
                         temp_param_list = []
                         temp = {}
                     v["neighbor"] = neighbor_list

--- a/plugins/module_utils/network/ios/facts/bgp_address_family/bgp_address_family.py
+++ b/plugins/module_utils/network/ios/facts/bgp_address_family/bgp_address_family.py
@@ -160,9 +160,11 @@ class Bgp_AddressFamilyFacts(object):
             lines=data.splitlines(), module=self._module
         )
         objs = bgp_af_parser.parse()
-        objs = utils.remove_empties(objs)
-        objs = self._process_facts(objs)
+
         if objs:
+
+            objs = self._process_facts(utils.remove_empties(objs))
+
             ansible_facts["ansible_network_resources"].pop(
                 "bgp_address_family", None
             )

--- a/plugins/module_utils/network/ios/facts/bgp_address_family/bgp_address_family.py
+++ b/plugins/module_utils/network/ios/facts/bgp_address_family/bgp_address_family.py
@@ -19,20 +19,20 @@ from ansible_collections.ansible.netcommon.plugins.module_utils.network.common i
     utils,
 )
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.rm_templates.bgp_address_family import (
-    Bgp_AddressFamilyTemplate,
+    Bgp_address_familyTemplate,
 )
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.argspec.bgp_address_family.bgp_address_family import (
-    Bgp_AddressFamilyArgs,
+    Bgp_address_familyArgs,
 )
 
 
-class Bgp_AddressFamilyFacts(object):
+class Bgp_address_familyFacts(object):
     """ The cisco.ios_bgp_address_family facts class
     """
 
     def __init__(self, module, subspec="config", options="options"):
         self._module = module
-        self.argument_spec = Bgp_AddressFamilyArgs.argument_spec
+        self.argument_spec = Bgp_address_familyArgs.argument_spec
 
     def get_bgp_address_family_data(self, connection):
         return connection.get("sh running-config | section ^router bgp")
@@ -156,7 +156,7 @@ class Bgp_AddressFamilyFacts(object):
             data = self.get_bgp_address_family_data(connection)
 
         # parse native config using the Bgp_address_family template
-        bgp_af_parser = Bgp_AddressFamilyTemplate(
+        bgp_af_parser = Bgp_address_familyTemplate(
             lines=data.splitlines(), module=self._module
         )
         objs = bgp_af_parser.parse()

--- a/plugins/module_utils/network/ios/facts/facts.py
+++ b/plugins/module_utils/network/ios/facts/facts.py
@@ -66,7 +66,7 @@ from ansible_collections.cisco.ios.plugins.module_utils.network.ios.facts.bgp_gl
     Bgp_globalFacts,
 )
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.facts.bgp_address_family.bgp_address_family import (
-    Bgp_AddressFamilyFacts,
+    Bgp_address_familyFacts,
 )
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.facts.logging_global.logging_global import (
     Logging_globalFacts,
@@ -109,7 +109,7 @@ FACT_RESOURCE_SUBSETS = dict(
     ospfv3=Ospfv3Facts,
     ospf_interfaces=Ospf_InterfacesFacts,
     bgp_global=Bgp_globalFacts,
-    bgp_address_family=Bgp_AddressFamilyFacts,
+    bgp_address_family=Bgp_address_familyFacts,
     logging_global=Logging_globalFacts,
     route_maps=Route_mapsFacts,
     prefix_lists=Prefix_listsFacts,

--- a/plugins/module_utils/network/ios/rm_templates/bgp_address_family.py
+++ b/plugins/module_utils/network/ios/rm_templates/bgp_address_family.py
@@ -729,9 +729,9 @@ def _tmplt_af_table_map(config_data):
         return cmd
 
 
-class Bgp_AddressFamilyTemplate(NetworkTemplate):
+class Bgp_address_familyTemplate(NetworkTemplate):
     def __init__(self, lines=None, module=None):
-        super(Bgp_AddressFamilyTemplate, self).__init__(
+        super(Bgp_address_familyTemplate, self).__init__(
             lines=lines, tmplt=self, module=module
         )
 

--- a/plugins/modules/ios_bgp_address_family.py
+++ b/plugins/modules/ios_bgp_address_family.py
@@ -174,8 +174,6 @@ options:
                 description: Nexthop triggering
                 type: list
                 elements: dict
-                aliases:
-                  - slow_peers
                 suboptions:
                   detection:
                     description: Slow-peer detection
@@ -237,8 +235,6 @@ options:
             description: Specify a neighbor router
             type: list
             elements: dict
-            aliases:
-              - neighbors
             suboptions:
               address:
                 description: Neighbor address (A.B.C.D)
@@ -736,8 +732,6 @@ options:
                 description: Configure slow-peer
                 type: list
                 elements: dict
-                aliases:
-                  - slow_peers
                 suboptions:
                   detection:
                     description: Configure slow-peer
@@ -842,8 +836,6 @@ options:
             description: Specify a network to announce via BGP
             type: list
             elements: dict
-            aliases:
-              - networks
             suboptions:
               address:
                 description: Network number (A.B.C.D)
@@ -1207,7 +1199,6 @@ options:
 """
 
 EXAMPLES = """
-
 # Using merged
 
 # Before state:
@@ -2137,6 +2128,7 @@ EXAMPLES = """
 #       ],
 #       "as_number": "65000"
 #   }
+
 
 """
 

--- a/plugins/modules/ios_bgp_address_family.py
+++ b/plugins/modules/ios_bgp_address_family.py
@@ -1250,7 +1250,7 @@ EXAMPLES = """
                 - name: test-route-in
                   in: true
               route_server_client: true
-          networks:
+          network:
             - address: 198.51.110.10
               mask: 255.255.255.255
               backdoor: true
@@ -1282,7 +1282,7 @@ EXAMPLES = """
             external: 10
             internal: 10
             local: 100
-          networks:
+          network:
             - address: 198.51.111.11
               mask: 255.255.255.255
               route_map: test
@@ -1436,7 +1436,7 @@ EXAMPLES = """
                 - name: test-replaced-route
                   out: true
               route_server_client: true
-          networks:
+          network:
             - address: 198.51.110.10
               mask: 255.255.255.255
               backdoor: true
@@ -1452,7 +1452,7 @@ EXAMPLES = """
             slow_peer:
               - detection:
                   threshold: 200
-          networks:
+          network:
             - address: 192.0.2.1
               mask: 255.255.255.255
               route_map: test

--- a/plugins/modules/ios_bgp_address_family.py
+++ b/plugins/modules/ios_bgp_address_family.py
@@ -174,6 +174,8 @@ options:
                 description: Nexthop triggering
                 type: list
                 elements: dict
+                aliases:
+                  - slow_peers
                 suboptions:
                   detection:
                     description: Slow-peer detection
@@ -231,12 +233,12 @@ options:
               local:
                 description: Distance for local routes
                 type: int
-          neighbors:
+          neighbor:
             description: Specify a neighbor router
             type: list
             elements: dict
             aliases:
-              - neighbor
+              - neighbors
             suboptions:
               address:
                 description: Neighbor address (A.B.C.D)
@@ -734,6 +736,8 @@ options:
                 description: Configure slow-peer
                 type: list
                 elements: dict
+                aliases:
+                  - slow_peers
                 suboptions:
                   detection:
                     description: Configure slow-peer
@@ -834,12 +838,12 @@ options:
               weight:
                 description: Set default weight for routes from this neighbor
                 type: int
-          networks:
+          network:
             description: Specify a network to announce via BGP
             type: list
             elements: dict
             aliases:
-              - network
+              - networks
             suboptions:
               address:
                 description: Network number (A.B.C.D)

--- a/plugins/modules/ios_bgp_address_family.py
+++ b/plugins/modules/ios_bgp_address_family.py
@@ -1,26 +1,17 @@
 #!/usr/bin/python
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
-#
+# -*- coding: utf-8 -*-
+# Copyright 2021 Red Hat
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
 """
 The module file for ios_bgp_address_family
 """
+
 from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
+
 DOCUMENTATION = """
 module: ios_bgp_address_family
 short_description: BGP Address family resource module
@@ -240,10 +231,12 @@ options:
               local:
                 description: Distance for local routes
                 type: int
-          neighbor:
+          neighbors:
             description: Specify a neighbor router
             type: list
             elements: dict
+            aliases:
+              - neighbor
             suboptions:
               address:
                 description: Neighbor address (A.B.C.D)
@@ -841,10 +834,12 @@ options:
               weight:
                 description: Set default weight for routes from this neighbor
                 type: int
-          network:
+          networks:
             description: Specify a network to announce via BGP
             type: list
             elements: dict
+            aliases:
+              - network
             suboptions:
               address:
                 description: Network number (A.B.C.D)
@@ -1260,7 +1255,7 @@ EXAMPLES = """
                 - name: test-route-in
                   in: true
               route_server_client: true
-          network:
+          networks:
             - address: 198.51.110.10
               mask: 255.255.255.255
               backdoor: true
@@ -1292,7 +1287,7 @@ EXAMPLES = """
             external: 10
             internal: 10
             local: 100
-          network:
+          networks:
             - address: 198.51.111.11
               mask: 255.255.255.255
               route_map: test
@@ -1446,7 +1441,7 @@ EXAMPLES = """
                 - name: test-replaced-route
                   out: true
               route_server_client: true
-          network:
+          networks:
             - address: 198.51.110.10
               mask: 255.255.255.255
               backdoor: true
@@ -1462,7 +1457,7 @@ EXAMPLES = """
             slow_peer:
               - detection:
                   threshold: 200
-          network:
+          networks:
             - address: 192.0.2.1
               mask: 255.255.255.255
               route_map: test
@@ -2143,57 +2138,84 @@ EXAMPLES = """
 
 RETURN = """
 before:
-  description: The configuration as structured data prior to module invocation.
-  returned: always
-  type: list
-  sample: The configuration returned will always be in the same format of the parameters above.
+  description: The configuration prior to the module execution.
+  returned: when I(state) is C(merged), C(replaced), C(overridden), C(deleted) or C(purged)
+  type: dict
+  sample: >
+    This output will always be in the same format as the
+    module argspec.
 after:
-  description: The configuration as structured data after module completion.
+  description: The resulting configuration after module execution.
   returned: when changed
-  type: list
-  sample: The configuration returned will always be in the same format of the parameters above.
+  type: dict
+  sample: >
+    This output will always be in the same format as the
+    module argspec.
 commands:
-  description: The set of commands pushed to the remote device
-  returned: always
+  description: The set of commands pushed to the remote device.
+  returned: when I(state) is C(merged), C(replaced), C(overridden), C(deleted) or C(purged)
   type: list
-  sample: [
-    "router bgp 65000",
-    "address-family ipv4 multicast",
-    "table-map test_tableMap filter",
-    "network 1.1.1.1 mask 255.255.255.255 route-map test",
-    "aggregate-address 192.0.3.1 255.255.255.255 as-confed-set",
-  ]
+  sample:
+    - router bgp 65000
+    - address-family ipv4 multicast
+    - table-map test_tableMap filter
+    - network 1.1.1.1 mask 255.255.255.255 route-map test
+    - aggregate-address 192.0.3.1 255.255.255.255 as-confed-set
+rendered:
+  description: The provided configuration in the task rendered in device-native format (offline).
+  returned: when I(state) is C(rendered)
+  type: list
+  sample:
+    - router bgp 65000
+    - address-family ipv4 multicast
+    - table-map test_tableMap filter
+    - network 1.1.1.1 mask 255.255.255.255 route-map test
+    - aggregate-address 192.0.3.1 255.255.255.255 as-confed-set
+gathered:
+  description: Facts about the network resource gathered from the remote device as structured data.
+  returned: when I(state) is C(gathered)
+  type: list
+  sample: >
+    This output will always be in the same format as the
+    module argspec.
+parsed:
+  description: The device native config provided in I(running_config) option parsed into structured data as per module argspec.
+  returned: when I(state) is C(parsed)
+  type: list
+  sample: >
+    This output will always be in the same format as the
+    module argspec.
 """
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.argspec.bgp_address_family.bgp_address_family import (
-    Bgp_AddressFamilyArgs,
+    Bgp_address_familyArgs,
 )
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.config.bgp_address_family.bgp_address_family import (
-    Bgp_AddressFamily,
+    Bgp_address_family,
 )
 
 
 def main():
     """
     Main entry point for module execution
+
     :returns: the result form module invocation
     """
-    required_if = [
-        ("state", "merged", ("config",)),
-        ("state", "replaced", ("config",)),
-        ("state", "overridden", ("config",)),
-        ("state", "rendered", ("config",)),
-        ("state", "parsed", ("running_config",)),
-    ]
-    mutually_exclusive = [("config", "running_config")]
     module = AnsibleModule(
-        argument_spec=Bgp_AddressFamilyArgs.argument_spec,
-        required_if=required_if,
-        mutually_exclusive=mutually_exclusive,
+        argument_spec=Bgp_address_familyArgs.argument_spec,
+        mutually_exclusive=[["config", "running_config"]],
+        required_if=[
+            ["state", "merged", ["config"]],
+            ["state", "replaced", ["config"]],
+            ["state", "overridden", ["config"]],
+            ["state", "rendered", ["config"]],
+            ["state", "parsed", ["running_config"]],
+        ],
         supports_check_mode=True,
     )
-    result = Bgp_AddressFamily(module).execute_module()
+
+    result = Bgp_address_family(module).execute_module()
     module.exit_json(**result)
 
 

--- a/tests/integration/targets/ios_bgp_address_family/tests/cli/_parsed.cfg
+++ b/tests/integration/targets/ios_bgp_address_family/tests/cli/_parsed.cfg
@@ -1,36 +1,15 @@
-router bgp 65000
+router bgp 65536
+ bgp router-id 198.51.110.175
  bgp log-neighbor-changes
- bgp nopeerup-delay cold-boot 20
- bgp nopeerup-delay post-boot 10
- bgp bestpath med confed
- neighbor 192.0.2.1 remote-as 100
- neighbor 192.0.2.1 description replace neighbor
- neighbor 198.51.100.1 remote-as 10
+ neighbor 198.51.110.212 remote-as 65536
+ neighbor 198.51.110.206 remote-as 65536
  !
- address-family ipv4 multicast
-  table-map test_tableMap filter
-  network 198.51.111.11 mask 255.255.255.255 route-map test
-  aggregate-address 192.0.3.1 255.255.255.255 as-confed-set
-  default-metric 12
-  distance bgp 10 10 100
- exit-address-family
- !
- address-family ipv4 mdt
-  bgp dampening 1 10 100 5
-  bgp dmzlink-bw
-  bgp soft-reconfig-backup
- exit-address-family
- !
- address-family ipv4 multicast vrf blue
-  bgp aggregate-timer 10
-  bgp slow-peer detection threshold 150
-  bgp dampening 1 1 1 1
-  network 198.51.110.10 mask 255.255.255.255 backdoor
-  aggregate-address 192.0.2.1 255.255.255.255 as-confed-set
-  neighbor 198.51.100.1 remote-as 10
-  neighbor 198.51.100.1 activate
-  neighbor 198.51.100.1 aigp send cost-community 100 poi igp-cost transitive
-  neighbor 198.51.100.1 route-server-client
-  neighbor 198.51.100.1 slow-peer detection threshold 150
-  neighbor 198.51.100.1 route-map test-route out
+ address-family ipv4
+  network 192.0.2.0
+  network 192.0.3.0
+  network 192.0.4.0
+  neighbor 198.51.110.212 activate
+  neighbor 198.51.110.212 soft-reconfiguration inbound
+  neighbor 198.51.110.206 activate
+  neighbor 198.51.110.206 soft-reconfiguration inbound
  exit-address-family

--- a/tests/integration/targets/ios_bgp_address_family/tests/cli/parsed.yaml
+++ b/tests/integration/targets/ios_bgp_address_family/tests/cli/parsed.yaml
@@ -12,3 +12,4 @@
 - assert:
     that:
       - result.changed == false
+      - parsed['config'] == result['parsed']

--- a/tests/integration/targets/ios_bgp_address_family/vars/main.yaml
+++ b/tests/integration/targets/ios_bgp_address_family/vars/main.yaml
@@ -289,3 +289,20 @@ deleted_all:
 
   after:
     as_number: "65000"
+
+parsed:
+  config:
+    address_family:
+      - afi: ipv4
+        neighbor:
+          - activate: true
+            address: 198.51.110.212
+            soft_reconfiguration: true
+          - activate: true
+            address: 198.51.110.206
+            soft_reconfiguration: true
+        network:
+          - address: 192.0.2.0
+          - address: 192.0.3.0
+          - address: 192.0.4.0
+    as_number: '65536'

--- a/tests/unit/modules/network/ios/test_ios_bgp_address_family.py
+++ b/tests/unit/modules/network/ios/test_ios_bgp_address_family.py
@@ -750,3 +750,108 @@ class TestIosBgpAddressFamilyModule(TestIosModule):
             "as_number": "65000",
         }
         self.assertEqual(parsed_list, result["parsed"])
+
+    def test_ios_bgp_address_family_merged_multiple_neighbor(self):
+        set_module_args(
+            dict(
+                config=dict(
+                    as_number="65000",
+                    address_family=[
+                        dict(
+                            afi="ipv4",
+                            neighbor=[
+                                dict(
+                                    address="192.31.39.212",
+                                    soft_reconfiguration=True,
+                                    activate=True,
+                                ),
+                                dict(
+                                    address="192.31.47.206",
+                                    soft_reconfiguration=True,
+                                    activate=True,
+                                ),
+                            ],
+                            network=[
+                                dict(
+                                    address="192.0.3.1", mask="255.255.255.0"
+                                ),
+                                dict(
+                                    address="192.0.2.1", mask="255.255.255.0"
+                                ),
+                                dict(
+                                    address="192.0.4.1", mask="255.255.255.0"
+                                ),
+                            ],
+                        )
+                    ],
+                ),
+                state="merged",
+            )
+        )
+        commands = [
+            "router bgp 65000",
+            "address-family ipv4",
+            "neighbor 192.31.39.212 activate",
+            "neighbor 192.31.39.212 soft-reconfiguration inbound",
+            "neighbor 192.31.47.206 activate",
+            "neighbor 192.31.47.206 soft-reconfiguration inbound",
+            "network 192.0.3.1 mask 255.255.255.0",
+            "network 192.0.2.1 mask 255.255.255.0",
+            "network 192.0.4.1 mask 255.255.255.0",
+        ]
+        result = self.execute_module(changed=True)
+        self.assertEqual(sorted(result["commands"]), sorted(commands))
+
+    def test_ios_bgp_address_family_overridden_multiple_neighbor(self):
+        set_module_args(
+            dict(
+                config=dict(
+                    as_number="65000",
+                    address_family=[
+                        dict(
+                            afi="ipv4",
+                            neighbor=[
+                                dict(
+                                    address="192.31.39.212",
+                                    soft_reconfiguration=True,
+                                    activate=True,
+                                ),
+                                dict(
+                                    address="192.31.47.206",
+                                    soft_reconfiguration=True,
+                                    activate=True,
+                                ),
+                            ],
+                            network=[
+                                dict(
+                                    address="192.0.3.1", mask="255.255.255.0"
+                                ),
+                                dict(
+                                    address="192.0.2.1", mask="255.255.255.0"
+                                ),
+                                dict(
+                                    address="192.0.4.1", mask="255.255.255.0"
+                                ),
+                            ],
+                        )
+                    ],
+                ),
+                state="overridden",
+            )
+        )
+        commands = [
+            "router bgp 65000",
+            "no address-family ipv4 multicast",
+            "no address-family ipv4 mdt",
+            "no address-family ipv4 multicast vrf blue",
+            "address-family ipv4",
+            "neighbor 192.31.39.212 activate",
+            "neighbor 192.31.39.212 soft-reconfiguration inbound",
+            "neighbor 192.31.47.206 activate",
+            "neighbor 192.31.47.206 soft-reconfiguration inbound",
+            "network 192.0.3.1 mask 255.255.255.0",
+            "network 192.0.2.1 mask 255.255.255.0",
+            "network 192.0.4.1 mask 255.255.255.0",
+        ]
+        result = self.execute_module(changed=True)
+        self.assertEqual(sorted(result["commands"]), sorted(commands))

--- a/tests/unit/modules/network/ios/test_ios_bgp_address_family.py
+++ b/tests/unit/modules/network/ios/test_ios_bgp_address_family.py
@@ -56,7 +56,7 @@ class TestIosBgpAddressFamilyModule(TestIosModule):
 
         self.mock_execute_show_command = patch(
             "ansible_collections.cisco.ios.plugins.module_utils.network.ios.facts.bgp_address_family.bgp_address_family."
-            "Bgp_AddressFamilyFacts.get_bgp_address_family_data"
+            "Bgp_address_familyFacts.get_bgp_address_family_data"
         )
         self.execute_show_command = self.mock_execute_show_command.start()
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

closing #422 #392 

- fix BGP address family to support multiple neighbors
- Inconsistent naming of class in the module fixed as per cli_rm_builders rule

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
bgp_address_family
