### PR TITLE
fix acl for parsing wrong command on ( num matches ) data

### DIFF
--- a/changelogs/fragments/acl_2_6.yaml
+++ b/changelogs/fragments/acl_2_6.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "`ios_acls` - Fixes standard acls getting wrongly parsed in v2.6.0"

--- a/plugins/module_utils/network/ios/facts/acls/acls.py
+++ b/plugins/module_utils/network/ios/facts/acls/acls.py
@@ -14,7 +14,7 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-
+import re
 from ansible.module_utils.six import iteritems
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import (
     utils,
@@ -52,6 +52,16 @@ class AclsFacts(object):
             _acl_data += "\n" + _remarks_data
         return _acl_data
 
+    def sanitize_data(self, data):
+        re_data = ""
+        for da in data.split("\n"):
+            if "matches" in da:
+                mod_da = re.sub(r"\([^()]*\)", "", da)
+                re_data += mod_da + "\n"
+            else:
+                re_data += da + "\n"
+        return re_data
+
     def populate_facts(self, connection, ansible_facts, data=None):
         """ Populate the facts for acls
         :param connection: the device connection
@@ -63,6 +73,7 @@ class AclsFacts(object):
 
         if not data:
             data = self.get_acl_data(connection)
+        data = self.sanitize_data(data)
 
         rmmod = NetworkTemplate(lines=data.splitlines(), tmplt=AclsTemplate())
         current = rmmod.parse()

--- a/plugins/module_utils/network/ios/facts/acls/acls.py
+++ b/plugins/module_utils/network/ios/facts/acls/acls.py
@@ -57,7 +57,7 @@ class AclsFacts(object):
         for da in data.split("\n"):
             if "matches" in da:
                 mod_da = re.sub(r"\([^()]*\)", "", da)
-                re_data += mod_da + "\n"
+                re_data += mod_da[:-1] + "\n"
             else:
                 re_data += da + "\n"
         return re_data
@@ -73,7 +73,9 @@ class AclsFacts(object):
 
         if not data:
             data = self.get_acl_data(connection)
-        data = self.sanitize_data(data)
+
+        if data:
+            data = self.sanitize_data(data)
 
         rmmod = NetworkTemplate(lines=data.splitlines(), tmplt=AclsTemplate())
         current = rmmod.parse()
@@ -95,6 +97,11 @@ class AclsFacts(object):
 
             def process_protocol_options(each):
                 for each_ace in each.get("aces"):
+                    if each_ace.get("source"):
+                        if each_ace.get("source", {}).get("address"):
+                            addr = each_ace.get("source", {}).get("address")
+                            if addr[-1] == ",":
+                                each_ace["source"]["address"] = addr[:-1]
                     if each_ace.get("icmp_igmp_tcp_protocol"):
                         each_ace["protocol_options"] = {
                             each_ace["protocol"]: {

--- a/plugins/module_utils/network/ios/rm_templates/acls.py
+++ b/plugins/module_utils/network/ios/rm_templates/acls.py
@@ -248,7 +248,7 @@ class AclsTemplate(NetworkTemplate):
                         (\s+(?P<address>(?!ahp|eigrp|esp|gre|icmp|igmp|ipv6|ipinip|ip|nos|object-group|ospf|pcp|pim|sctp|tcp|udp)\S+|\S+,))?
                         (\s*(?P<any>any))?
                         (\shost\s(?P<host>\S+))?
-                        (,\swildcard\sbits\s(?P<wildcard>\S+))?
+                        (\swildcard\sbits\s(?P<wildcard>\S+))?
                         (\s(?P<log>log))?
                     $""",
                 re.VERBOSE,

--- a/tests/unit/modules/network/ios/test_ios_acls.py
+++ b/tests/unit/modules/network/ios/test_ios_acls.py
@@ -766,6 +766,70 @@ class TestIosAclsModule(TestIosModule):
         ]
         self.assertEqual(parsed_list, result["parsed"])
 
+    def test_ios_acls_parsed_matches(self):
+        set_module_args(
+            dict(
+                running_config="Standard IP access list R1_TRAFFIC\n10 permit 10.11.12.13 (2 matches)\n40 permit 128.0.0.0, wildcard bits 63.255.255.255 (2 matches)",
+                state="parsed",
+            )
+        )
+        result = self.execute_module(changed=False)
+        parsed_list2 = [
+            {
+                "name": "R1_TRAFFIC",
+                "acl_type": "standard",
+                "aces": [
+                    {
+                        "sequence": 10,
+                        "source": {
+                            "address": "permit",
+                            "wildcard_bits": "10.11.12.13",
+                        },
+                    },
+                    {
+                        "sequence": 40,
+                        "grant": "permit",
+                        "source": {
+                            "address": "128.0.0.0,",
+                            "wildcard_bits": "wildcard",
+                        },
+                        "destination": {
+                            "address": "bits",
+                            "wildcard_bits": "63.255.255.255",
+                        },
+                    },
+                ],
+            }
+        ]
+        parsed_list = [
+            {
+                "afi": "ipv4",
+                "acls": [
+                    {
+                        "name": "R1_TRAFFIC",
+                        "acl_type": "standard",
+                        "aces": [
+                            {
+                                "sequence": 10,
+                                "grant": "permit",
+                                "source": {"address": "10.11.12.13"},
+                            },
+                            {
+                                "sequence": 40,
+                                "grant": "permit",
+                                "source": {
+                                    "address": "128.0.0.0,",
+                                    "wildcard_bits": "wildcard",
+                                },
+                            },
+                        ],
+                    }
+                ],
+            }
+        ]
+        print(result)
+        self.assertEqual(parsed_list, result["parsed"])
+
     def test_ios_acls_overridden_remark(self):
         self.execute_show_command.return_value = dedent(
             """\

--- a/tests/unit/modules/network/ios/test_ios_acls.py
+++ b/tests/unit/modules/network/ios/test_ios_acls.py
@@ -769,7 +769,8 @@ class TestIosAclsModule(TestIosModule):
     def test_ios_acls_parsed_matches(self):
         set_module_args(
             dict(
-                running_config="Standard IP access list R1_TRAFFIC\n10 permit 10.11.12.13 (2 matches)\n40 permit 128.0.0.0, wildcard bits 63.255.255.255 (2 matches)",
+                running_config="""Standard IP access list R1_TRAFFIC\n10 permit 10.11.12.13 (2 matches)\n
+                40 permit 128.0.0.0, wildcard bits 63.255.255.255 (2 matches)""",
                 state="parsed",
             )
         )

--- a/tests/unit/modules/network/ios/test_ios_acls.py
+++ b/tests/unit/modules/network/ios/test_ios_acls.py
@@ -774,33 +774,6 @@ class TestIosAclsModule(TestIosModule):
             )
         )
         result = self.execute_module(changed=False)
-        parsed_list2 = [
-            {
-                "name": "R1_TRAFFIC",
-                "acl_type": "standard",
-                "aces": [
-                    {
-                        "sequence": 10,
-                        "source": {
-                            "address": "permit",
-                            "wildcard_bits": "10.11.12.13",
-                        },
-                    },
-                    {
-                        "sequence": 40,
-                        "grant": "permit",
-                        "source": {
-                            "address": "128.0.0.0,",
-                            "wildcard_bits": "wildcard",
-                        },
-                        "destination": {
-                            "address": "bits",
-                            "wildcard_bits": "63.255.255.255",
-                        },
-                    },
-                ],
-            }
-        ]
         parsed_list = [
             {
                 "afi": "ipv4",
@@ -818,8 +791,8 @@ class TestIosAclsModule(TestIosModule):
                                 "sequence": 40,
                                 "grant": "permit",
                                 "source": {
-                                    "address": "128.0.0.0,",
-                                    "wildcard_bits": "wildcard",
+                                    "address": "128.0.0.0",
+                                    "wildcard_bits": "63.255.255.255",
                                 },
                             },
                         ],


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
IOS parsing standard ACLs wrongly, when matches are visible in running config
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios_acls

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
