### PR TITLE
Fix bgp_global errors.

### DIFF
--- a/changelogs/fragments/498-fix-bgp-global-peer-group.yaml
+++ b/changelogs/fragments/498-fix-bgp-global-peer-group.yaml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - "`ios_bgp_global` - Fix bgp_global error when peer-groups are defined.
+    Fix issue with peer-group neighbors not being found. (https://github.com/ansible-collections/cisco.ios/issues/318)."

--- a/plugins/module_utils/network/ios/argspec/bgp_global/bgp_global.py
+++ b/plugins/module_utils/network/ios/argspec/bgp_global/bgp_global.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2021 Red Hat
+# Copyright 2022 Red Hat
 # GNU General Public License v3.0+
 # (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
@@ -23,12 +23,12 @@ __metaclass__ = type
 #############################################
 
 """
-The arg spec for the cisco.ios_bgp_global module
+The arg spec for the ios_bgp_global module
 """
 
 
 class Bgp_globalArgs(object):  # pylint: disable=R0903
-    """The arg spec for the cisco.ios_bgp_global module
+    """The arg spec for the ios_bgp_global module
     """
 
     argument_spec = {
@@ -349,6 +349,9 @@ class Bgp_globalArgs(object):  # pylint: disable=R0903
                 "neighbor": {
                     "type": "list",
                     "elements": "dict",
+                    "mutually_exclusive": [
+                        ["address", "ipv6_adddress", "tag"]
+                    ],
                     "options": {
                         "address": {"type": "str"},
                         "tag": {"type": "str"},

--- a/plugins/module_utils/network/ios/config/bgp_global/bgp_global.py
+++ b/plugins/module_utils/network/ios/config/bgp_global/bgp_global.py
@@ -373,17 +373,25 @@ class Bgp_global(ResourceModule):
                                     for each in self.commands
                                     if "neighbor" not in each
                                 ]
+                                + list(set(
+                                    each
+                                    for each in self.commands
+                                    if each.startswith("neighbor")
+                                    and each.endswith("peer-group")
+                                 )) # make sure that we define the peer-group before other neighbors
                                 + [
                                     each
                                     for each in self.commands
                                     if "remote-as" in each
-                                    and "neighbor" in each
+                                    and each.startswith("neighbor")
+                                    and not each.endswith("peer-group")
                                 ]
                                 + [
                                     each
                                     for each in self.commands
                                     if "remote-as" not in each
-                                    and "neighbor" in each
+                                    and each.startswith("neighbor")
+                                    and not each.endswith("peer-group")
                                 ]
                             )
                         elif every == "redistribute":

--- a/plugins/module_utils/network/ios/rm_templates/bgp_global.py
+++ b/plugins/module_utils/network/ios/rm_templates/bgp_global.py
@@ -395,6 +395,7 @@ def _tmplt_neighbor(config_data):
         if "address" in config_data["neighbor"]:
             cmd += " {address}".format(**config_data["neighbor"])
         elif "tag" in config_data["neighbor"]:
+            commands.append("{0} {tag} peer-group".format(cmd, **config_data["neighbor"]))
             cmd += " {tag}".format(**config_data["neighbor"])
         elif "ipv6_adddress" in config_data["neighbor"]:
             cmd += " {ipv6_adddress}".format(**config_data["neighbor"])
@@ -1597,7 +1598,7 @@ class Bgp_globalTemplate(NetworkTemplate):
                                     'in' in path_attribute %}{{ True }}{% endif %}",
                             },
                         },
-                        "peer_group": "{{ listen.split('peer-group ')[1] if listen is defined and 'peer-group' in listen }}",
+                        "peer_group": "{{ peer_group.split('peer-group ')[1] if peer_group is defined and 'peer-group' in peer_group }}",
                         "remote_as": "{{ remote_as.split('remote-as ')[1] if remote_as is defined }}",
                         "remove_private_as": {
                             "set": "{{ True if remove_private_as is defined and remove_private_as.split(' ')|length == 1 }}",

--- a/plugins/modules/ios_bgp_global.py
+++ b/plugins/modules/ios_bgp_global.py
@@ -1,20 +1,9 @@
 #!/usr/bin/python
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
-#
+# -*- coding: utf-8 -*-
+# Copyright 2022 Red Hat
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
 """
 The module file for ios_bgp_global
 """
@@ -673,9 +662,10 @@ options:
             description: iBGP-secondary-multipath
             type: int
       neighbor:
-        description: Specify a neighbor router
+        description: Specify a neighbor router or create a peer group
         type: list
         elements: dict
+        mutually_exclusive: [["address", "ipv6_adddress", "tag"]]
         suboptions:
           address:
             description: Neighbor address (A.B.C.D)
@@ -1002,6 +992,7 @@ options:
           password:
             description: Set a password
             type: str
+            no_log: true
           path_attribute:
             description: BGP optional attribute filtering
             type: dict
@@ -2082,7 +2073,6 @@ EXAMPLES = """
 #             }
 #         ]
 #     }
-
 """
 
 RETURN = """


### PR DESCRIPTION

##### SUMMARY
Fix bgp_global error when peer-groups are defined.
The bgp_global module could only collect facts for ipv4 addresses.
Added the ability to work with ipv6 addresses and peer-groups.

Fix issue with peer-group neighbors not being found.

Fix #318 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
bgp_global

##### ADDITIONAL INFORMATION
The module would only accept IPv4 addresses as neighbors even though IPv6 addresses and peer-groups were defined in the argspec. Added path for all 3 to be created, and in the case of a peer-group, make sure that we define it in the config before using it in a neighbor.
