### PR TITLE
static_routes unable to render Interfaces in facts properly

### DIFF
--- a/changelogs/fragments/static_route_interface_issue.yaml
+++ b/changelogs/fragments/static_route_interface_issue.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "`ios_static_routes` - Fixes static routes unable to identify interface names when supplied with destination attribute."

--- a/plugins/module_utils/network/ios/config/static_routes/static_routes.py
+++ b/plugins/module_utils/network/ios/config/static_routes/static_routes.py
@@ -167,7 +167,7 @@ class Static_Routes(ConfigBase):
 
         commands = []
 
-        # Drill each iteration of want n have and then based on dest and afi tyoe comparison take config call
+        # Drill each iteration of want n have and then based on dest and afi type comparison take config call
         for w in want:
             for addr_want in w.get("address_families"):
                 for route_want in addr_want.get("routes"):
@@ -294,7 +294,7 @@ class Static_Routes(ConfigBase):
         # performed during override want n have comparison
         temp_want = copy.deepcopy(want)
 
-        # Drill each iteration of want n have and then based on dest and afi tyoe comparison take config call
+        # Drill each iteration of want n have and then based on dest and afi type comparison take config call
         for h in have:
             if h.get("address_families"):
                 for addr_have in h.get("address_families"):
@@ -387,7 +387,7 @@ class Static_Routes(ConfigBase):
         """
         commands = []
 
-        # Drill each iteration of want n have and then based on dest and afi tyoe comparison take config call
+        # Drill each iteration of want n have and then based on dest and afi type comparison take config call
         for w in want:
             for addr_want in w.get("address_families"):
                 for route_want in addr_want.get("routes"):

--- a/plugins/module_utils/network/ios/facts/static_routes/static_routes.py
+++ b/plugins/module_utils/network/ios/facts/static_routes/static_routes.py
@@ -50,9 +50,7 @@ class Static_RoutesFacts(object):
         self.generated_spec = utils.generate_dict(facts_argument_spec)
 
     def get_static_routes_data(self, connection):
-        return connection.get(
-            "sh running-config | section ^ip route|ipv6 route"
-        )
+        return connection.get("sh running-config | section ^ip route|ipv6 route")
 
     def populate_facts(self, connection, ansible_facts, data=None):
         """ Populate the facts for static_routes
@@ -72,9 +70,7 @@ class Static_RoutesFacts(object):
         same_dest = self.populate_destination(config)
         for key in same_dest.keys():
             if key:
-                obj = self.render_config(
-                    self.generated_spec, key, same_dest[key]
-                )
+                obj = self.render_config(self.generated_spec, key, same_dest[key])
                 if obj:
                     objs.append(obj)
         facts = {}
@@ -94,9 +90,7 @@ class Static_RoutesFacts(object):
 
         if objs:
             facts["static_routes"] = []
-            params = utils.validate_config(
-                self.argument_spec, {"config": objs}
-            )
+            params = utils.validate_config(self.argument_spec, {"config": objs})
             for cfg in params["config"]:
                 facts["static_routes"].append(utils.remove_empties(cfg))
         ansible_facts["ansible_network_resources"].update(facts)
@@ -144,9 +138,7 @@ class Static_RoutesFacts(object):
                         same_dest[dest_vrf].append(("vrf " + filter_vrf))
                 else:
                     filter_non_vrf = utils.parse_conf_arg(i, ip_str)
-                    if (
-                        "::" not in filter_non_vrf
-                    ):  # "/" not in filter_non_vrf and
+                    if "::" not in filter_non_vrf:  # "/" not in filter_non_vrf and
                         filter_non_vrf, dest = self.update_netmask_to_cidr(
                             filter_non_vrf, 0, 1
                         )
@@ -184,11 +176,14 @@ class Static_RoutesFacts(object):
         address_family = dict()
         for each in conf_val:
             route = each.split(" ")
+            len_route = len(route)
+
             if "vrf" in conf_val[0]:
                 vrf = route[route.index("vrf") + 1]
                 route_dict["dest"] = conf.split("_")[0]
             else:
                 route_dict["dest"] = conf
+
             if "vrf" in conf_val[0]:
                 hops = {}
                 if "::" in conf:
@@ -201,10 +196,9 @@ class Static_RoutesFacts(object):
                     else:
                         hops["interface"] = route[3]
                         afi["afi"] = "ipv4"
-                        if is_valid_ip(route[4]):
+                        if len_route >= 5 and is_valid_ip(route[4]):
                             hops["forward_router_address"] = route[4]
             else:
-
                 if "::" in conf:
                     if is_valid_ip(route[1]):
                         hops["forward_router_address"] = route[1]
@@ -221,8 +215,9 @@ class Static_RoutesFacts(object):
                     else:
                         hops["interface"] = route[1]
                         afi["afi"] = "ipv4"
-                        if is_valid_ip(route[2]):
+                        if len_route >= 3 and is_valid_ip(route[2]):
                             hops["forward_router_address"] = route[2]
+
             try:
                 temp_list = each.split(" ")
                 if "tag" in temp_list:

--- a/plugins/module_utils/network/ios/facts/static_routes/static_routes.py
+++ b/plugins/module_utils/network/ios/facts/static_routes/static_routes.py
@@ -50,7 +50,9 @@ class Static_RoutesFacts(object):
         self.generated_spec = utils.generate_dict(facts_argument_spec)
 
     def get_static_routes_data(self, connection):
-        return connection.get("sh running-config | section ^ip route|ipv6 route")
+        return connection.get(
+            "sh running-config | section ^ip route|ipv6 route"
+        )
 
     def populate_facts(self, connection, ansible_facts, data=None):
         """ Populate the facts for static_routes
@@ -70,7 +72,9 @@ class Static_RoutesFacts(object):
         same_dest = self.populate_destination(config)
         for key in same_dest.keys():
             if key:
-                obj = self.render_config(self.generated_spec, key, same_dest[key])
+                obj = self.render_config(
+                    self.generated_spec, key, same_dest[key]
+                )
                 if obj:
                     objs.append(obj)
         facts = {}
@@ -90,7 +94,9 @@ class Static_RoutesFacts(object):
 
         if objs:
             facts["static_routes"] = []
-            params = utils.validate_config(self.argument_spec, {"config": objs})
+            params = utils.validate_config(
+                self.argument_spec, {"config": objs}
+            )
             for cfg in params["config"]:
                 facts["static_routes"].append(utils.remove_empties(cfg))
         ansible_facts["ansible_network_resources"].update(facts)
@@ -138,7 +144,9 @@ class Static_RoutesFacts(object):
                         same_dest[dest_vrf].append(("vrf " + filter_vrf))
                 else:
                     filter_non_vrf = utils.parse_conf_arg(i, ip_str)
-                    if "::" not in filter_non_vrf:  # "/" not in filter_non_vrf and
+                    if (
+                        "::" not in filter_non_vrf
+                    ):  # "/" not in filter_non_vrf and
                         filter_non_vrf, dest = self.update_netmask_to_cidr(
                             filter_non_vrf, 0, 1
                         )

--- a/tests/unit/modules/network/ios/fixtures/ios_static_routes_config.cfg
+++ b/tests/unit/modules/network/ios/fixtures/ios_static_routes_config.cfg
@@ -1,5 +1,0 @@
-ip route vrf ansible_vrf 0.0.0.0 0.0.0.0 198.51.101.1 name test_vrf_1 track 150 tag 100
-ip route vrf ansible_vrf 192.0.2.0 255.255.255.0 192.0.2.1 name test_vrf_2 track 175 tag 50
-ip route vrf ansible_vrf 192.51.110.0 255.255.255.255 GigabitEthernet0/2 192.51.111.1 10 name partner
-ip route 198.51.100.0 255.255.255.0 198.51.101.1 110 multicast name route_1 tag 60
-ipv6 route 2001:DB8:0:3::/64 GigabitEthernet0/2 2001:DB8:0:3::2 tag 105 name test_v6

--- a/tests/unit/modules/network/ios/test_ios_static_routes.py
+++ b/tests/unit/modules/network/ios/test_ios_static_routes.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
+from textwrap import dedent
 from ansible_collections.cisco.ios.tests.unit.compat.mock import patch
 from ansible_collections.cisco.ios.plugins.modules import ios_static_routes
 from ansible_collections.cisco.ios.tests.unit.modules.utils import (
@@ -67,13 +68,31 @@ class TestIosStaticRoutesModule(TestIosModule):
         self.mock_load_config.stop()
         self.mock_execute_show_command.stop()
 
-    def load_fixtures(self, commands=None, transport="cli"):
-        def load_from_file(*args, **kwargs):
-            return load_fixture("ios_static_routes_config.cfg")
+    # def load_fixtures(self, commands=None, transport="cli"):
+    #     # def load_from_file(*args, **kwargs):
+    #     #     return load_fixture("ios_static_routes_config.cfg")
 
-        self.execute_show_command.side_effect = load_from_file
+    #     # self.execute_show_command.side_effect = load_from_file
+    #     self.execute_show_command.return_value = dedent(
+    #         """\
+    #         ip route vrf ansible_vrf 0.0.0.0 0.0.0.0 198.51.101.1 name test_vrf_1 track 150 tag 100
+    #         ip route vrf ansible_vrf 192.0.2.0 255.255.255.0 192.0.2.1 name test_vrf_2 track 175 tag 50
+    #         ip route vrf ansible_vrf 192.51.110.0 255.255.255.255 GigabitEthernet0/2 192.51.111.1 10 name partner
+    #         ip route 198.51.100.0 255.255.255.0 198.51.101.1 110 multicast name route_1 tag 60
+    #         ipv6 route 2001:DB8:0:3::/64 GigabitEthernet0/2 2001:DB8:0:3::2 tag 105 name test_v6
+    #         """
+    #     )
 
     def test_ios_static_routes_merged(self):
+        self.execute_show_command.return_value = dedent(
+            """\
+            ip route vrf ansible_vrf 0.0.0.0 0.0.0.0 198.51.101.1 name test_vrf_1 track 150 tag 100
+            ip route vrf ansible_vrf 192.0.2.0 255.255.255.0 192.0.2.1 name test_vrf_2 track 175 tag 50
+            ip route vrf ansible_vrf 192.51.110.0 255.255.255.255 GigabitEthernet0/2 192.51.111.1 10 name partner
+            ip route 198.51.100.0 255.255.255.0 198.51.101.1 110 multicast name route_1 tag 60
+            ipv6 route 2001:DB8:0:3::/64 GigabitEthernet0/2 2001:DB8:0:3::2 tag 105 name test_v6
+            """
+        )
         set_module_args(
             dict(
                 config=[
@@ -131,6 +150,15 @@ class TestIosStaticRoutesModule(TestIosModule):
         self.assertEqual(result["commands"], commands)
 
     def test_ios_static_routes_merged_idempotent(self):
+        self.execute_show_command.return_value = dedent(
+            """\
+            ip route vrf ansible_vrf 0.0.0.0 0.0.0.0 198.51.101.1 name test_vrf_1 track 150 tag 100
+            ip route vrf ansible_vrf 192.0.2.0 255.255.255.0 192.0.2.1 name test_vrf_2 track 175 tag 50
+            ip route vrf ansible_vrf 192.51.110.0 255.255.255.255 GigabitEthernet0/2 192.51.111.1 10 name partner
+            ip route 198.51.100.0 255.255.255.0 198.51.101.1 110 multicast name route_1 tag 60
+            ipv6 route 2001:DB8:0:3::/64 GigabitEthernet0/2 2001:DB8:0:3::2 tag 105 name test_v6
+            """
+        )
         set_module_args(
             dict(
                 config=[
@@ -245,6 +273,15 @@ class TestIosStaticRoutesModule(TestIosModule):
         self.execute_module(changed=False, commands=[], sort=True)
 
     def test_ios_static_routes_replaced(self):
+        self.execute_show_command.return_value = dedent(
+            """\
+            ip route vrf ansible_vrf 0.0.0.0 0.0.0.0 198.51.101.1 name test_vrf_1 track 150 tag 100
+            ip route vrf ansible_vrf 192.0.2.0 255.255.255.0 192.0.2.1 name test_vrf_2 track 175 tag 50
+            ip route vrf ansible_vrf 192.51.110.0 255.255.255.255 GigabitEthernet0/2 192.51.111.1 10 name partner
+            ip route 198.51.100.0 255.255.255.0 198.51.101.1 110 multicast name route_1 tag 60
+            ipv6 route 2001:DB8:0:3::/64 GigabitEthernet0/2 2001:DB8:0:3::2 tag 105 name test_v6
+            """
+        )
         set_module_args(
             dict(
                 config=[
@@ -302,6 +339,15 @@ class TestIosStaticRoutesModule(TestIosModule):
         self.assertEqual(result["commands"], commands)
 
     def test_ios_static_routes_replaced_idempotent(self):
+        self.execute_show_command.return_value = dedent(
+            """\
+            ip route vrf ansible_vrf 0.0.0.0 0.0.0.0 198.51.101.1 name test_vrf_1 track 150 tag 100
+            ip route vrf ansible_vrf 192.0.2.0 255.255.255.0 192.0.2.1 name test_vrf_2 track 175 tag 50
+            ip route vrf ansible_vrf 192.51.110.0 255.255.255.255 GigabitEthernet0/2 192.51.111.1 10 name partner
+            ip route 198.51.100.0 255.255.255.0 198.51.101.1 110 multicast name route_1 tag 60
+            ipv6 route 2001:DB8:0:3::/64 GigabitEthernet0/2 2001:DB8:0:3::2 tag 105 name test_v6
+            """
+        )
         set_module_args(
             dict(
                 config=[
@@ -416,6 +462,15 @@ class TestIosStaticRoutesModule(TestIosModule):
         self.execute_module(changed=False, commands=[], sort=True)
 
     def test_ios_static_routes_overridden(self):
+        self.execute_show_command.return_value = dedent(
+            """\
+            ip route vrf ansible_vrf 0.0.0.0 0.0.0.0 198.51.101.1 name test_vrf_1 track 150 tag 100
+            ip route vrf ansible_vrf 192.0.2.0 255.255.255.0 192.0.2.1 name test_vrf_2 track 175 tag 50
+            ip route vrf ansible_vrf 192.51.110.0 255.255.255.255 GigabitEthernet0/2 192.51.111.1 10 name partner
+            ip route 198.51.100.0 255.255.255.0 198.51.101.1 110 multicast name route_1 tag 60
+            ipv6 route 2001:DB8:0:3::/64 GigabitEthernet0/2 2001:DB8:0:3::2 tag 105 name test_v6
+            """
+        )
         set_module_args(
             dict(
                 config=[
@@ -457,6 +512,15 @@ class TestIosStaticRoutesModule(TestIosModule):
         self.assertEqual(result["commands"], commands)
 
     def test_ios_static_routes_overridden_idempotent(self):
+        self.execute_show_command.return_value = dedent(
+            """\
+            ip route vrf ansible_vrf 0.0.0.0 0.0.0.0 198.51.101.1 name test_vrf_1 track 150 tag 100
+            ip route vrf ansible_vrf 192.0.2.0 255.255.255.0 192.0.2.1 name test_vrf_2 track 175 tag 50
+            ip route vrf ansible_vrf 192.51.110.0 255.255.255.255 GigabitEthernet0/2 192.51.111.1 10 name partner
+            ip route 198.51.100.0 255.255.255.0 198.51.101.1 110 multicast name route_1 tag 60
+            ipv6 route 2001:DB8:0:3::/64 GigabitEthernet0/2 2001:DB8:0:3::2 tag 105 name test_v6
+            """
+        )
         set_module_args(
             dict(
                 config=[
@@ -571,6 +635,15 @@ class TestIosStaticRoutesModule(TestIosModule):
         self.execute_module(changed=False, commands=[], sort=True)
 
     def test_ios_delete_static_route_config(self):
+        self.execute_show_command.return_value = dedent(
+            """\
+            ip route vrf ansible_vrf 0.0.0.0 0.0.0.0 198.51.101.1 name test_vrf_1 track 150 tag 100
+            ip route vrf ansible_vrf 192.0.2.0 255.255.255.0 192.0.2.1 name test_vrf_2 track 175 tag 50
+            ip route vrf ansible_vrf 192.51.110.0 255.255.255.255 GigabitEthernet0/2 192.51.111.1 10 name partner
+            ip route 198.51.100.0 255.255.255.0 198.51.101.1 110 multicast name route_1 tag 60
+            ipv6 route 2001:DB8:0:3::/64 GigabitEthernet0/2 2001:DB8:0:3::2 tag 105 name test_v6
+            """
+        )
         set_module_args(
             dict(
                 config=[
@@ -628,6 +701,15 @@ class TestIosStaticRoutesModule(TestIosModule):
         self.assertEqual(result["commands"], commands)
 
     def test_ios_delete_static_route_dest_based(self):
+        self.execute_show_command.return_value = dedent(
+            """\
+            ip route vrf ansible_vrf 0.0.0.0 0.0.0.0 198.51.101.1 name test_vrf_1 track 150 tag 100
+            ip route vrf ansible_vrf 192.0.2.0 255.255.255.0 192.0.2.1 name test_vrf_2 track 175 tag 50
+            ip route vrf ansible_vrf 192.51.110.0 255.255.255.255 GigabitEthernet0/2 192.51.111.1 10 name partner
+            ip route 198.51.100.0 255.255.255.0 198.51.101.1 110 multicast name route_1 tag 60
+            ipv6 route 2001:DB8:0:3::/64 GigabitEthernet0/2 2001:DB8:0:3::2 tag 105 name test_v6
+            """
+        )
         set_module_args(
             dict(
                 config=[
@@ -650,6 +732,15 @@ class TestIosStaticRoutesModule(TestIosModule):
         self.assertEqual(result["commands"], commands)
 
     def test_ios_delete_static_route_vrf_based(self):
+        self.execute_show_command.return_value = dedent(
+            """\
+            ip route vrf ansible_vrf 0.0.0.0 0.0.0.0 198.51.101.1 name test_vrf_1 track 150 tag 100
+            ip route vrf ansible_vrf 192.0.2.0 255.255.255.0 192.0.2.1 name test_vrf_2 track 175 tag 50
+            ip route vrf ansible_vrf 192.51.110.0 255.255.255.255 GigabitEthernet0/2 192.51.111.1 10 name partner
+            ip route 198.51.100.0 255.255.255.0 198.51.101.1 110 multicast name route_1 tag 60
+            ipv6 route 2001:DB8:0:3::/64 GigabitEthernet0/2 2001:DB8:0:3::2 tag 105 name test_v6
+            """
+        )
         set_module_args(
             dict(
                 config=[
@@ -672,6 +763,15 @@ class TestIosStaticRoutesModule(TestIosModule):
         self.assertEqual(result["commands"], commands)
 
     def test_static_route_rendered(self):
+        self.execute_show_command.return_value = dedent(
+            """\
+            ip route vrf ansible_vrf 0.0.0.0 0.0.0.0 198.51.101.1 name test_vrf_1 track 150 tag 100
+            ip route vrf ansible_vrf 192.0.2.0 255.255.255.0 192.0.2.1 name test_vrf_2 track 175 tag 50
+            ip route vrf ansible_vrf 192.51.110.0 255.255.255.255 GigabitEthernet0/2 192.51.111.1 10 name partner
+            ip route 198.51.100.0 255.255.255.0 198.51.101.1 110 multicast name route_1 tag 60
+            ipv6 route 2001:DB8:0:3::/64 GigabitEthernet0/2 2001:DB8:0:3::2 tag 105 name test_v6
+            """
+        )
         set_module_args(
             dict(
                 config=[
@@ -707,109 +807,31 @@ class TestIosStaticRoutesModule(TestIosModule):
         self.assertEqual(sorted(result["rendered"]), commands)
 
     def test_static_route_gathered(self):
+        self.execute_show_command.return_value = dedent(
+            """\
+            ip route 10.0.0.0 255.0.0.0 Null0 permanent
+            """
+        )
         set_module_args(dict(state="gathered"))
         gathered = [
             {
-                "vrf": "ansible_vrf",
                 "address_families": [
                     {
                         "afi": "ipv4",
                         "routes": [
                             {
-                                "dest": "0.0.0.0/0",
+                                "dest": "10.0.0.0/8",
                                 "next_hops": [
-                                    {
-                                        "forward_router_address": "198.51.101.1",
-                                        "name": "test_vrf_1",
-                                        "tag": 100,
-                                        "track": 150,
-                                    }
+                                    {"interface": "Null0", "permanent": True}
                                 ],
                             }
                         ],
                     }
-                ],
-            },
-            {
-                "vrf": "ansible_vrf",
-                "address_families": [
-                    {
-                        "afi": "ipv4",
-                        "routes": [
-                            {
-                                "dest": "192.0.2.0/24",
-                                "next_hops": [
-                                    {
-                                        "forward_router_address": "192.0.2.1",
-                                        "name": "test_vrf_2",
-                                        "tag": 50,
-                                        "track": 175,
-                                    }
-                                ],
-                            }
-                        ],
-                    }
-                ],
-            },
-            {
-                "vrf": "ansible_vrf",
-                "address_families": [
-                    {
-                        "afi": "ipv4",
-                        "routes": [
-                            {
-                                "dest": "192.51.110.0/32",
-                                "next_hops": [
-                                    {
-                                        "interface": "GigabitEthernet0/2",
-                                        "forward_router_address": "192.51.111.1",
-                                        "distance_metric": 10,
-                                        "name": "partner",
-                                    }
-                                ],
-                            }
-                        ],
-                    }
-                ],
-            },
-            {
-                "address_families": [
-                    {
-                        "afi": "ipv4",
-                        "routes": [
-                            {
-                                "dest": "198.51.100.0/24",
-                                "next_hops": [
-                                    {
-                                        "forward_router_address": "198.51.101.1",
-                                        "distance_metric": 110,
-                                        "name": "route_1",
-                                        "multicast": True,
-                                        "tag": 60,
-                                    }
-                                ],
-                            }
-                        ],
-                    },
-                    {
-                        "afi": "ipv6",
-                        "routes": [
-                            {
-                                "dest": "2001:DB8:0:3::/64",
-                                "next_hops": [
-                                    {
-                                        "interface": "GigabitEthernet0/2",
-                                        "forward_router_address": "2001:DB8:0:3::2",
-                                        "name": "test_v6",
-                                        "tag": 105,
-                                    }
-                                ],
-                            }
-                        ],
-                    },
                 ]
-            },
+            }
         ]
         result = self.execute_module(changed=False)
         self.maxDiff = None
+        print(result["gathered"])
         self.assertEqual(sorted(result["gathered"]), sorted(gathered))
+        # self.assertEqual(result["gathered"], gathered)

--- a/tests/unit/modules/network/ios/test_ios_static_routes.py
+++ b/tests/unit/modules/network/ios/test_ios_static_routes.py
@@ -705,3 +705,111 @@ class TestIosStaticRoutesModule(TestIosModule):
         ]
         result = self.execute_module(changed=False)
         self.assertEqual(sorted(result["rendered"]), commands)
+
+    def test_static_route_gathered(self):
+        set_module_args(dict(state="gathered"))
+        gathered = [
+            {
+                "vrf": "ansible_vrf",
+                "address_families": [
+                    {
+                        "afi": "ipv4",
+                        "routes": [
+                            {
+                                "dest": "0.0.0.0/0",
+                                "next_hops": [
+                                    {
+                                        "forward_router_address": "198.51.101.1",
+                                        "name": "test_vrf_1",
+                                        "tag": 100,
+                                        "track": 150,
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            },
+            {
+                "vrf": "ansible_vrf",
+                "address_families": [
+                    {
+                        "afi": "ipv4",
+                        "routes": [
+                            {
+                                "dest": "192.0.2.0/24",
+                                "next_hops": [
+                                    {
+                                        "forward_router_address": "192.0.2.1",
+                                        "name": "test_vrf_2",
+                                        "tag": 50,
+                                        "track": 175,
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            },
+            {
+                "vrf": "ansible_vrf",
+                "address_families": [
+                    {
+                        "afi": "ipv4",
+                        "routes": [
+                            {
+                                "dest": "192.51.110.0/32",
+                                "next_hops": [
+                                    {
+                                        "interface": "GigabitEthernet0/2",
+                                        "forward_router_address": "192.51.111.1",
+                                        "distance_metric": 10,
+                                        "name": "partner",
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            },
+            {
+                "address_families": [
+                    {
+                        "afi": "ipv4",
+                        "routes": [
+                            {
+                                "dest": "198.51.100.0/24",
+                                "next_hops": [
+                                    {
+                                        "forward_router_address": "198.51.101.1",
+                                        "distance_metric": 110,
+                                        "name": "route_1",
+                                        "multicast": True,
+                                        "tag": 60,
+                                    }
+                                ],
+                            }
+                        ],
+                    },
+                    {
+                        "afi": "ipv6",
+                        "routes": [
+                            {
+                                "dest": "2001:DB8:0:3::/64",
+                                "next_hops": [
+                                    {
+                                        "interface": "GigabitEthernet0/2",
+                                        "forward_router_address": "2001:DB8:0:3::2",
+                                        "name": "test_v6",
+                                        "tag": 105,
+                                    }
+                                ],
+                            }
+                        ],
+                    },
+                ]
+            },
+        ]
+        result = self.execute_module(changed=False)
+        self.maxDiff = None
+        self.assertEqual(sorted(result["gathered"]), sorted(gathered))

--- a/tests/unit/modules/network/ios/test_ios_static_routes.py
+++ b/tests/unit/modules/network/ios/test_ios_static_routes.py
@@ -13,7 +13,7 @@ from ansible_collections.cisco.ios.plugins.modules import ios_static_routes
 from ansible_collections.cisco.ios.tests.unit.modules.utils import (
     set_module_args,
 )
-from .ios_module import TestIosModule, load_fixture
+from .ios_module import TestIosModule
 
 
 class TestIosStaticRoutesModule(TestIosModule):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
static_routes was unable to determine the interface names with it was supplied within the destination
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios_static_routes
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
