### PR TITLE
Support to sd-wan terminal init commands

### DIFF
--- a/changelogs/fragments/sd_wan_support.yaml
+++ b/changelogs/fragments/sd_wan_support.yaml
@@ -1,3 +1,3 @@
 ---
-bugfixes:
+minor_changes:
   - Terminal plugin to support IOS device running in SD-WAN mode.

--- a/changelogs/fragments/sd_wan_support.yaml
+++ b/changelogs/fragments/sd_wan_support.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Terminal plugin to support IOS device running in SD-WAN mode.

--- a/plugins/terminal/ios.py
+++ b/plugins/terminal/ios.py
@@ -79,7 +79,7 @@ class TerminalModule(TerminalBase):
         return int(prompt.group(1))
 
     def on_open_shell(self):
-        _is_sdWan = False
+        _is_sdWan = False  # initialize to false for default IOS execution
         try:
             self._exec_cli_command(b"terminal length 0")
         except AnsibleConnectionFailure:
@@ -88,29 +88,25 @@ class TerminalModule(TerminalBase):
                     b"screen-length 0"
                 )  # support to SD-WAN mode
                 _is_sdWan = True
-            except AnsibleConnectionFailure:
+            except AnsibleConnectionFailure:  # fails as length required for handling prompt
                 raise AnsibleConnectionFailure(
                     "unable to set terminal parameters"
                 )
-
         try:
-            self._exec_cli_command(b"terminal width 512")
-            try:
-                self._exec_cli_command(b"terminal width 0")
-            except AnsibleConnectionFailure:
-                pass
+            if _is_sdWan:
+                self._exec_cli_command(
+                    b"screen-width 512"
+                )  # support to SD-WAN mode
+            else:
+                self._exec_cli_command(b"terminal width 512")
+                try:
+                    self._exec_cli_command(b"terminal width 0")
+                except AnsibleConnectionFailure:
+                    pass
         except AnsibleConnectionFailure:
             display.display(
-                "WARNING: Unable to set terminal width, command responses may be truncated"
+                "WARNING: Unable to set terminal/screen width, command responses may be truncated"
             )
-
-        if _is_sdWan:
-            try:
-                self._exec_cli_command(b"screen-width 512")
-            except AnsibleConnectionFailure:
-                display.display(
-                    "WARNING: Unable to set screen width, command responses may be truncated"
-                )
 
     def on_become(self, passwd=None):
         if (


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
devices in the sd-wan mode were unable to handle the `"terminal length 0"` command

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Closing #349

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
/ios/plugins/terminal/ios.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```json
fatal: [10.10.20.90]: FAILED! => {
    "changed": false,
    "invocation": {
        "module_args": {
            "commands": [
                "request execute mkdir backups"
            ],
            "interval": 1,
            "match": "all",
            "provider": null,
            "retries": 10,
            "wait_for": null
        }
    },
    "msg": "unable to set terminal parameters"
}
```

fixed as - 
```json
ok: [10.10.20.90] => {
    "changed": false,
    "invocation": {
        "module_args": {
            "commands": [
                "request execute mkdir backups"
            ],
            "interval": 1,
            "match": "all",
            "provider": null,
            "retries": 10,
            "wait_for": null
        }
    },
    "stdout": [
        ""
    ],
    "stdout_lines": [
        [
            ""
        ]
    ]
}
```
```json
ok: [10.10.20.90] => {
    "changed": false,
    "invocation": {
        "module_args": {
            "commands": [
                "request execute mkdir backups"
            ],
            "interval": 1,
            "match": "all",
            "provider": null,
            "retries": 10,
            "wait_for": null
        }
    },
    "stdout": [
        "mkdir: cannot create directory 'backups': File exists"
    ],
    "stdout_lines": [
        [
            "mkdir: cannot create directory 'backups': File exists"
        ]
    ]
}
```
