### PR TITLE
vlan bugfix | parsing range | parsing space in name |

### DIFF
--- a/changelogs/fragments/fix_vlan.yaml
+++ b/changelogs/fragments/fix_vlan.yaml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - "`ios_vlans` - fix parsing of VLAN names with spaces."
+  - "`ios_vlans` - fix parsing of VLAN ranges under remote span."

--- a/plugins/module_utils/network/ios/facts/vlans/vlans.py
+++ b/plugins/module_utils/network/ios/facts/vlans/vlans.py
@@ -159,7 +159,7 @@ class VlansFacts(object):
                 config["name"] += " " + conf[i]
             try:
                 if len(conf[state_idx].split("/")) > 1:
-                    _state = len(conf[state_idx].split("/"))[0]
+                    _state = conf[state_idx].split("/")[0]
                     if _state == "sus":
                         config["state"] = "suspend"
                     elif _state == "act":

--- a/plugins/module_utils/network/ios/facts/vlans/vlans.py
+++ b/plugins/module_utils/network/ios/facts/vlans/vlans.py
@@ -148,17 +148,27 @@ class VlansFacts(object):
             conf = list(filter(None, conf.split(" ")))
             config["vlan_id"] = int(conf[0])
             config["name"] = conf[1]
+            state_idx = 2
+            for i in range(2, len(conf)):  # check for index where state starts
+                if conf[i] in ["suspended", "active"]:
+                    state_idx = i
+                    break
+                elif conf[i].split("/")[0] in ["sus", "act"]:
+                    state_idx = i
+                    break
+                config["name"] += " " + conf[i]
             try:
-                if len(conf[2].split("/")) > 1:
-                    if conf[2].split("/")[0] == "sus":
+                if len(conf[state_idx].split("/")) > 1:
+                    _state = len(conf[state_idx].split("/"))[0]
+                    if _state == "sus":
                         config["state"] = "suspend"
-                    elif conf[2].split("/")[0] == "act":
+                    elif _state == "act":
                         config["state"] = "active"
                     config["shutdown"] = "enabled"
                 else:
-                    if conf[2] == "suspended":
+                    if conf[state_idx] == "suspended":
                         config["state"] = "suspend"
-                    elif conf[2] == "active":
+                    elif conf[state_idx] == "active":
                         config["state"] = "active"
                     config["shutdown"] = "disabled"
             except IndexError:
@@ -175,7 +185,14 @@ class VlansFacts(object):
                     remote_span_vlan.append(conf)
                 remote_span = []
                 for each in remote_span_vlan:
-                    remote_span.append(int(each))
+                    split_sp_list = each.split("-")
+                    if len(split_sp_list) > 1:  # break range
+                        for r_sp in range(
+                            int(split_sp_list[0]), int(split_sp_list[1]) + 1
+                        ):
+                            remote_span.append(r_sp)
+                    else:
+                        remote_span.append(int(each))
                 config["remote_span"] = remote_span
 
         return utils.remove_empties(config)

--- a/tests/unit/modules/network/ios/test_ios_vlans.py
+++ b/tests/unit/modules/network/ios/test_ios_vlans.py
@@ -12,8 +12,7 @@ from ansible_collections.cisco.ios.plugins.modules import ios_vlans
 from ansible_collections.cisco.ios.tests.unit.modules.utils import (
     set_module_args,
 )
-from .ios_module import TestIosModule
-from textwrap import dedent
+from .ios_module import TestIosModule, load_fixture
 
 
 class TestIosVlansModule(TestIosModule):
@@ -73,57 +72,14 @@ class TestIosVlansModule(TestIosModule):
         self.mock_execute_show_command.stop()
         self.mock_l2_device_command.stop()
 
-    # def load_fixtures(self, commands=None, transport="cli"):
-    #     def load_from_file(*args, **kwargs):
-    #         return load_fixture("ios_vlans_config.cfg")
+    def load_fixtures(self, commands=None, transport="cli"):
+        def load_from_file(*args, **kwargs):
+            return load_fixture("ios_vlans_config.cfg")
 
-    #     self.mock_l2_device_command.side_effect = True
-    #     self.execute_show_command.side_effect = load_from_file
+        self.mock_l2_device_command.side_effect = True
+        self.execute_show_command.side_effect = load_from_file
 
     def test_ios_vlans_merged(self):
-        self.mock_l2_device_command.side_effect = True
-        self.execute_show_command.side_effect = dedent(
-            """\
-            VLAN Name                             Status    Ports
-            ---- -------------------------------- --------- -------------------------------
-            1    default                          active    Gi0/1, Gi0/2
-            123  RemoteIsInMyName                 act/unsup Fa0/1, Fa0/4, Fa0/5, Fa0/6, Fa0/7, Fa0/8, Fa0/9, Fa0/10, Fa0/11, Fa0/12
-                                                            Fa0/13, Fa0/14, Fa0/15, Fa0/16, Fa0/17, Fa0/18, Fa0/19, Fa0/20, Fa0/21
-                                                            Fa0/22, Fa0/23, Fa0/24, Fa0/25, Fa0/26, Fa0/27, Fa0/28, Fa0/29, Fa0/30
-                                                            Fa0/31, Fa0/32, Fa0/33, Fa0/34, Fa0/35, Fa0/36, Fa0/37, Fa0/38, Fa0/39
-                                                            Fa0/40, Fa0/41, Fa0/42, Fa0/43, Fa0/44, Fa0/45, Fa0/46, Fa0/47, Fa0/48
-            150  VLAN0150                         active
-            888  a_very_long_vlan_name_a_very_long_vlan_name
-                                                active
-            1002 fddi-default                     act/unsup
-            1003 trcrf-default                    act/unsup
-            1004 fddinet-default                  act/unsup
-            1005 trbrf-default                    act/unsup
-
-            VLAN Type  SAID       MTU   Parent RingNo BridgeNo Stp  BrdgMode Trans1 Trans2
-            ---- ----- ---------- ----- ------ ------ -------- ---- -------- ------ ------
-            1    enet  100001     1500  -      -      -        -    -        0      0
-            123  enet  100123     610   -      -      -        -    -        0      0
-            150  enet  100150     1500  -      -      -        -    -        0      0
-            888  enet  100888     1500  -      -      -        -    -        0      0
-            1002 fddi  101002     1500  -      -      -        -    -        0      0
-            1003 trcrf 101003     4472  1005   3276   -        -    srb      0      0
-            1004 fdnet 101004     1500  -      -      -        ieee -        0      0
-            1005 trbrf 101005     4472  -      -      15       ibm  -        0      0
-
-
-            VLAN AREHops STEHops Backup CRF
-            ---- ------- ------- ----------
-            1003 7       7       off
-
-            Remote SPAN VLANs
-            ------------------------------------------------------------------------------
-            150
-
-            Primary Secondary Type              Ports
-            ------- --------- ----------------- ------------------------------------------
-            """
-        )
         set_module_args(
             dict(
                 config=[
@@ -149,49 +105,6 @@ class TestIosVlansModule(TestIosModule):
         self.assertEqual(result["commands"], commands)
 
     def test_ios_vlans_merged_idempotent(self):
-        self.mock_l2_device_command.side_effect = True
-        self.execute_show_command.side_effect = dedent(
-            """\
-            VLAN Name                             Status    Ports
-            ---- -------------------------------- --------- -------------------------------
-            1    default                          active    Gi0/1, Gi0/2
-            123  RemoteIsInMyName                 act/unsup Fa0/1, Fa0/4, Fa0/5, Fa0/6, Fa0/7, Fa0/8, Fa0/9, Fa0/10, Fa0/11, Fa0/12
-                                                            Fa0/13, Fa0/14, Fa0/15, Fa0/16, Fa0/17, Fa0/18, Fa0/19, Fa0/20, Fa0/21
-                                                            Fa0/22, Fa0/23, Fa0/24, Fa0/25, Fa0/26, Fa0/27, Fa0/28, Fa0/29, Fa0/30
-                                                            Fa0/31, Fa0/32, Fa0/33, Fa0/34, Fa0/35, Fa0/36, Fa0/37, Fa0/38, Fa0/39
-                                                            Fa0/40, Fa0/41, Fa0/42, Fa0/43, Fa0/44, Fa0/45, Fa0/46, Fa0/47, Fa0/48
-            150  VLAN0150                         active
-            888  a_very_long_vlan_name_a_very_long_vlan_name
-                                                active
-            1002 fddi-default                     act/unsup
-            1003 trcrf-default                    act/unsup
-            1004 fddinet-default                  act/unsup
-            1005 trbrf-default                    act/unsup
-
-            VLAN Type  SAID       MTU   Parent RingNo BridgeNo Stp  BrdgMode Trans1 Trans2
-            ---- ----- ---------- ----- ------ ------ -------- ---- -------- ------ ------
-            1    enet  100001     1500  -      -      -        -    -        0      0
-            123  enet  100123     610   -      -      -        -    -        0      0
-            150  enet  100150     1500  -      -      -        -    -        0      0
-            888  enet  100888     1500  -      -      -        -    -        0      0
-            1002 fddi  101002     1500  -      -      -        -    -        0      0
-            1003 trcrf 101003     4472  1005   3276   -        -    srb      0      0
-            1004 fdnet 101004     1500  -      -      -        ieee -        0      0
-            1005 trbrf 101005     4472  -      -      15       ibm  -        0      0
-
-
-            VLAN AREHops STEHops Backup CRF
-            ---- ------- ------- ----------
-            1003 7       7       off
-
-            Remote SPAN VLANs
-            ------------------------------------------------------------------------------
-            150
-
-            Primary Secondary Type              Ports
-            ------- --------- ----------------- ------------------------------------------
-            """
-        )
         set_module_args(
             dict(
                 config=[
@@ -259,48 +172,6 @@ class TestIosVlansModule(TestIosModule):
         self.execute_module(changed=False, commands=[], sort=True)
 
     def test_ios_vlans_replaced(self):
-        self.mock_l2_device_command.side_effect = True
-        self.execute_show_command.side_effect = dedent(
-            """\
-            VLAN Name                             Status    Ports
-            ---- -------------------------------- --------- -------------------------------
-            1    default                          active    Gi0/1, Gi0/2
-            123  RemoteIsInMyName                 act/unsup Fa0/1, Fa0/4, Fa0/5, Fa0/6, Fa0/7, Fa0/8, Fa0/9, Fa0/10, Fa0/11, Fa0/12
-                                                            Fa0/13, Fa0/14, Fa0/15, Fa0/16, Fa0/17, Fa0/18, Fa0/19, Fa0/20, Fa0/21
-                                                            Fa0/22, Fa0/23, Fa0/24, Fa0/25, Fa0/26, Fa0/27, Fa0/28, Fa0/29, Fa0/30
-                                                            Fa0/31, Fa0/32, Fa0/33, Fa0/34, Fa0/35, Fa0/36, Fa0/37, Fa0/38, Fa0/39
-                                                            Fa0/40, Fa0/41, Fa0/42, Fa0/43, Fa0/44, Fa0/45, Fa0/46, Fa0/47, Fa0/48
-            150  VLAN0150                         active
-            888  a_very_long_vlan_name_a_very_long_vlan_name
-                                                active
-            1002 fddi-default                     act/unsup
-            1003 trcrf-default                    act/unsup
-            1004 fddinet-default                  act/unsup
-            1005 trbrf-default                    act/unsup
-
-            VLAN Type  SAID       MTU   Parent RingNo BridgeNo Stp  BrdgMode Trans1 Trans2
-            ---- ----- ---------- ----- ------ ------ -------- ---- -------- ------ ------
-            1    enet  100001     1500  -      -      -        -    -        0      0
-            123  enet  100123     610   -      -      -        -    -        0      0
-            150  enet  100150     1500  -      -      -        -    -        0      0
-            888  enet  100888     1500  -      -      -        -    -        0      0
-            1002 fddi  101002     1500  -      -      -        -    -        0      0
-            1003 trcrf 101003     4472  1005   3276   -        -    srb      0      0
-            1004 fdnet 101004     1500  -      -      -        ieee -        0      0
-            1005 trbrf 101005     4472  -      -      15       ibm  -        0      0
-
-            VLAN AREHops STEHops Backup CRF
-            ---- ------- ------- ----------
-            1003 7       7       off
-
-            Remote SPAN VLANs
-            ------------------------------------------------------------------------------
-            150
-
-            Primary Secondary Type              Ports
-            ------- --------- ----------------- ------------------------------------------
-            """
-        )
         set_module_args(
             dict(
                 config=[
@@ -337,48 +208,6 @@ class TestIosVlansModule(TestIosModule):
         self.assertEqual(result["commands"], commands)
 
     def test_ios_vlans_replaced_idempotent(self):
-        self.mock_l2_device_command.side_effect = True
-        self.execute_show_command.side_effect = dedent(
-            """\
-            VLAN Name                             Status    Ports
-            ---- -------------------------------- --------- -------------------------------
-            1    default                          active    Gi0/1, Gi0/2
-            123  RemoteIsInMyName                 act/unsup Fa0/1, Fa0/4, Fa0/5, Fa0/6, Fa0/7, Fa0/8, Fa0/9, Fa0/10, Fa0/11, Fa0/12
-                                                            Fa0/13, Fa0/14, Fa0/15, Fa0/16, Fa0/17, Fa0/18, Fa0/19, Fa0/20, Fa0/21
-                                                            Fa0/22, Fa0/23, Fa0/24, Fa0/25, Fa0/26, Fa0/27, Fa0/28, Fa0/29, Fa0/30
-                                                            Fa0/31, Fa0/32, Fa0/33, Fa0/34, Fa0/35, Fa0/36, Fa0/37, Fa0/38, Fa0/39
-                                                            Fa0/40, Fa0/41, Fa0/42, Fa0/43, Fa0/44, Fa0/45, Fa0/46, Fa0/47, Fa0/48
-            150  VLAN0150                         active
-            888  a_very_long_vlan_name_a_very_long_vlan_name
-                                                active
-            1002 fddi-default                     act/unsup
-            1003 trcrf-default                    act/unsup
-            1004 fddinet-default                  act/unsup
-            1005 trbrf-default                    act/unsup
-
-            VLAN Type  SAID       MTU   Parent RingNo BridgeNo Stp  BrdgMode Trans1 Trans2
-            ---- ----- ---------- ----- ------ ------ -------- ---- -------- ------ ------
-            1    enet  100001     1500  -      -      -        -    -        0      0
-            123  enet  100123     610   -      -      -        -    -        0      0
-            150  enet  100150     1500  -      -      -        -    -        0      0
-            888  enet  100888     1500  -      -      -        -    -        0      0
-            1002 fddi  101002     1500  -      -      -        -    -        0      0
-            1003 trcrf 101003     4472  1005   3276   -        -    srb      0      0
-            1004 fdnet 101004     1500  -      -      -        ieee -        0      0
-            1005 trbrf 101005     4472  -      -      15       ibm  -        0      0
-
-            VLAN AREHops STEHops Backup CRF
-            ---- ------- ------- ----------
-            1003 7       7       off
-
-            Remote SPAN VLANs
-            ------------------------------------------------------------------------------
-            150
-
-            Primary Secondary Type              Ports
-            ------- --------- ----------------- ------------------------------------------
-            """
-        )
         set_module_args(
             dict(
                 config=[
@@ -446,48 +275,6 @@ class TestIosVlansModule(TestIosModule):
         self.execute_module(changed=False, commands=[], sort=True)
 
     def test_ios_vlans_overridden(self):
-        self.mock_l2_device_command.side_effect = True
-        self.execute_show_command.side_effect = dedent(
-            """\
-            VLAN Name                             Status    Ports
-            ---- -------------------------------- --------- -------------------------------
-            1    default                          active    Gi0/1, Gi0/2
-            123  RemoteIsInMyName                 act/unsup Fa0/1, Fa0/4, Fa0/5, Fa0/6, Fa0/7, Fa0/8, Fa0/9, Fa0/10, Fa0/11, Fa0/12
-                                                            Fa0/13, Fa0/14, Fa0/15, Fa0/16, Fa0/17, Fa0/18, Fa0/19, Fa0/20, Fa0/21
-                                                            Fa0/22, Fa0/23, Fa0/24, Fa0/25, Fa0/26, Fa0/27, Fa0/28, Fa0/29, Fa0/30
-                                                            Fa0/31, Fa0/32, Fa0/33, Fa0/34, Fa0/35, Fa0/36, Fa0/37, Fa0/38, Fa0/39
-                                                            Fa0/40, Fa0/41, Fa0/42, Fa0/43, Fa0/44, Fa0/45, Fa0/46, Fa0/47, Fa0/48
-            150  VLAN0150                         active
-            888  a_very_long_vlan_name_a_very_long_vlan_name
-                                                active
-            1002 fddi-default                     act/unsup
-            1003 trcrf-default                    act/unsup
-            1004 fddinet-default                  act/unsup
-            1005 trbrf-default                    act/unsup
-
-            VLAN Type  SAID       MTU   Parent RingNo BridgeNo Stp  BrdgMode Trans1 Trans2
-            ---- ----- ---------- ----- ------ ------ -------- ---- -------- ------ ------
-            1    enet  100001     1500  -      -      -        -    -        0      0
-            123  enet  100123     610   -      -      -        -    -        0      0
-            150  enet  100150     1500  -      -      -        -    -        0      0
-            888  enet  100888     1500  -      -      -        -    -        0      0
-            1002 fddi  101002     1500  -      -      -        -    -        0      0
-            1003 trcrf 101003     4472  1005   3276   -        -    srb      0      0
-            1004 fdnet 101004     1500  -      -      -        ieee -        0      0
-            1005 trbrf 101005     4472  -      -      15       ibm  -        0      0
-
-            VLAN AREHops STEHops Backup CRF
-            ---- ------- ------- ----------
-            1003 7       7       off
-
-            Remote SPAN VLANs
-            ------------------------------------------------------------------------------
-            150
-
-            Primary Secondary Type              Ports
-            ------- --------- ----------------- ------------------------------------------
-            """
-        )
         set_module_args(
             dict(
                 config=[
@@ -527,48 +314,6 @@ class TestIosVlansModule(TestIosModule):
         self.assertEqual(result["commands"], commands)
 
     def test_ios_vlans_overridden_idempotent(self):
-        self.mock_l2_device_command.side_effect = True
-        self.execute_show_command.side_effect = dedent(
-            """\
-            VLAN Name                             Status    Ports
-            ---- -------------------------------- --------- -------------------------------
-            1    default                          active    Gi0/1, Gi0/2
-            123  RemoteIsInMyName                 act/unsup Fa0/1, Fa0/4, Fa0/5, Fa0/6, Fa0/7, Fa0/8, Fa0/9, Fa0/10, Fa0/11, Fa0/12
-                                                            Fa0/13, Fa0/14, Fa0/15, Fa0/16, Fa0/17, Fa0/18, Fa0/19, Fa0/20, Fa0/21
-                                                            Fa0/22, Fa0/23, Fa0/24, Fa0/25, Fa0/26, Fa0/27, Fa0/28, Fa0/29, Fa0/30
-                                                            Fa0/31, Fa0/32, Fa0/33, Fa0/34, Fa0/35, Fa0/36, Fa0/37, Fa0/38, Fa0/39
-                                                            Fa0/40, Fa0/41, Fa0/42, Fa0/43, Fa0/44, Fa0/45, Fa0/46, Fa0/47, Fa0/48
-            150  VLAN0150                         active
-            888  a_very_long_vlan_name_a_very_long_vlan_name
-                                                active
-            1002 fddi-default                     act/unsup
-            1003 trcrf-default                    act/unsup
-            1004 fddinet-default                  act/unsup
-            1005 trbrf-default                    act/unsup
-
-            VLAN Type  SAID       MTU   Parent RingNo BridgeNo Stp  BrdgMode Trans1 Trans2
-            ---- ----- ---------- ----- ------ ------ -------- ---- -------- ------ ------
-            1    enet  100001     1500  -      -      -        -    -        0      0
-            123  enet  100123     610   -      -      -        -    -        0      0
-            150  enet  100150     1500  -      -      -        -    -        0      0
-            888  enet  100888     1500  -      -      -        -    -        0      0
-            1002 fddi  101002     1500  -      -      -        -    -        0      0
-            1003 trcrf 101003     4472  1005   3276   -        -    srb      0      0
-            1004 fdnet 101004     1500  -      -      -        ieee -        0      0
-            1005 trbrf 101005     4472  -      -      15       ibm  -        0      0
-
-            VLAN AREHops STEHops Backup CRF
-            ---- ------- ------- ----------
-            1003 7       7       off
-
-            Remote SPAN VLANs
-            ------------------------------------------------------------------------------
-            150
-
-            Primary Secondary Type              Ports
-            ------- --------- ----------------- ------------------------------------------
-            """
-        )
         set_module_args(
             dict(
                 config=[
@@ -636,96 +381,12 @@ class TestIosVlansModule(TestIosModule):
         self.execute_module(changed=False, commands=[], sort=True)
 
     def test_ios_delete_vlans_config(self):
-        self.mock_l2_device_command.side_effect = True
-        self.execute_show_command.side_effect = dedent(
-            """\
-            VLAN Name                             Status    Ports
-            ---- -------------------------------- --------- -------------------------------
-            1    default                          active    Gi0/1, Gi0/2
-            123  RemoteIsInMyName                 act/unsup Fa0/1, Fa0/4, Fa0/5, Fa0/6, Fa0/7, Fa0/8, Fa0/9, Fa0/10, Fa0/11, Fa0/12
-                                                            Fa0/13, Fa0/14, Fa0/15, Fa0/16, Fa0/17, Fa0/18, Fa0/19, Fa0/20, Fa0/21
-                                                            Fa0/22, Fa0/23, Fa0/24, Fa0/25, Fa0/26, Fa0/27, Fa0/28, Fa0/29, Fa0/30
-                                                            Fa0/31, Fa0/32, Fa0/33, Fa0/34, Fa0/35, Fa0/36, Fa0/37, Fa0/38, Fa0/39
-                                                            Fa0/40, Fa0/41, Fa0/42, Fa0/43, Fa0/44, Fa0/45, Fa0/46, Fa0/47, Fa0/48
-            150  VLAN0150                         active
-            888  a_very_long_vlan_name_a_very_long_vlan_name
-                                                active
-            1002 fddi-default                     act/unsup
-            1003 trcrf-default                    act/unsup
-            1004 fddinet-default                  act/unsup
-            1005 trbrf-default                    act/unsup
-
-            VLAN Type  SAID       MTU   Parent RingNo BridgeNo Stp  BrdgMode Trans1 Trans2
-            ---- ----- ---------- ----- ------ ------ -------- ---- -------- ------ ------
-            1    enet  100001     1500  -      -      -        -    -        0      0
-            123  enet  100123     610   -      -      -        -    -        0      0
-            150  enet  100150     1500  -      -      -        -    -        0      0
-            888  enet  100888     1500  -      -      -        -    -        0      0
-            1002 fddi  101002     1500  -      -      -        -    -        0      0
-            1003 trcrf 101003     4472  1005   3276   -        -    srb      0      0
-            1004 fdnet 101004     1500  -      -      -        ieee -        0      0
-            1005 trbrf 101005     4472  -      -      15       ibm  -        0      0
-
-            VLAN AREHops STEHops Backup CRF
-            ---- ------- ------- ----------
-            1003 7       7       off
-
-            Remote SPAN VLANs
-            ------------------------------------------------------------------------------
-            150
-
-            Primary Secondary Type              Ports
-            ------- --------- ----------------- ------------------------------------------
-            """
-        )
         set_module_args(dict(config=[dict(vlan_id=150)], state="deleted"))
         result = self.execute_module(changed=True)
         commands = ["no vlan 150"]
         self.assertEqual(result["commands"], commands)
 
     def test_vlans_rendered(self):
-        self.mock_l2_device_command.side_effect = True
-        self.execute_show_command.side_effect = dedent(
-            """\
-            VLAN Name                             Status    Ports
-            ---- -------------------------------- --------- -------------------------------
-            1    default                          active    Gi0/1, Gi0/2
-            123  RemoteIsInMyName                 act/unsup Fa0/1, Fa0/4, Fa0/5, Fa0/6, Fa0/7, Fa0/8, Fa0/9, Fa0/10, Fa0/11, Fa0/12
-                                                            Fa0/13, Fa0/14, Fa0/15, Fa0/16, Fa0/17, Fa0/18, Fa0/19, Fa0/20, Fa0/21
-                                                            Fa0/22, Fa0/23, Fa0/24, Fa0/25, Fa0/26, Fa0/27, Fa0/28, Fa0/29, Fa0/30
-                                                            Fa0/31, Fa0/32, Fa0/33, Fa0/34, Fa0/35, Fa0/36, Fa0/37, Fa0/38, Fa0/39
-                                                            Fa0/40, Fa0/41, Fa0/42, Fa0/43, Fa0/44, Fa0/45, Fa0/46, Fa0/47, Fa0/48
-            150  VLAN0150                         active
-            888  a_very_long_vlan_name_a_very_long_vlan_name
-                                                active
-            1002 fddi-default                     act/unsup
-            1003 trcrf-default                    act/unsup
-            1004 fddinet-default                  act/unsup
-            1005 trbrf-default                    act/unsup
-
-            VLAN Type  SAID       MTU   Parent RingNo BridgeNo Stp  BrdgMode Trans1 Trans2
-            ---- ----- ---------- ----- ------ ------ -------- ---- -------- ------ ------
-            1    enet  100001     1500  -      -      -        -    -        0      0
-            123  enet  100123     610   -      -      -        -    -        0      0
-            150  enet  100150     1500  -      -      -        -    -        0      0
-            888  enet  100888     1500  -      -      -        -    -        0      0
-            1002 fddi  101002     1500  -      -      -        -    -        0      0
-            1003 trcrf 101003     4472  1005   3276   -        -    srb      0      0
-            1004 fdnet 101004     1500  -      -      -        ieee -        0      0
-            1005 trbrf 101005     4472  -      -      15       ibm  -        0      0
-
-            VLAN AREHops STEHops Backup CRF
-            ---- ------- ------- ----------
-            1003 7       7       off
-
-            Remote SPAN VLANs
-            ------------------------------------------------------------------------------
-            150
-
-            Primary Secondary Type              Ports
-            ------- --------- ----------------- ------------------------------------------
-            """
-        )
         set_module_args(
             dict(
                 config=[

--- a/tests/unit/modules/network/ios/test_ios_vlans.py
+++ b/tests/unit/modules/network/ios/test_ios_vlans.py
@@ -12,7 +12,8 @@ from ansible_collections.cisco.ios.plugins.modules import ios_vlans
 from ansible_collections.cisco.ios.tests.unit.modules.utils import (
     set_module_args,
 )
-from .ios_module import TestIosModule, load_fixture
+from .ios_module import TestIosModule
+from textwrap import dedent
 
 
 class TestIosVlansModule(TestIosModule):
@@ -72,14 +73,57 @@ class TestIosVlansModule(TestIosModule):
         self.mock_execute_show_command.stop()
         self.mock_l2_device_command.stop()
 
-    def load_fixtures(self, commands=None, transport="cli"):
-        def load_from_file(*args, **kwargs):
-            return load_fixture("ios_vlans_config.cfg")
+    # def load_fixtures(self, commands=None, transport="cli"):
+    #     def load_from_file(*args, **kwargs):
+    #         return load_fixture("ios_vlans_config.cfg")
 
-        self.mock_l2_device_command.side_effect = True
-        self.execute_show_command.side_effect = load_from_file
+    #     self.mock_l2_device_command.side_effect = True
+    #     self.execute_show_command.side_effect = load_from_file
 
     def test_ios_vlans_merged(self):
+        self.mock_l2_device_command.side_effect = True
+        self.execute_show_command.side_effect = dedent(
+            """\
+            VLAN Name                             Status    Ports
+            ---- -------------------------------- --------- -------------------------------
+            1    default                          active    Gi0/1, Gi0/2
+            123  RemoteIsInMyName                 act/unsup Fa0/1, Fa0/4, Fa0/5, Fa0/6, Fa0/7, Fa0/8, Fa0/9, Fa0/10, Fa0/11, Fa0/12
+                                                            Fa0/13, Fa0/14, Fa0/15, Fa0/16, Fa0/17, Fa0/18, Fa0/19, Fa0/20, Fa0/21
+                                                            Fa0/22, Fa0/23, Fa0/24, Fa0/25, Fa0/26, Fa0/27, Fa0/28, Fa0/29, Fa0/30
+                                                            Fa0/31, Fa0/32, Fa0/33, Fa0/34, Fa0/35, Fa0/36, Fa0/37, Fa0/38, Fa0/39
+                                                            Fa0/40, Fa0/41, Fa0/42, Fa0/43, Fa0/44, Fa0/45, Fa0/46, Fa0/47, Fa0/48
+            150  VLAN0150                         active
+            888  a_very_long_vlan_name_a_very_long_vlan_name
+                                                active
+            1002 fddi-default                     act/unsup
+            1003 trcrf-default                    act/unsup
+            1004 fddinet-default                  act/unsup
+            1005 trbrf-default                    act/unsup
+
+            VLAN Type  SAID       MTU   Parent RingNo BridgeNo Stp  BrdgMode Trans1 Trans2
+            ---- ----- ---------- ----- ------ ------ -------- ---- -------- ------ ------
+            1    enet  100001     1500  -      -      -        -    -        0      0
+            123  enet  100123     610   -      -      -        -    -        0      0
+            150  enet  100150     1500  -      -      -        -    -        0      0
+            888  enet  100888     1500  -      -      -        -    -        0      0
+            1002 fddi  101002     1500  -      -      -        -    -        0      0
+            1003 trcrf 101003     4472  1005   3276   -        -    srb      0      0
+            1004 fdnet 101004     1500  -      -      -        ieee -        0      0
+            1005 trbrf 101005     4472  -      -      15       ibm  -        0      0
+
+
+            VLAN AREHops STEHops Backup CRF
+            ---- ------- ------- ----------
+            1003 7       7       off
+
+            Remote SPAN VLANs
+            ------------------------------------------------------------------------------
+            150
+
+            Primary Secondary Type              Ports
+            ------- --------- ----------------- ------------------------------------------
+            """
+        )
         set_module_args(
             dict(
                 config=[
@@ -105,6 +149,49 @@ class TestIosVlansModule(TestIosModule):
         self.assertEqual(result["commands"], commands)
 
     def test_ios_vlans_merged_idempotent(self):
+        self.mock_l2_device_command.side_effect = True
+        self.execute_show_command.side_effect = dedent(
+            """\
+            VLAN Name                             Status    Ports
+            ---- -------------------------------- --------- -------------------------------
+            1    default                          active    Gi0/1, Gi0/2
+            123  RemoteIsInMyName                 act/unsup Fa0/1, Fa0/4, Fa0/5, Fa0/6, Fa0/7, Fa0/8, Fa0/9, Fa0/10, Fa0/11, Fa0/12
+                                                            Fa0/13, Fa0/14, Fa0/15, Fa0/16, Fa0/17, Fa0/18, Fa0/19, Fa0/20, Fa0/21
+                                                            Fa0/22, Fa0/23, Fa0/24, Fa0/25, Fa0/26, Fa0/27, Fa0/28, Fa0/29, Fa0/30
+                                                            Fa0/31, Fa0/32, Fa0/33, Fa0/34, Fa0/35, Fa0/36, Fa0/37, Fa0/38, Fa0/39
+                                                            Fa0/40, Fa0/41, Fa0/42, Fa0/43, Fa0/44, Fa0/45, Fa0/46, Fa0/47, Fa0/48
+            150  VLAN0150                         active
+            888  a_very_long_vlan_name_a_very_long_vlan_name
+                                                active
+            1002 fddi-default                     act/unsup
+            1003 trcrf-default                    act/unsup
+            1004 fddinet-default                  act/unsup
+            1005 trbrf-default                    act/unsup
+
+            VLAN Type  SAID       MTU   Parent RingNo BridgeNo Stp  BrdgMode Trans1 Trans2
+            ---- ----- ---------- ----- ------ ------ -------- ---- -------- ------ ------
+            1    enet  100001     1500  -      -      -        -    -        0      0
+            123  enet  100123     610   -      -      -        -    -        0      0
+            150  enet  100150     1500  -      -      -        -    -        0      0
+            888  enet  100888     1500  -      -      -        -    -        0      0
+            1002 fddi  101002     1500  -      -      -        -    -        0      0
+            1003 trcrf 101003     4472  1005   3276   -        -    srb      0      0
+            1004 fdnet 101004     1500  -      -      -        ieee -        0      0
+            1005 trbrf 101005     4472  -      -      15       ibm  -        0      0
+
+
+            VLAN AREHops STEHops Backup CRF
+            ---- ------- ------- ----------
+            1003 7       7       off
+
+            Remote SPAN VLANs
+            ------------------------------------------------------------------------------
+            150
+
+            Primary Secondary Type              Ports
+            ------- --------- ----------------- ------------------------------------------
+            """
+        )
         set_module_args(
             dict(
                 config=[
@@ -172,6 +259,48 @@ class TestIosVlansModule(TestIosModule):
         self.execute_module(changed=False, commands=[], sort=True)
 
     def test_ios_vlans_replaced(self):
+        self.mock_l2_device_command.side_effect = True
+        self.execute_show_command.side_effect = dedent(
+            """\
+            VLAN Name                             Status    Ports
+            ---- -------------------------------- --------- -------------------------------
+            1    default                          active    Gi0/1, Gi0/2
+            123  RemoteIsInMyName                 act/unsup Fa0/1, Fa0/4, Fa0/5, Fa0/6, Fa0/7, Fa0/8, Fa0/9, Fa0/10, Fa0/11, Fa0/12
+                                                            Fa0/13, Fa0/14, Fa0/15, Fa0/16, Fa0/17, Fa0/18, Fa0/19, Fa0/20, Fa0/21
+                                                            Fa0/22, Fa0/23, Fa0/24, Fa0/25, Fa0/26, Fa0/27, Fa0/28, Fa0/29, Fa0/30
+                                                            Fa0/31, Fa0/32, Fa0/33, Fa0/34, Fa0/35, Fa0/36, Fa0/37, Fa0/38, Fa0/39
+                                                            Fa0/40, Fa0/41, Fa0/42, Fa0/43, Fa0/44, Fa0/45, Fa0/46, Fa0/47, Fa0/48
+            150  VLAN0150                         active
+            888  a_very_long_vlan_name_a_very_long_vlan_name
+                                                active
+            1002 fddi-default                     act/unsup
+            1003 trcrf-default                    act/unsup
+            1004 fddinet-default                  act/unsup
+            1005 trbrf-default                    act/unsup
+
+            VLAN Type  SAID       MTU   Parent RingNo BridgeNo Stp  BrdgMode Trans1 Trans2
+            ---- ----- ---------- ----- ------ ------ -------- ---- -------- ------ ------
+            1    enet  100001     1500  -      -      -        -    -        0      0
+            123  enet  100123     610   -      -      -        -    -        0      0
+            150  enet  100150     1500  -      -      -        -    -        0      0
+            888  enet  100888     1500  -      -      -        -    -        0      0
+            1002 fddi  101002     1500  -      -      -        -    -        0      0
+            1003 trcrf 101003     4472  1005   3276   -        -    srb      0      0
+            1004 fdnet 101004     1500  -      -      -        ieee -        0      0
+            1005 trbrf 101005     4472  -      -      15       ibm  -        0      0
+
+            VLAN AREHops STEHops Backup CRF
+            ---- ------- ------- ----------
+            1003 7       7       off
+
+            Remote SPAN VLANs
+            ------------------------------------------------------------------------------
+            150
+
+            Primary Secondary Type              Ports
+            ------- --------- ----------------- ------------------------------------------
+            """
+        )
         set_module_args(
             dict(
                 config=[
@@ -208,6 +337,48 @@ class TestIosVlansModule(TestIosModule):
         self.assertEqual(result["commands"], commands)
 
     def test_ios_vlans_replaced_idempotent(self):
+        self.mock_l2_device_command.side_effect = True
+        self.execute_show_command.side_effect = dedent(
+            """\
+            VLAN Name                             Status    Ports
+            ---- -------------------------------- --------- -------------------------------
+            1    default                          active    Gi0/1, Gi0/2
+            123  RemoteIsInMyName                 act/unsup Fa0/1, Fa0/4, Fa0/5, Fa0/6, Fa0/7, Fa0/8, Fa0/9, Fa0/10, Fa0/11, Fa0/12
+                                                            Fa0/13, Fa0/14, Fa0/15, Fa0/16, Fa0/17, Fa0/18, Fa0/19, Fa0/20, Fa0/21
+                                                            Fa0/22, Fa0/23, Fa0/24, Fa0/25, Fa0/26, Fa0/27, Fa0/28, Fa0/29, Fa0/30
+                                                            Fa0/31, Fa0/32, Fa0/33, Fa0/34, Fa0/35, Fa0/36, Fa0/37, Fa0/38, Fa0/39
+                                                            Fa0/40, Fa0/41, Fa0/42, Fa0/43, Fa0/44, Fa0/45, Fa0/46, Fa0/47, Fa0/48
+            150  VLAN0150                         active
+            888  a_very_long_vlan_name_a_very_long_vlan_name
+                                                active
+            1002 fddi-default                     act/unsup
+            1003 trcrf-default                    act/unsup
+            1004 fddinet-default                  act/unsup
+            1005 trbrf-default                    act/unsup
+
+            VLAN Type  SAID       MTU   Parent RingNo BridgeNo Stp  BrdgMode Trans1 Trans2
+            ---- ----- ---------- ----- ------ ------ -------- ---- -------- ------ ------
+            1    enet  100001     1500  -      -      -        -    -        0      0
+            123  enet  100123     610   -      -      -        -    -        0      0
+            150  enet  100150     1500  -      -      -        -    -        0      0
+            888  enet  100888     1500  -      -      -        -    -        0      0
+            1002 fddi  101002     1500  -      -      -        -    -        0      0
+            1003 trcrf 101003     4472  1005   3276   -        -    srb      0      0
+            1004 fdnet 101004     1500  -      -      -        ieee -        0      0
+            1005 trbrf 101005     4472  -      -      15       ibm  -        0      0
+
+            VLAN AREHops STEHops Backup CRF
+            ---- ------- ------- ----------
+            1003 7       7       off
+
+            Remote SPAN VLANs
+            ------------------------------------------------------------------------------
+            150
+
+            Primary Secondary Type              Ports
+            ------- --------- ----------------- ------------------------------------------
+            """
+        )
         set_module_args(
             dict(
                 config=[
@@ -275,6 +446,48 @@ class TestIosVlansModule(TestIosModule):
         self.execute_module(changed=False, commands=[], sort=True)
 
     def test_ios_vlans_overridden(self):
+        self.mock_l2_device_command.side_effect = True
+        self.execute_show_command.side_effect = dedent(
+            """\
+            VLAN Name                             Status    Ports
+            ---- -------------------------------- --------- -------------------------------
+            1    default                          active    Gi0/1, Gi0/2
+            123  RemoteIsInMyName                 act/unsup Fa0/1, Fa0/4, Fa0/5, Fa0/6, Fa0/7, Fa0/8, Fa0/9, Fa0/10, Fa0/11, Fa0/12
+                                                            Fa0/13, Fa0/14, Fa0/15, Fa0/16, Fa0/17, Fa0/18, Fa0/19, Fa0/20, Fa0/21
+                                                            Fa0/22, Fa0/23, Fa0/24, Fa0/25, Fa0/26, Fa0/27, Fa0/28, Fa0/29, Fa0/30
+                                                            Fa0/31, Fa0/32, Fa0/33, Fa0/34, Fa0/35, Fa0/36, Fa0/37, Fa0/38, Fa0/39
+                                                            Fa0/40, Fa0/41, Fa0/42, Fa0/43, Fa0/44, Fa0/45, Fa0/46, Fa0/47, Fa0/48
+            150  VLAN0150                         active
+            888  a_very_long_vlan_name_a_very_long_vlan_name
+                                                active
+            1002 fddi-default                     act/unsup
+            1003 trcrf-default                    act/unsup
+            1004 fddinet-default                  act/unsup
+            1005 trbrf-default                    act/unsup
+
+            VLAN Type  SAID       MTU   Parent RingNo BridgeNo Stp  BrdgMode Trans1 Trans2
+            ---- ----- ---------- ----- ------ ------ -------- ---- -------- ------ ------
+            1    enet  100001     1500  -      -      -        -    -        0      0
+            123  enet  100123     610   -      -      -        -    -        0      0
+            150  enet  100150     1500  -      -      -        -    -        0      0
+            888  enet  100888     1500  -      -      -        -    -        0      0
+            1002 fddi  101002     1500  -      -      -        -    -        0      0
+            1003 trcrf 101003     4472  1005   3276   -        -    srb      0      0
+            1004 fdnet 101004     1500  -      -      -        ieee -        0      0
+            1005 trbrf 101005     4472  -      -      15       ibm  -        0      0
+
+            VLAN AREHops STEHops Backup CRF
+            ---- ------- ------- ----------
+            1003 7       7       off
+
+            Remote SPAN VLANs
+            ------------------------------------------------------------------------------
+            150
+
+            Primary Secondary Type              Ports
+            ------- --------- ----------------- ------------------------------------------
+            """
+        )
         set_module_args(
             dict(
                 config=[
@@ -314,6 +527,48 @@ class TestIosVlansModule(TestIosModule):
         self.assertEqual(result["commands"], commands)
 
     def test_ios_vlans_overridden_idempotent(self):
+        self.mock_l2_device_command.side_effect = True
+        self.execute_show_command.side_effect = dedent(
+            """\
+            VLAN Name                             Status    Ports
+            ---- -------------------------------- --------- -------------------------------
+            1    default                          active    Gi0/1, Gi0/2
+            123  RemoteIsInMyName                 act/unsup Fa0/1, Fa0/4, Fa0/5, Fa0/6, Fa0/7, Fa0/8, Fa0/9, Fa0/10, Fa0/11, Fa0/12
+                                                            Fa0/13, Fa0/14, Fa0/15, Fa0/16, Fa0/17, Fa0/18, Fa0/19, Fa0/20, Fa0/21
+                                                            Fa0/22, Fa0/23, Fa0/24, Fa0/25, Fa0/26, Fa0/27, Fa0/28, Fa0/29, Fa0/30
+                                                            Fa0/31, Fa0/32, Fa0/33, Fa0/34, Fa0/35, Fa0/36, Fa0/37, Fa0/38, Fa0/39
+                                                            Fa0/40, Fa0/41, Fa0/42, Fa0/43, Fa0/44, Fa0/45, Fa0/46, Fa0/47, Fa0/48
+            150  VLAN0150                         active
+            888  a_very_long_vlan_name_a_very_long_vlan_name
+                                                active
+            1002 fddi-default                     act/unsup
+            1003 trcrf-default                    act/unsup
+            1004 fddinet-default                  act/unsup
+            1005 trbrf-default                    act/unsup
+
+            VLAN Type  SAID       MTU   Parent RingNo BridgeNo Stp  BrdgMode Trans1 Trans2
+            ---- ----- ---------- ----- ------ ------ -------- ---- -------- ------ ------
+            1    enet  100001     1500  -      -      -        -    -        0      0
+            123  enet  100123     610   -      -      -        -    -        0      0
+            150  enet  100150     1500  -      -      -        -    -        0      0
+            888  enet  100888     1500  -      -      -        -    -        0      0
+            1002 fddi  101002     1500  -      -      -        -    -        0      0
+            1003 trcrf 101003     4472  1005   3276   -        -    srb      0      0
+            1004 fdnet 101004     1500  -      -      -        ieee -        0      0
+            1005 trbrf 101005     4472  -      -      15       ibm  -        0      0
+
+            VLAN AREHops STEHops Backup CRF
+            ---- ------- ------- ----------
+            1003 7       7       off
+
+            Remote SPAN VLANs
+            ------------------------------------------------------------------------------
+            150
+
+            Primary Secondary Type              Ports
+            ------- --------- ----------------- ------------------------------------------
+            """
+        )
         set_module_args(
             dict(
                 config=[
@@ -381,12 +636,96 @@ class TestIosVlansModule(TestIosModule):
         self.execute_module(changed=False, commands=[], sort=True)
 
     def test_ios_delete_vlans_config(self):
+        self.mock_l2_device_command.side_effect = True
+        self.execute_show_command.side_effect = dedent(
+            """\
+            VLAN Name                             Status    Ports
+            ---- -------------------------------- --------- -------------------------------
+            1    default                          active    Gi0/1, Gi0/2
+            123  RemoteIsInMyName                 act/unsup Fa0/1, Fa0/4, Fa0/5, Fa0/6, Fa0/7, Fa0/8, Fa0/9, Fa0/10, Fa0/11, Fa0/12
+                                                            Fa0/13, Fa0/14, Fa0/15, Fa0/16, Fa0/17, Fa0/18, Fa0/19, Fa0/20, Fa0/21
+                                                            Fa0/22, Fa0/23, Fa0/24, Fa0/25, Fa0/26, Fa0/27, Fa0/28, Fa0/29, Fa0/30
+                                                            Fa0/31, Fa0/32, Fa0/33, Fa0/34, Fa0/35, Fa0/36, Fa0/37, Fa0/38, Fa0/39
+                                                            Fa0/40, Fa0/41, Fa0/42, Fa0/43, Fa0/44, Fa0/45, Fa0/46, Fa0/47, Fa0/48
+            150  VLAN0150                         active
+            888  a_very_long_vlan_name_a_very_long_vlan_name
+                                                active
+            1002 fddi-default                     act/unsup
+            1003 trcrf-default                    act/unsup
+            1004 fddinet-default                  act/unsup
+            1005 trbrf-default                    act/unsup
+
+            VLAN Type  SAID       MTU   Parent RingNo BridgeNo Stp  BrdgMode Trans1 Trans2
+            ---- ----- ---------- ----- ------ ------ -------- ---- -------- ------ ------
+            1    enet  100001     1500  -      -      -        -    -        0      0
+            123  enet  100123     610   -      -      -        -    -        0      0
+            150  enet  100150     1500  -      -      -        -    -        0      0
+            888  enet  100888     1500  -      -      -        -    -        0      0
+            1002 fddi  101002     1500  -      -      -        -    -        0      0
+            1003 trcrf 101003     4472  1005   3276   -        -    srb      0      0
+            1004 fdnet 101004     1500  -      -      -        ieee -        0      0
+            1005 trbrf 101005     4472  -      -      15       ibm  -        0      0
+
+            VLAN AREHops STEHops Backup CRF
+            ---- ------- ------- ----------
+            1003 7       7       off
+
+            Remote SPAN VLANs
+            ------------------------------------------------------------------------------
+            150
+
+            Primary Secondary Type              Ports
+            ------- --------- ----------------- ------------------------------------------
+            """
+        )
         set_module_args(dict(config=[dict(vlan_id=150)], state="deleted"))
         result = self.execute_module(changed=True)
         commands = ["no vlan 150"]
         self.assertEqual(result["commands"], commands)
 
     def test_vlans_rendered(self):
+        self.mock_l2_device_command.side_effect = True
+        self.execute_show_command.side_effect = dedent(
+            """\
+            VLAN Name                             Status    Ports
+            ---- -------------------------------- --------- -------------------------------
+            1    default                          active    Gi0/1, Gi0/2
+            123  RemoteIsInMyName                 act/unsup Fa0/1, Fa0/4, Fa0/5, Fa0/6, Fa0/7, Fa0/8, Fa0/9, Fa0/10, Fa0/11, Fa0/12
+                                                            Fa0/13, Fa0/14, Fa0/15, Fa0/16, Fa0/17, Fa0/18, Fa0/19, Fa0/20, Fa0/21
+                                                            Fa0/22, Fa0/23, Fa0/24, Fa0/25, Fa0/26, Fa0/27, Fa0/28, Fa0/29, Fa0/30
+                                                            Fa0/31, Fa0/32, Fa0/33, Fa0/34, Fa0/35, Fa0/36, Fa0/37, Fa0/38, Fa0/39
+                                                            Fa0/40, Fa0/41, Fa0/42, Fa0/43, Fa0/44, Fa0/45, Fa0/46, Fa0/47, Fa0/48
+            150  VLAN0150                         active
+            888  a_very_long_vlan_name_a_very_long_vlan_name
+                                                active
+            1002 fddi-default                     act/unsup
+            1003 trcrf-default                    act/unsup
+            1004 fddinet-default                  act/unsup
+            1005 trbrf-default                    act/unsup
+
+            VLAN Type  SAID       MTU   Parent RingNo BridgeNo Stp  BrdgMode Trans1 Trans2
+            ---- ----- ---------- ----- ------ ------ -------- ---- -------- ------ ------
+            1    enet  100001     1500  -      -      -        -    -        0      0
+            123  enet  100123     610   -      -      -        -    -        0      0
+            150  enet  100150     1500  -      -      -        -    -        0      0
+            888  enet  100888     1500  -      -      -        -    -        0      0
+            1002 fddi  101002     1500  -      -      -        -    -        0      0
+            1003 trcrf 101003     4472  1005   3276   -        -    srb      0      0
+            1004 fdnet 101004     1500  -      -      -        ieee -        0      0
+            1005 trbrf 101005     4472  -      -      15       ibm  -        0      0
+
+            VLAN AREHops STEHops Backup CRF
+            ---- ------- ------- ----------
+            1003 7       7       off
+
+            Remote SPAN VLANs
+            ------------------------------------------------------------------------------
+            150
+
+            Primary Secondary Type              Ports
+            ------- --------- ----------------- ------------------------------------------
+            """
+        )
         set_module_args(
             dict(
                 config=[


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
fix vlan not parsing names with space correctly 
fix vlan parsing range options correctly
Depends-On: https://github.com/ansible-collections/cisco.ios/pull/485
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios_vlan

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
