### PR TITLE
Update result to add views in facts for snmp_server.py

### DIFF
--- a/changelogs/fragments/492-snmp-fact-view-key-correction
+++ b/changelogs/fragments/492-snmp-fact-view-key-correction
@@ -1,0 +1,3 @@
+bugfixes:
+  - `ios_snmp_server` - Change key from `users` to `views` in rm template to fix failure when collecting snmp server facts from devices 
+    that have a view defined in the configuration (https://github.com/ansible-collections/cisco.ios/issues/491).

--- a/changelogs/fragments/492-snmp-fact-view-key-correction.yaml
+++ b/changelogs/fragments/492-snmp-fact-view-key-correction.yaml
@@ -1,4 +1,4 @@
 ---
 bugfixes:
-  - `ios_snmp_server` - Change key from `users` to `views` in rm template to fix failure when collecting snmp server facts from devices 
-    that have a view defined in the configuration (https://github.com/ansible-collections/cisco.ios/issues/491).
+  - "`ios_snmp_server` - Change key from `users` to `views` in rm template to fix failure when collecting snmp server facts from devices
+    that have a view defined in the configuration (https://github.com/ansible-collections/cisco.ios/issues/491)."

--- a/changelogs/fragments/492-snmp-fact-view-key-correction.yaml
+++ b/changelogs/fragments/492-snmp-fact-view-key-correction.yaml
@@ -1,3 +1,4 @@
+---
 bugfixes:
   - `ios_snmp_server` - Change key from `users` to `views` in rm template to fix failure when collecting snmp server facts from devices 
     that have a view defined in the configuration (https://github.com/ansible-collections/cisco.ios/issues/491).

--- a/plugins/module_utils/network/ios/rm_templates/snmp_server.py
+++ b/plugins/module_utils/network/ios/rm_templates/snmp_server.py
@@ -437,7 +437,7 @@ class Snmp_serverTemplate(NetworkTemplate):
                       "{{ ' excluded' if excluded is defined else '' }}"
                       "{{ ' included' if included is defined else '' }}",
             "result": {
-                "users": [
+                "views": [
                     {
                         "name": "{{ name }}",
                         "family_name": "{{ family_name }}",


### PR DESCRIPTION
##### SUMMARY
Fix incorrect key name that causes snmp server fact collection to fail whenever a view is defined in the config.
Fix #491 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
`rm_templates.snmp_server.Snmp_serverTemplate`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
