### PR TITLE
Five gigabit ethernet

### DIFF
--- a/changelogs/fragments/fix_fiveGigabit_name.yaml
+++ b/changelogs/fragments/fix_fiveGigabit_name.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "`ios_l2_interfaces` - fix unable to identify FiveGigabitEthernet names on facts gathering."

--- a/plugins/module_utils/network/ios/facts/l2_interfaces/l2_interfaces.py
+++ b/plugins/module_utils/network/ios/facts/l2_interfaces/l2_interfaces.py
@@ -99,6 +99,7 @@ class L2_InterfacesFacts(object):
         if intf.upper()[:2] in (
             "HU",
             "FO",
+            "FI",
             "TW",
             "TE",
             "GI",

--- a/plugins/module_utils/network/ios/ios.py
+++ b/plugins/module_utils/network/ios/ios.py
@@ -178,6 +178,8 @@ def normalize_interface(name):
         if_type = "FastEthernet"
     elif name.lower().startswith("fo"):
         if_type = "FortyGigabitEthernet"
+    elif name.lower().startswith("fi"):
+        if_type = "FiveGigabitEthernet"
     elif name.lower().startswith("et"):
         if_type = "Ethernet"
     elif name.lower().startswith("vl"):

--- a/plugins/module_utils/network/ios/utils/utils.py
+++ b/plugins/module_utils/network/ios/utils/utils.py
@@ -316,6 +316,8 @@ def normalize_interface(name):
         if_type = "FastEthernet"
     elif name.lower().startswith("fo"):
         if_type = "FortyGigabitEthernet"
+    elif name.lower().startswith("fi"):
+        if_type = "FiveGigabitEthernet"
     elif name.lower().startswith("long"):
         if_type = "LongReachEthernet"
     elif name.lower().startswith("et"):
@@ -367,6 +369,8 @@ def get_interface_type(interface):
         return "FastEthernet"
     elif interface.upper().startswith("FO"):
         return "FortyGigabitEthernet"
+    elif interface.upper().startswith("FI"):
+        return "FiveGigabitEthernet"
     elif interface.upper().startswith("LON"):
         return "LongReachEthernet"
     elif interface.upper().startswith("ET"):

--- a/plugins/modules/ios_l2_interface.py
+++ b/plugins/modules/ios_l2_interface.py
@@ -187,6 +187,7 @@ def get_interface_type(interface):
         "FA",
         "TE",
         "FO",
+        "FI",
         "HU",
         "TWE",
         "TW",

--- a/tests/unit/modules/network/ios/test_ios_l2_interfaces.py
+++ b/tests/unit/modules/network/ios/test_ios_l2_interfaces.py
@@ -486,3 +486,23 @@ class TestIosL2InterfacesModule(TestIosModule):
         ]
         result = self.execute_module(changed=True)
         self.assertEqual(result["commands"], commands)
+
+    def test_ios_l2_interfaces_fiveGibBit(self):
+        set_module_args(
+            dict(
+                config=[
+                    dict(
+                        access=dict(vlan=20),
+                        mode="trunk",
+                        name="FiveGigabitEthernet1/0/1",
+                    )
+                ],
+                state="merged",
+            )
+        )
+        commands = [
+            "interface FiveGigabitEthernet1/0/1",
+            "switchport mode trunk",
+        ]
+        result = self.execute_module(changed=True)
+        self.assertEqual(result["commands"], commands)

--- a/tests/unit/modules/network/ios/test_ios_l2_interfaces.py
+++ b/tests/unit/modules/network/ios/test_ios_l2_interfaces.py
@@ -502,6 +502,7 @@ class TestIosL2InterfacesModule(TestIosModule):
         )
         commands = [
             "interface FiveGigabitEthernet1/0/1",
+            "switchport access vlan 20",
             "switchport mode trunk",
         ]
         result = self.execute_module(changed=True)


### PR DESCRIPTION
##### SUMMARY

Allows ios_facts to collect l2_interface information for FiveGigabitEthernet interfaces on Cisco Catalyst 9300 mGig switches.

Fixes #442

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

ios_facts

##### ADDITIONAL INFORMATION

Before change: 

```json
{
  "ansible_facts": {
      "ansible_network_resources": {
          "l2_interfaces": [
              {
                  "name": "GigabitEthernet0/0"
              },
              {
                  "name": "GigabitEthernet1/1/1"
              },
              {
                  "name": "GigabitEthernet1/1/2"
              },
              {
                  "name": "GigabitEthernet1/1/3"
              },
              {
                  "name": "GigabitEthernet1/1/4"
              }
          ]
      }
  }
}
```

After change:
```json
{
    "ansible_facts": {
        "ansible_network_resources": {
            "l2_interfaces": [
                {
                    "name": "GigabitEthernet0/0"
                },
                {
                    "name": "GigabitEthernet1/1/1"
                },
                {
                    "name": "GigabitEthernet1/1/2"
                },
                {
                    "name": "GigabitEthernet1/1/3"
                },
                {
                    "name": "GigabitEthernet1/1/4"
                },
                {
                    "name": "FiveGigabitEthernet1/0/1"
                },
                {
                    "name": "FiveGigabitEthernet1/0/10"
                },
                {
                    "name": "FiveGigabitEthernet1/0/11"
                },
                {
                    "name": "FiveGigabitEthernet1/0/12"
                }
            ]
        }
    }
}
```
