### PR TITLE
2.13 sanity fixes

### DIFF
--- a/changelogs/fragments/sanity-213.yaml
+++ b/changelogs/fragments/sanity-213.yaml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - Remove python26 skips from ignore-2.13 as those tests no longer run

--- a/tests/sanity/ignore-2.13.txt
+++ b/tests/sanity/ignore-2.13.txt
@@ -1,23 +1,3 @@
 plugins/action/ios.py action-plugin-docs # base class for deprecated network platform modules using `connection: local`
-plugins/module_utils/network/ios/config/bgp_global/bgp_global.py compile-2.6!skip
-plugins/module_utils/network/ios/config/bgp_address_family/bgp_address_family.py compile-2.6!skip
-plugins/module_utils/network/ios/config/ospf_interfaces/ospf_interfaces.py compile-2.6!skip
-plugins/module_utils/network/ios/config/ospfv3/ospfv3.py compile-2.6!skip
-plugins/module_utils/network/ios/config/route_maps/route_maps.py compile-2.6!skip
-plugins/module_utils/network/ios/config/logging_global/logging_global.py compile-2.6!skip
-plugins/module_utils/network/ios/config/ntp_global/ntp_global.py compile-2.6!skip
-plugins/module_utils/network/ios/config/prefix_lists/prefix_lists.py compile-2.6!skip
-plugins/modules/ios_route_maps.py import-2.6!skip
-plugins/modules/ios_logging_global.py import-2.6!skip
-plugins/modules/ios_prefix_lists.py import-2.6!skip
-plugins/modules/ios_bgp_address_family.py import-2.6!skip
-plugins/module_utils/network/ios/config/bgp_global/bgp_global.py import-2.6!skip
-plugins/module_utils/network/ios/config/bgp_address_family/bgp_address_family.py import-2.6!skip
-plugins/module_utils/network/ios/config/ospf_interfaces/ospf_interfaces.py import-2.6!skip
-plugins/module_utils/network/ios/config/ospfv3/ospfv3.py import-2.6!skip
-plugins/module_utils/network/ios/config/route_maps/route_maps.py import-2.6!skip
-plugins/module_utils/network/ios/config/logging_global/logging_global.py import-2.6!skip
-plugins/module_utils/network/ios/config/ntp_global/ntp_global.py import-2.6!skip
-plugins/module_utils/network/ios/config/prefix_lists/prefix_lists.py import-2.6!skip
 plugins/cliconf/ios.py pylint:arguments-renamed
 tests/unit/mock/loader.py pylint:arguments-renamed


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Depends-on: https://github.com/ansible/ansible-zuul-jobs/pull/1143
https://github.com/ansible-collections/cisco.ios/pull/432 identified this issue, but as that PR is not meant to be merged, this will actually fix the failures

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test Pull Request

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
2021-10-01 14:01:07.484756 | centos-8-stream | Running sanity test "ignores"
2021-10-01 14:01:07.484837 | centos-8-stream | ERROR: Found 20 ignores issue(s) which need to be resolved:
2021-10-01 14:01:07.484961 | centos-8-stream | ERROR: tests/sanity/ignore-2.13.txt:2:66: Sanity test 'compile-2.6' does not exist
2021-10-01 14:01:07.484985 | centos-8-stream | ERROR: tests/sanity/ignore-2.13.txt:3:82: Sanity test 'compile-2.6' does not exist
2021-10-01 14:01:07.484993 | centos-8-stream | ERROR: tests/sanity/ignore-2.13.txt:4:76: Sanity test 'compile-2.6' does not exist
2021-10-01 14:01:07.485001 | centos-8-stream | ERROR: tests/sanity/ignore-2.13.txt:5:58: Sanity test 'compile-2.6' does not exist
2021-10-01 14:01:07.485009 | centos-8-stream | ERROR: tests/sanity/ignore-2.13.txt:6:66: Sanity test 'compile-2.6' does not exist
2021-10-01 14:01:07.485017 | centos-8-stream | ERROR: tests/sanity/ignore-2.13.txt:7:74: Sanity test 'compile-2.6' does not exist
2021-10-01 14:01:07.485029 | centos-8-stream | ERROR: tests/sanity/ignore-2.13.txt:8:66: Sanity test 'compile-2.6' does not exist
2021-10-01 14:01:07.485038 | centos-8-stream | ERROR: tests/sanity/ignore-2.13.txt:9:70: Sanity test 'compile-2.6' does not exist
2021-10-01 14:01:07.485151 | centos-8-stream | ERROR: tests/sanity/ignore-2.13.txt:10:35: Sanity test 'import-2.6' does not exist
2021-10-01 14:01:07.485174 | centos-8-stream | ERROR: tests/sanity/ignore-2.13.txt:11:39: Sanity test 'import-2.6' does not exist
2021-10-01 14:01:07.485183 | centos-8-stream | ERROR: tests/sanity/ignore-2.13.txt:12:37: Sanity test 'import-2.6' does not exist
2021-10-01 14:01:07.485190 | centos-8-stream | ERROR: tests/sanity/ignore-2.13.txt:13:43: Sanity test 'import-2.6' does not exist
2021-10-01 14:01:07.485198 | centos-8-stream | ERROR: tests/sanity/ignore-2.13.txt:14:66: Sanity test 'import-2.6' does not exist
2021-10-01 14:01:07.485206 | centos-8-stream | ERROR: tests/sanity/ignore-2.13.txt:15:82: Sanity test 'import-2.6' does not exist
2021-10-01 14:01:07.485218 | centos-8-stream | ERROR: tests/sanity/ignore-2.13.txt:16:76: Sanity test 'import-2.6' does not exist
2021-10-01 14:01:07.485226 | centos-8-stream | ERROR: tests/sanity/ignore-2.13.txt:17:58: Sanity test 'import-2.6' does not exist
2021-10-01 14:01:07.485234 | centos-8-stream | ERROR: tests/sanity/ignore-2.13.txt:18:66: Sanity test 'import-2.6' does not exist
2021-10-01 14:01:07.485315 | centos-8-stream | ERROR: tests/sanity/ignore-2.13.txt:19:74: Sanity test 'import-2.6' does not exist
2021-10-01 14:01:07.485339 | centos-8-stream | ERROR: tests/sanity/ignore-2.13.txt:20:66: Sanity test 'import-2.6' does not exist
2021-10-01 14:01:07.485352 | centos-8-stream | ERROR: tests/sanity/ignore-2.13.txt:21:70: Sanity test 'import-2.6' does not exist
```
