### PR TITLE
Fix multiple bgp_address_family issues.

### DIFF
--- a/changelogs/fragments/499-fix-bgp-af-issues.yaml
+++ b/changelogs/fragments/499-fix-bgp-af-issues.yaml
@@ -1,0 +1,8 @@
+---
+bugfixes:
+  - "`ios_bgp_address_family` - Fix multiple bgp_address_family issues.
+    Add `set` option in `send_community` to allow backwards compatiblity with older configs.
+    Add `set` option in `redistribute.connected` to allow ospf redistribution.
+    Fix issue with ipv6 and peer-group neighbor identification.
+    Add ability to pull `redistribute` information for address families to conform to argspec.
+    Fix issue with not pulling `local_as` when defined for neighbors."

--- a/docs/cisco.ios.ios_bgp_address_family_module.rst
+++ b/docs/cisco.ios.ios_bgp_address_family_module.rst
@@ -2542,7 +2542,7 @@ Parameters
                     <td class="elbow-placeholder"></td>
                 <td colspan="5">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
-                    <b>ipv6_adddress</b>
+                    <b>ipv6_address</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
                         <span style="color: purple">string</span>

--- a/docs/cisco.ios.ios_bgp_address_family_module.rst
+++ b/docs/cisco.ios.ios_bgp_address_family_module.rst
@@ -2542,7 +2542,7 @@ Parameters
                     <td class="elbow-placeholder"></td>
                 <td colspan="5">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
-                    <b>ipv6_address</b>
+                    <b>ipv6_adddress</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
                         <span style="color: purple">string</span>
@@ -2552,6 +2552,7 @@ Parameters
                 </td>
                 <td>
                         <div>Neighbor ipv6 address (X:X:X:X::X)</div>
+                        <div style="font-size: small; color: darkgreen"><br/>aliases: ipv6_address</div>
                 </td>
             </tr>
             <tr>

--- a/plugins/module_utils/network/ios/argspec/bgp_address_family/bgp_address_family.py
+++ b/plugins/module_utils/network/ios/argspec/bgp_address_family/bgp_address_family.py
@@ -433,6 +433,7 @@ class Bgp_address_familyArgs(object):  # pylint: disable=R0903
                                 "send_community": {
                                     "type": "dict",
                                     "options": {
+                                        "set": {"type": "bool"},
                                         "both": {"type": "bool"},
                                         "extended": {"type": "bool"},
                                         "standard": {"type": "bool"},
@@ -548,6 +549,7 @@ class Bgp_address_familyArgs(object):  # pylint: disable=R0903
                                 "connected": {
                                     "type": "dict",
                                     "options": {
+                                        "set": {"type": "bool"},
                                         "metric": {"type": "int"},
                                         "route_map": {"type": "str"},
                                     },

--- a/plugins/module_utils/network/ios/argspec/bgp_address_family/bgp_address_family.py
+++ b/plugins/module_utils/network/ios/argspec/bgp_address_family/bgp_address_family.py
@@ -166,7 +166,7 @@ class Bgp_address_familyArgs(object):  # pylint: disable=R0903
                             "options": {
                                 "address": {"type": "str"},
                                 "tag": {"type": "str"},
-                                "ipv6_adddress": {"type": "str"},
+                                "ipv6_address": {"type": "str"},
                                 "activate": {"type": "bool"},
                                 "additional_paths": {
                                     "type": "dict",

--- a/plugins/module_utils/network/ios/argspec/bgp_address_family/bgp_address_family.py
+++ b/plugins/module_utils/network/ios/argspec/bgp_address_family/bgp_address_family.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2021 Red Hat
+# Copyright 2022 Red Hat
 # GNU General Public License v3.0+
 # (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
@@ -166,7 +166,10 @@ class Bgp_address_familyArgs(object):  # pylint: disable=R0903
                             "options": {
                                 "address": {"type": "str"},
                                 "tag": {"type": "str"},
-                                "ipv6_address": {"type": "str"},
+                                "ipv6_adddress": {
+                                    "type": "str",
+                                    "aliases": ["ipv6_address"],
+                                },
                                 "activate": {"type": "bool"},
                                 "additional_paths": {
                                     "type": "dict",

--- a/plugins/module_utils/network/ios/config/bgp_address_family/bgp_address_family.py
+++ b/plugins/module_utils/network/ios/config/bgp_address_family/bgp_address_family.py
@@ -255,7 +255,7 @@ class Bgp_address_family(ResourceModule):
             "neighbor.route_maps",
             "neighbor.slow_peer",
         ]
-        neighbor_key = ["address", "ipv6_address", "tag"]
+        neighbor_key = ["address", "ipv6_adddress", "tag"]
         deprecated = False
         w = want.get("neighbor", {}) if want else {}
         if have:
@@ -508,7 +508,7 @@ class Bgp_address_family(ResourceModule):
                             }
                     val["neighbor"] = {
                         each.get("address")
-                        or each.get("ipv6_address")
+                        or each.get("ipv6_adddress")
                         or each.get("tag"): each
                         for each in val.get("neighbor", [])
                     }

--- a/plugins/module_utils/network/ios/config/bgp_address_family/bgp_address_family.py
+++ b/plugins/module_utils/network/ios/config/bgp_address_family/bgp_address_family.py
@@ -46,6 +46,7 @@ class Bgp_address_family(ResourceModule):
         "default_metric",
         "distance",
         "table_map",
+        "redistribute",
     ]
 
     def __init__(self, module):
@@ -372,8 +373,8 @@ class Bgp_address_family(ResourceModule):
                     parsers=parsers, want=dict(), have={"neighbor": val}
                 )
             count = 0
-            remote = None
-            activate = None
+            remote = 0
+            activate = 0
             for each in self.commands:
                 if "no" in each and "remote-as" in each:
                     remote = count
@@ -516,6 +517,11 @@ class Bgp_address_family(ResourceModule):
                     for each in val.get("network", []):
                         temp.update({each["address"]: each})
                     val["network"] = temp
+                if "redistribute" in val:
+                    temp = {}
+                    for each in val.get("redistribute", []):
+                        temp.update(each)
+                    val["redistribute"] = temp
 
     def handle_deprecated(self, want_to_validate):
         if want_to_validate.get("next_hop_self") and want_to_validate.get(

--- a/plugins/module_utils/network/ios/facts/bgp_address_family/bgp_address_family.py
+++ b/plugins/module_utils/network/ios/facts/bgp_address_family/bgp_address_family.py
@@ -73,7 +73,7 @@ class Bgp_address_familyFacts(object):
                             for neighbor_type in [
                                 "address",
                                 "ipv6_address",
-                                "tag"
+                                "tag",
                             ]:
                                 try:
                                     if (

--- a/plugins/module_utils/network/ios/facts/bgp_address_family/bgp_address_family.py
+++ b/plugins/module_utils/network/ios/facts/bgp_address_family/bgp_address_family.py
@@ -88,35 +88,25 @@ class Bgp_address_familyFacts(object):
                     temp, al = {}, {}
                     temp_param, neighbor_identifier = None, None
 
+                    neighbor_type_list = ["address", "ipv6_address", "tag"]
+
                     for each in neighbor:
                         if temp_param and not each.get(temp_param) and temp:
                             temp.update({temp_param: temp_param_list})
                             _update_neighor_list(neighbor_list, temp)
                             temp_param_list = []
                             temp = {}
-                        if (
-                            each.get("address")
-                            or each.get("ipv6_address")
-                            or each.get("tag")
-                        ) != neighbor_identifier:
-                            neighbor_identifier = (
-                                each.get("address")
-                                or each.get("ipv6_address")
-                                or each.get("tag")
-                            )
-                            if "address" in each:
-                                temp["address"] = neighbor_identifier
-                            elif "ipv6_address" in each:
-                                temp["ipv6_address"] = neighbor_identifier
-                            else:
-                                temp["tag"] = neighbor_identifier
-                        temp.update(each)
-                        if not al.get(
-                            each.get("address")
-                        ):  # adds multiple nighbors
-                            al[each.get("address")] = each
-                        else:
-                            al.get(each.get("address")).update(each)
+                        for neighbor_type in neighbor_type_list:
+                            try:
+                                temp[neighbor_type] = each[neighbor_type]
+                                temp.update(each)
+                                if not al.get(each.get(neighbor_type)):
+                                    al[each.get(neighbor_type)] = each
+                                else:
+                                    al.get(each.get(neighbor_type)).update(each)
+                                break
+                            except KeyError:
+                                continue
                         for param in [
                             "prefix_lists",
                             "route_maps",

--- a/plugins/module_utils/network/ios/facts/bgp_address_family/bgp_address_family.py
+++ b/plugins/module_utils/network/ios/facts/bgp_address_family/bgp_address_family.py
@@ -70,9 +70,14 @@ class Bgp_address_familyFacts(object):
                         set = False
                         temp = utils.remove_empties(temp)
                         for each in neighbor_list:
-                            if neighbor_identifier == each["address"]:
-                                each.update(temp)
-                                set = True
+                            for neighbor_type in ["address","ipv6_address","tag"]:
+                                try:
+                                    if neighbor_identifier == each[neighbor_type]:
+                                        each.update(temp)
+                                        set = True
+                                        break
+                                except KeyError:
+                                    continue
                         if not neighbor_list or not set:
                             if alter:
                                 neighbor_list.extend(list(alter.values()))

--- a/plugins/module_utils/network/ios/facts/bgp_address_family/bgp_address_family.py
+++ b/plugins/module_utils/network/ios/facts/bgp_address_family/bgp_address_family.py
@@ -72,7 +72,7 @@ class Bgp_address_familyFacts(object):
                         for each in neighbor_list:
                             for neighbor_type in [
                                 "address",
-                                "ipv6_address",
+                                "ipv6_adddress",
                                 "tag",
                             ]:
                                 try:
@@ -95,7 +95,7 @@ class Bgp_address_familyFacts(object):
                     temp, al = {}, {}
                     temp_param, neighbor_identifier = None, None
 
-                    neighbor_type_list = ["address", "ipv6_address", "tag"]
+                    neighbor_type_list = ["address", "ipv6_adddress", "tag"]
 
                     for each in neighbor:
                         if temp_param and not each.get(temp_param) and temp:

--- a/plugins/module_utils/network/ios/facts/bgp_address_family/bgp_address_family.py
+++ b/plugins/module_utils/network/ios/facts/bgp_address_family/bgp_address_family.py
@@ -70,9 +70,16 @@ class Bgp_address_familyFacts(object):
                         set = False
                         temp = utils.remove_empties(temp)
                         for each in neighbor_list:
-                            for neighbor_type in ["address", "ipv6_address", "tag"]:
+                            for neighbor_type in [
+                                "address",
+                                "ipv6_address",
+                                "tag"
+                            ]:
                                 try:
-                                    if neighbor_identifier == each[neighbor_type]:
+                                    if (
+                                        neighbor_identifier
+                                        == each[neighbor_type]
+                                    ):
                                         each.update(temp)
                                         set = True
                                         break
@@ -103,7 +110,9 @@ class Bgp_address_familyFacts(object):
                                 if not al.get(each.get(neighbor_type)):
                                     al[each.get(neighbor_type)] = each
                                 else:
-                                    al.get(each.get(neighbor_type)).update(each)
+                                    al.get(each.get(neighbor_type)).update(
+                                        each
+                                    )
                                 break
                             except KeyError:
                                 continue

--- a/plugins/module_utils/network/ios/facts/bgp_address_family/bgp_address_family.py
+++ b/plugins/module_utils/network/ios/facts/bgp_address_family/bgp_address_family.py
@@ -70,7 +70,7 @@ class Bgp_address_familyFacts(object):
                         set = False
                         temp = utils.remove_empties(temp)
                         for each in neighbor_list:
-                            for neighbor_type in ["address","ipv6_address","tag"]:
+                            for neighbor_type in ["address", "ipv6_address", "tag"]:
                                 try:
                                     if neighbor_identifier == each[neighbor_type]:
                                         each.update(temp)

--- a/plugins/module_utils/network/ios/rm_templates/bgp_address_family.py
+++ b/plugins/module_utils/network/ios/rm_templates/bgp_address_family.py
@@ -859,7 +859,6 @@ def _tmplt_af_redistribute(config_data):
         return command
 
 
-
 class Bgp_address_familyTemplate(NetworkTemplate):
     def __init__(self, lines=None, module=None):
         super(Bgp_address_familyTemplate, self).__init__(
@@ -1634,7 +1633,8 @@ class Bgp_address_familyTemplate(NetworkTemplate):
                                 "application": {
                                     "name": "{{ application.split(' ')[1] if application is defined }}",
                                     "metric": "{{ application.split('metric ')[1].split(' ')[0] if application is defined and 'metric' in application }}",
-                                    "route_map": "{{ application.split('route-map ')[1].split(' ')[0] if application is defined and 'route-map' in application }}",
+                                    "route_map": "{{ application.split('route-map ')[1].split(' ')[0] if application is defined and\
+                                        'route-map' in application }}",
                                 },
                                 "bgp": {
                                     "as_number": "{{ bgp.split(' ')[1] if bgp is defined }}",

--- a/plugins/module_utils/network/ios/rm_templates/bgp_address_family.py
+++ b/plugins/module_utils/network/ios/rm_templates/bgp_address_family.py
@@ -204,8 +204,8 @@ def _tmplt_af_neighbor(config_data):
             cmd += " {address}".format(**config_data["neighbor"])
         elif "tag" in config_data["neighbor"]:
             cmd += " {tag}".format(**config_data["neighbor"])
-        elif "ipv6_address" in config_data["neighbor"]:
-            cmd += " {ipv6_address}".format(**config_data["neighbor"])
+        elif "ipv6_adddress" in config_data["neighbor"]:
+            cmd += " {ipv6_adddress}".format(**config_data["neighbor"])
         if "peer_group" in config_data["neighbor"]:
             commands.append(
                 "{0} peer-group {peer_group}".format(
@@ -554,8 +554,8 @@ def _tmplt_neighbor_af_prefix_lists(config_data):
             cmd += " {address}".format(**config_data["neighbor"])
         elif "tag" in config_data["neighbor"]:
             cmd += " {tag}".format(**config_data["neighbor"])
-        elif "ipv6_address" in config_data["neighbor"]:
-            cmd += " {ipv6_address}".format(**config_data["neighbor"])
+        elif "ipv6_adddress" in config_data["neighbor"]:
+            cmd += " {ipv6_adddress}".format(**config_data["neighbor"])
         cmd = "{0} prefix-list {name}".format(
             cmd, **config_data["neighbor"]["prefix_lists"]
         )
@@ -577,8 +577,8 @@ def _tmplt_neighbor_af_route_maps(config_data):
             cmd += " {address}".format(**config_data["neighbor"])
         elif "tag" in config_data["neighbor"]:
             cmd += " {tag}".format(**config_data["neighbor"])
-        elif "ipv6_address" in config_data["neighbor"]:
-            cmd += " {ipv6_address}".format(**config_data["neighbor"])
+        elif "ipv6_adddress" in config_data["neighbor"]:
+            cmd += " {ipv6_adddress}".format(**config_data["neighbor"])
         cmd = "{0} route-map".format(cmd)
         if "name" in config_data["neighbor"]["route_maps"]:
             cmd += " {name}".format(**config_data["neighbor"]["route_maps"])
@@ -596,8 +596,8 @@ def _tmplt_neighbor_af_slow_peer(config_data):
             cmd += " {address}".format(**config_data["neighbor"])
         elif "tag" in config_data["neighbor"]:
             cmd += " {tag}".format(**config_data["neighbor"])
-        elif "ipv6_address" in config_data["neighbor"]:
-            cmd += " {ipv6_address}".format(**config_data["neighbor"])
+        elif "ipv6_adddress" in config_data["neighbor"]:
+            cmd += " {ipv6_adddress}".format(**config_data["neighbor"])
         cmd = "{0} slow-peer".format(cmd)
         if "detection" in config_data["neighbor"]["slow_peer"]:
             cmd += " detection"
@@ -1169,7 +1169,7 @@ class Bgp_address_familyTemplate(NetworkTemplate):
                         "neighbor": [
                             {
                                 "address": "{{ neighbor if ':' not in neighbor and '.' in neighbor }}",
-                                "ipv6_address": "{{ neighbor if ':' in neighbor and '.' not in neighbor }}",
+                                "ipv6_adddress": "{{ neighbor if ':' in neighbor and '.' not in neighbor }}",
                                 "tag": "{{ neighbor if ':' not in neighbor and '.' not in neighbor }}",
                                 "prefix_lists": [
                                     {
@@ -1200,7 +1200,7 @@ class Bgp_address_familyTemplate(NetworkTemplate):
                         "neighbor": [
                             {
                                 "address": "{{ neighbor if ':' not in neighbor and '.' in neighbor }}",
-                                "ipv6_address": "{{ neighbor if ':' in neighbor and '.' not in neighbor }}",
+                                "ipv6_adddress": "{{ neighbor if ':' in neighbor and '.' not in neighbor }}",
                                 "tag": "{{ neighbor if ':' not in neighbor and '.' not in neighbor }}",
                                 "route_maps": [
                                     {
@@ -1272,7 +1272,7 @@ class Bgp_address_familyTemplate(NetworkTemplate):
                         "neighbor": [
                             {
                                 "address": "{{ neighbor if ':' not in neighbor and '.' in neighbor }}",
-                                "ipv6_address": "{{ neighbor if ':' in neighbor and '.' not in neighbor }}",
+                                "ipv6_adddress": "{{ neighbor if ':' in neighbor and '.' not in neighbor }}",
                                 "tag": "{{ neighbor if ':' not in neighbor and '.' not in neighbor }}",
                                 "activate": "{{ True if activate is defined }}",
                                 "additional_paths": {
@@ -1471,7 +1471,7 @@ class Bgp_address_familyTemplate(NetworkTemplate):
                         "neighbor": [
                             {
                                 "address": "{{ neighbor if ':' not in neighbor and '.' in neighbor }}",
-                                "ipv6_address": "{{ neighbor if ':' in neighbor and '.' not in neighbor }}",
+                                "ipv6_adddress": "{{ neighbor if ':' in neighbor and '.' not in neighbor }}",
                                 "tag": "{{ neighbor if ':' not in neighbor and '.' not in neighbor }}",
                                 "slow_peer": [
                                     {

--- a/plugins/module_utils/network/ios/rm_templates/bgp_address_family.py
+++ b/plugins/module_utils/network/ios/rm_templates/bgp_address_family.py
@@ -747,14 +747,12 @@ def _tmplt_af_redistribute(config_data):
         command = "redistribute"
         if config_data["redistribute"].get("application"):
             cmd = "{0} application {name}".format(
-                command,
-                **config_data["redistribute"]["application"]
+                command, **config_data["redistribute"]["application"]
             )
             common_config(cmd, "application")
         if config_data["redistribute"].get("bgp"):
             cmd = "{0} bgp {as_number}".format(
-                command,
-                **config_data["redistribute"]["bgp"]
+                command, **config_data["redistribute"]["bgp"]
             )
             common_config(cmd, "bgp")
         if config_data["redistribute"].get("connected"):
@@ -762,14 +760,12 @@ def _tmplt_af_redistribute(config_data):
             common_config(cmd, "connected")
         if config_data["redistribute"].get("eigrp"):
             cmd = "{0} eigrp {as_number}".format(
-                command,
-                **config_data["redistribute"]["eigrp"]
+                command, **config_data["redistribute"]["eigrp"]
             )
             common_config(cmd, "eigrp")
         if config_data["redistribute"].get("isis"):
             cmd = "{0} isis {area_tag}".format(
-                command,
-                **config_data["redistribute"]["isis"]
+                command, **config_data["redistribute"]["isis"]
             )
             if config_data["redistribute"]["isis"].get("clns"):
                 cmd += " clns"
@@ -778,8 +774,7 @@ def _tmplt_af_redistribute(config_data):
             common_config(cmd, "isis")
         if config_data["redistribute"].get("iso_igrp"):
             cmd = "{0} iso-igrp {area_tag}".format(
-                command,
-                **config_data["redistribute"]["iso_igrp"]
+                command, **config_data["redistribute"]["iso_igrp"]
             )
             if config_data["redistribute"]["iso_igrp"].get("route_map"):
                 cmd += " route-map {route_map}".format(
@@ -800,8 +795,7 @@ def _tmplt_af_redistribute(config_data):
             common_config(cmd, "rip")
         if config_data["redistribute"].get("ospf"):
             cmd = "{0} ospf {process_id}".format(
-                command,
-                **config_data["redistribute"]["ospf"]
+                command, **config_data["redistribute"]["ospf"]
             )
             common_config(cmd, "ospf")
             if config_data["redistribute"]["ospf"].get("match"):
@@ -819,20 +813,21 @@ def _tmplt_af_redistribute(config_data):
                     "nssa_external"
                 ):
                     external_type = " nssa-external"
-                if config_data["redistribute"]["ospf"]["match"].get(
-                    "type_1"
-                ) and external_type:
+                if (
+                    config_data["redistribute"]["ospf"]["match"].get("type_1")
+                    and external_type
+                ):
                     commands[-1] += "{0} 1".format(external_type)
-                if config_data["redistribute"]["ospf"]["match"].get(
-                    "type_2"
-                ) and external_type:
+                if (
+                    config_data["redistribute"]["ospf"]["match"].get("type_2")
+                    and external_type
+                ):
                     commands[-1] += "{0} 2".format(external_type)
             if config_data["redistribute"]["ospf"].get("vrf"):
                 commands[-1] += " vrf"
         if config_data["redistribute"].get("ospfv3"):
             cmd = "{0} ospfv3 {process_id}".format(
-                command,
-                **config_data["redistribute"]["ospfv3"]
+                command, **config_data["redistribute"]["ospfv3"]
             )
             if config_data["redistribute"]["ospfv3"].get("match"):
                 cmd += " match"
@@ -863,8 +858,7 @@ def _tmplt_af_redistribute(config_data):
         if config_data["redistribute"].get("vrf"):
             if config_data["redistribute"]["vrf"].get("name"):
                 cmd = "{0} vrf {name}".format(
-                    command,
-                    **config_data["redistribute"]["vrf"]
+                    command, **config_data["redistribute"]["vrf"]
                 )
             elif config_data["redistribute"]["vrf"].get("global"):
                 cmd = "{0} vrf global".format(command)
@@ -1732,6 +1726,6 @@ class Bgp_address_familyTemplate(NetworkTemplate):
                         ]
                     }
                 }
-            }
+            },
         },
     ]

--- a/plugins/module_utils/network/ios/rm_templates/bgp_address_family.py
+++ b/plugins/module_utils/network/ios/rm_templates/bgp_address_family.py
@@ -204,8 +204,8 @@ def _tmplt_af_neighbor(config_data):
             cmd += " {address}".format(**config_data["neighbor"])
         elif "tag" in config_data["neighbor"]:
             cmd += " {tag}".format(**config_data["neighbor"])
-        elif "ipv6_adddress" in config_data["neighbor"]:
-            cmd += " {ipv6_adddress}".format(**config_data["neighbor"])
+        elif "ipv6_address" in config_data["neighbor"]:
+            cmd += " {ipv6_address}".format(**config_data["neighbor"])
         if "peer_group" in config_data["neighbor"]:
             commands.append(
                 "{0} peer-group {peer_group}".format(
@@ -554,8 +554,8 @@ def _tmplt_neighbor_af_prefix_lists(config_data):
             cmd += " {address}".format(**config_data["neighbor"])
         elif "tag" in config_data["neighbor"]:
             cmd += " {tag}".format(**config_data["neighbor"])
-        elif "ipv6_adddress" in config_data["neighbor"]:
-            cmd += " {ipv6_adddress}".format(**config_data["neighbor"])
+        elif "ipv6_address" in config_data["neighbor"]:
+            cmd += " {ipv6_address}".format(**config_data["neighbor"])
         cmd = "{0} prefix-list {name}".format(
             cmd, **config_data["neighbor"]["prefix_lists"]
         )
@@ -577,8 +577,8 @@ def _tmplt_neighbor_af_route_maps(config_data):
             cmd += " {address}".format(**config_data["neighbor"])
         elif "tag" in config_data["neighbor"]:
             cmd += " {tag}".format(**config_data["neighbor"])
-        elif "ipv6_adddress" in config_data["neighbor"]:
-            cmd += " {ipv6_adddress}".format(**config_data["neighbor"])
+        elif "ipv6_address" in config_data["neighbor"]:
+            cmd += " {ipv6_address}".format(**config_data["neighbor"])
         cmd = "{0} route-map".format(cmd)
         if "name" in config_data["neighbor"]["route_maps"]:
             cmd += " {name}".format(**config_data["neighbor"]["route_maps"])
@@ -596,8 +596,8 @@ def _tmplt_neighbor_af_slow_peer(config_data):
             cmd += " {address}".format(**config_data["neighbor"])
         elif "tag" in config_data["neighbor"]:
             cmd += " {tag}".format(**config_data["neighbor"])
-        elif "ipv6_adddress" in config_data["neighbor"]:
-            cmd += " {ipv6_adddress}".format(**config_data["neighbor"])
+        elif "ipv6_address" in config_data["neighbor"]:
+            cmd += " {ipv6_address}".format(**config_data["neighbor"])
         cmd = "{0} slow-peer".format(cmd)
         if "detection" in config_data["neighbor"]["slow_peer"]:
             cmd += " detection"
@@ -731,6 +731,7 @@ def _tmplt_af_table_map(config_data):
 
 def _tmplt_af_redistribute(config_data):
     if "redistribute" in config_data:
+        commands = []
 
         def common_config(command, param):
             if config_data["redistribute"][param].get("metric"):
@@ -741,122 +742,135 @@ def _tmplt_af_redistribute(config_data):
                 command += " route-map {route_map}".format(
                     **config_data["redistribute"][param]
                 )
-            return command
+            commands.append(command)
 
         command = "redistribute"
         if config_data["redistribute"].get("application"):
-            command += " application {name}".format(
+            cmd = "{0} application {name}".format(
+                command,
                 **config_data["redistribute"]["application"]
             )
-            command = common_config(command, "application")
-        elif config_data["redistribute"].get("bgp"):
-            command += " bgp {as_number}".format(
+            common_config(cmd, "application")
+        if config_data["redistribute"].get("bgp"):
+            cmd = "{0} bgp {as_number}".format(
+                command,
                 **config_data["redistribute"]["bgp"]
             )
-            command = common_config(command, "bgp")
-        elif config_data["redistribute"].get("connected"):
-            command += " connected"
-            command = common_config(command, "connected")
-        elif config_data["redistribute"].get("eigrp"):
-            command += " eigrp {as_number}".format(
+            common_config(cmd, "bgp")
+        if config_data["redistribute"].get("connected"):
+            cmd = "{0} connected".format(command)
+            common_config(cmd, "connected")
+        if config_data["redistribute"].get("eigrp"):
+            cmd = "{0} eigrp {as_number}".format(
+                command,
                 **config_data["redistribute"]["eigrp"]
             )
-            command = common_config(command, "eigrp")
-        elif config_data["redistribute"].get("isis"):
-            command += " isis {area_tag}".format(
+            common_config(cmd, "eigrp")
+        if config_data["redistribute"].get("isis"):
+            cmd = "{0} isis {area_tag}".format(
+                command,
                 **config_data["redistribute"]["isis"]
             )
             if config_data["redistribute"]["isis"].get("clns"):
-                command += " clns"
+                cmd += " clns"
             elif config_data["redistribute"]["isis"].get("ip"):
-                command += " ip"
-            command = common_config(command, "isis")
-        elif config_data["redistribute"].get("iso_igrp"):
-            command += " iso-igrp {area_tag}".format(
+                cmd += " ip"
+            common_config(cmd, "isis")
+        if config_data["redistribute"].get("iso_igrp"):
+            cmd = "{0} iso-igrp {area_tag}".format(
+                command,
                 **config_data["redistribute"]["iso_igrp"]
             )
             if config_data["redistribute"]["iso_igrp"].get("route_map"):
-                command += " route-map {route_map}".format(
+                cmd += " route-map {route_map}".format(
                     **config_data["redistribute"]["iso_igrp"]
                 )
-        elif config_data["redistribute"].get("lisp"):
-            command += " lisp"
-            command = common_config(command, "lisp")
-        elif config_data["redistribute"].get("mobile"):
-            command += " mobile"
-            command = common_config(command, "mobile")
-        elif config_data["redistribute"].get("odr"):
-            command += " odr"
-            command = common_config(command, "odr")
-        elif config_data["redistribute"].get("rip"):
-            command += " rip"
-            command = common_config(command, "rip")
-        elif config_data["redistribute"].get("ospf"):
-            command += " ospf {process_id}".format(
+            common_config(cmd, "iso_igrp")
+        if config_data["redistribute"].get("lisp"):
+            cmd = "{0} lisp".format(command)
+            common_config(cmd, "lisp")
+        if config_data["redistribute"].get("mobile"):
+            cmd = "{0} mobile".format(command)
+            common_config(cmd, "mobile")
+        if config_data["redistribute"].get("odr"):
+            cmd = "{0} odr".format(command)
+            common_config(cmd, "odr")
+        if config_data["redistribute"].get("rip"):
+            cmd = "{0} rip".format(command)
+            common_config(cmd, "rip")
+        if config_data["redistribute"].get("ospf"):
+            cmd = "{0} ospf {process_id}".format(
+                command,
                 **config_data["redistribute"]["ospf"]
             )
+            common_config(cmd, "ospf")
             if config_data["redistribute"]["ospf"].get("match"):
-                command += " match"
-                if config_data["redistribute"]["ospf"]["match"].get(
-                    "external"
-                ):
-                    command += " external"
+                external_type = None
+                commands[-1] += " match"
                 if config_data["redistribute"]["ospf"]["match"].get(
                     "internal"
                 ):
-                    command += " internal"
+                    commands[-1] += " internal"
+                if config_data["redistribute"]["ospf"]["match"].get(
+                    "external"
+                ):
+                    external_type = " external"
                 if config_data["redistribute"]["ospf"]["match"].get(
                     "nssa_external"
                 ):
-                    command += " nssa-external"
-                if config_data["redistribute"]["ospf"]["match"].get("type_1"):
-                    command += " 1"
-                elif config_data["redistribute"]["ospf"]["match"].get(
+                    external_type = " nssa-external"
+                if config_data["redistribute"]["ospf"]["match"].get(
+                    "type_1"
+                ) and external_type:
+                    commands[-1] += "{0} 1".format(external_type)
+                if config_data["redistribute"]["ospf"]["match"].get(
                     "type_2"
-                ):
-                    command += " 2"
+                ) and external_type:
+                    commands[-1] += "{0} 2".format(external_type)
             if config_data["redistribute"]["ospf"].get("vrf"):
-                command += " vrf"
-            command = common_config(command, "ospf")
-        elif config_data["redistribute"].get("ospfv3"):
-            command += " ospfv3 {process_id}".format(
+                commands[-1] += " vrf"
+        if config_data["redistribute"].get("ospfv3"):
+            cmd = "{0} ospfv3 {process_id}".format(
+                command,
                 **config_data["redistribute"]["ospfv3"]
             )
             if config_data["redistribute"]["ospfv3"].get("match"):
-                command += " match"
+                cmd += " match"
                 if config_data["redistribute"]["ospfv3"]["match"].get(
                     "external"
                 ):
-                    command += " external"
+                    cmd += " external"
                 if config_data["redistribute"]["ospfv3"]["match"].get(
                     "internal"
                 ):
-                    command += " internal"
+                    cmd += " internal"
                 if config_data["redistribute"]["ospfv3"]["match"].get(
                     "nssa_external"
                 ):
-                    command += " nssa-external"
+                    cmd += " nssa-external"
                 if config_data["redistribute"]["ospfv3"]["match"].get(
                     "type_1"
                 ):
-                    command += " 1"
+                    cmd += " 1"
                 elif config_data["redistribute"]["ospfv3"]["match"].get(
                     "type_2"
                 ):
-                    command += " 2"
-            command = common_config(command, "ospf")
-        elif config_data["redistribute"].get("static"):
-            command += " static"
-            command = common_config(command, "static")
-        elif config_data["redistribute"].get("vrf"):
+                    cmd += " 2"
+            common_config(cmd, "ospf")
+        if config_data["redistribute"].get("static"):
+            cmd += "{0} static".format(command)
+            common_config(cmd, "static")
+        if config_data["redistribute"].get("vrf"):
             if config_data["redistribute"]["vrf"].get("name"):
-                command += " vrf {name}".format(
+                cmd = "{0} vrf {name}".format(
+                    command,
                     **config_data["redistribute"]["vrf"]
                 )
             elif config_data["redistribute"]["vrf"].get("global"):
-                command += " vrf global"
+                cmd = "{0} vrf global".format(command)
+            common_config(cmd, "vrf")
 
-        return command
+        return commands
 
 
 class Bgp_address_familyTemplate(NetworkTemplate):
@@ -1161,7 +1175,7 @@ class Bgp_address_familyTemplate(NetworkTemplate):
                         "neighbor": [
                             {
                                 "address": "{{ neighbor if ':' not in neighbor and '.' in neighbor }}",
-                                "ipv6_address": "{{ neighbor if ':' in neighbor and '.' in neighbor }}",
+                                "ipv6_address": "{{ neighbor if ':' in neighbor and '.' not in neighbor }}",
                                 "tag": "{{ neighbor if ':' not in neighbor and '.' not in neighbor }}",
                                 "prefix_lists": [
                                     {
@@ -1192,7 +1206,7 @@ class Bgp_address_familyTemplate(NetworkTemplate):
                         "neighbor": [
                             {
                                 "address": "{{ neighbor if ':' not in neighbor and '.' in neighbor }}",
-                                "ipv6_address": "{{ neighbor if ':' in neighbor and '.' in neighbor }}",
+                                "ipv6_address": "{{ neighbor if ':' in neighbor and '.' not in neighbor }}",
                                 "tag": "{{ neighbor if ':' not in neighbor and '.' not in neighbor }}",
                                 "route_maps": [
                                     {
@@ -1264,7 +1278,7 @@ class Bgp_address_familyTemplate(NetworkTemplate):
                         "neighbor": [
                             {
                                 "address": "{{ neighbor if ':' not in neighbor and '.' in neighbor }}",
-                                "ipv6_address": "{{ neighbor if ':' in neighbor and '.' in neighbor }}",
+                                "ipv6_address": "{{ neighbor if ':' in neighbor and '.' not in neighbor }}",
                                 "tag": "{{ neighbor if ':' not in neighbor and '.' not in neighbor }}",
                                 "activate": "{{ True if activate is defined }}",
                                 "additional_paths": {
@@ -1463,7 +1477,7 @@ class Bgp_address_familyTemplate(NetworkTemplate):
                         "neighbor": [
                             {
                                 "address": "{{ neighbor if ':' not in neighbor and '.' in neighbor }}",
-                                "ipv6_address": "{{ neighbor if ':' in neighbor and '.' in neighbor }}",
+                                "ipv6_address": "{{ neighbor if ':' in neighbor and '.' not in neighbor }}",
                                 "tag": "{{ neighbor if ':' not in neighbor and '.' not in neighbor }}",
                                 "slow_peer": [
                                     {

--- a/plugins/module_utils/network/ios/rm_templates/bgp_address_family.py
+++ b/plugins/module_utils/network/ios/rm_templates/bgp_address_family.py
@@ -729,6 +729,137 @@ def _tmplt_af_table_map(config_data):
         return cmd
 
 
+def _tmplt_af_redistribute(config_data):
+    if "redistribute" in config_data:
+
+        def common_config(command, param):
+            if config_data["redistribute"][param].get("metric"):
+                command += " metric {metric}".format(
+                    **config_data["redistribute"][param]
+                )
+            if config_data["redistribute"][param].get("route_map"):
+                command += " route-map {route_map}".format(
+                    **config_data["redistribute"][param]
+                )
+            return command
+
+        command = "redistribute"
+        if config_data["redistribute"].get("application"):
+            command += " application {name}".format(
+                **config_data["redistribute"]["application"]
+            )
+            command = common_config(command, "application")
+        elif config_data["redistribute"].get("bgp"):
+            command += " bgp {as_number}".format(
+                **config_data["redistribute"]["bgp"]
+            )
+            command = common_config(command, "bgp")
+        elif config_data["redistribute"].get("connected"):
+            command += " connected"
+            command = common_config(command, "connected")
+        elif config_data["redistribute"].get("eigrp"):
+            command += " eigrp {as_number}".format(
+                **config_data["redistribute"]["eigrp"]
+            )
+            command = common_config(command, "eigrp")
+        elif config_data["redistribute"].get("isis"):
+            command += " isis {area_tag}".format(
+                **config_data["redistribute"]["isis"]
+            )
+            if config_data["redistribute"]["isis"].get("clns"):
+                command += " clns"
+            elif config_data["redistribute"]["isis"].get("ip"):
+                command += " ip"
+            command = common_config(command, "isis")
+        elif config_data["redistribute"].get("iso_igrp"):
+            command += " iso-igrp {area_tag}".format(
+                **config_data["redistribute"]["iso_igrp"]
+            )
+            if config_data["redistribute"]["iso_igrp"].get("route_map"):
+                command += " route-map {route_map}".format(
+                    **config_data["redistribute"]["iso_igrp"]
+                )
+        elif config_data["redistribute"].get("lisp"):
+            command += " lisp"
+            command = common_config(command, "lisp")
+        elif config_data["redistribute"].get("mobile"):
+            command += " mobile"
+            command = common_config(command, "mobile")
+        elif config_data["redistribute"].get("odr"):
+            command += " odr"
+            command = common_config(command, "odr")
+        elif config_data["redistribute"].get("rip"):
+            command += " rip"
+            command = common_config(command, "rip")
+        elif config_data["redistribute"].get("ospf"):
+            command += " ospf {process_id}".format(
+                **config_data["redistribute"]["ospf"]
+            )
+            if config_data["redistribute"]["ospf"].get("match"):
+                command += " match"
+                if config_data["redistribute"]["ospf"]["match"].get(
+                    "external"
+                ):
+                    command += " external"
+                if config_data["redistribute"]["ospf"]["match"].get(
+                    "internal"
+                ):
+                    command += " internal"
+                if config_data["redistribute"]["ospf"]["match"].get(
+                    "nssa_external"
+                ):
+                    command += " nssa-external"
+                if config_data["redistribute"]["ospf"]["match"].get("type_1"):
+                    command += " 1"
+                elif config_data["redistribute"]["ospf"]["match"].get(
+                    "type_2"
+                ):
+                    command += " 2"
+            if config_data["redistribute"]["ospf"].get("vrf"):
+                command += " vrf"
+            command = common_config(command, "ospf")
+        elif config_data["redistribute"].get("ospfv3"):
+            command += " ospfv3 {process_id}".format(
+                **config_data["redistribute"]["ospfv3"]
+            )
+            if config_data["redistribute"]["ospfv3"].get("match"):
+                command += " match"
+                if config_data["redistribute"]["ospfv3"]["match"].get(
+                    "external"
+                ):
+                    command += " external"
+                if config_data["redistribute"]["ospfv3"]["match"].get(
+                    "internal"
+                ):
+                    command += " internal"
+                if config_data["redistribute"]["ospfv3"]["match"].get(
+                    "nssa_external"
+                ):
+                    command += " nssa-external"
+                if config_data["redistribute"]["ospfv3"]["match"].get(
+                    "type_1"
+                ):
+                    command += " 1"
+                elif config_data["redistribute"]["ospfv3"]["match"].get(
+                    "type_2"
+                ):
+                    command += " 2"
+            command = common_config(command, "ospf")
+        elif config_data["redistribute"].get("static"):
+            command += " static"
+            command = common_config(command, "static")
+        elif config_data["redistribute"].get("vrf"):
+            if config_data["redistribute"]["vrf"].get("name"):
+                command += " vrf {name}".format(
+                    **config_data["redistribute"]["vrf"]
+                )
+            elif config_data["redistribute"]["vrf"].get("global"):
+                command += " vrf global"
+
+        return command
+
+
+
 class Bgp_address_familyTemplate(NetworkTemplate):
     def __init__(self, lines=None, module=None):
         super(Bgp_address_familyTemplate, self).__init__(
@@ -1103,7 +1234,7 @@ class Bgp_address_familyTemplate(NetworkTemplate):
                     \s*(?P<filter_list>filter-list\s\d+\s(in|out))*
                     \s*(?P<ha_mode>ha-mode\s(graceful-restart\sdisable|graceful-restart))*
                     \s*(?P<inherit>inherit\speer-session\s\S+)*
-                    \s*(?P<local_as>(local-as\s\d+\s(dual-as|(no-prepend\sreplace-as|no-prepend))|local-as))*
+                    \s*(?P<local_as>(local-as\s\d+\s(dual-as|(no-prepend\sreplace-as|no-prepend))|local-as|local-as\s\d+))*
                     \s*(?P<log_neighbor_changes>log-neighbor-changes\sdisable|log-neighbor-changes)*
                     \s*(?P<maximum_prefix>maximum-prefix\s(\d+\s\d+\s(restart\s\d+|warning-only)|\d+\s(restart\s\d+|warning-only)))*
                     \s*(?P<nexthop_self>next-hop-self\sall|next-hop-self)*
@@ -1471,5 +1602,122 @@ class Bgp_address_familyTemplate(NetworkTemplate):
                     }
                 }
             },
+        },
+        {
+            "name": "redistribute",
+            "getval": re.compile(
+                r"""\s*redistribute*
+                        \s*(?P<application>application\s\S+\smetric\s\d+\sroute-map\s\S+|application\s\S+\s(metric\s\d+|route-map\s\S+))*
+                        \s*(?P<bgp>bgp\s\d+\smetric\s\d+\sroute-map\s\S+|bgp\s\d+\s(metric\s\d+\sroute-map\s\S+))*
+                        \s*(?P<connected>connected\s(metric\s\d+\sroute-map\s\S+|metric\s\d+)|connected)*
+                        \s*(?P<eigrp>eigrp\s\d+\smetric\s\d+\sroute-map\s\S+|eigrp\s\d+\s(metric\s\d+\sroute-map\s\S+))*
+                        \s*(?P<isis>isis\s\S+\sclns\smetric\s\d+\sroute-map\s\S+|isis\s\S+\sip\smetric\s\d+\sroute-map\s\S+|isis\s\S+\s(clns|ip)\s(metric\s\d+\sroute-map\s\S+))*
+                        \s*(?P<iso_igrp>iso-igrp\s\S+\sroute-map\s\S+|iso-igrp\s\S+)*
+                        \s*(?P<lisp>lisp\smetric\s\d+\sroute-map\s\S+|lisp\s(metric\s\d+\sroute-map\s\S+))*
+                        \s*(?P<mobile>mobile\smetric\s\d+\sroute-map\s\S+|mobile\s(metric\s\d+\sroute-map\s\S+))*
+                        \s*(?P<odr>odr\smetric\s\d+\sroute-map\s\S+|odr\s(metric\s\d+\sroute-map\s\S+))*
+                        \s*(?P<ospf>ospf\s\d+(\s.*))*
+                        \s*(?P<ospfv3>ospfv3\s\d+(\s.*))*
+                        \s*(?P<rip>rip\smetric\s\d+\sroute-map\s\S+|rip\s(metric\s\d+\sroute-map\s\S+))*
+                        \s*(?P<static>static\sclns\smetric\s\d+\sroute-map\s\S+|static\sip\smetric\s\d+\sroute-map\s\S+|static\s(clns|ip)\s(metric\s\d+\sroute-map\s\S+))*
+                        \s*(?P<vrf>vrf\s\S+|vrf\sglobal)*
+                    $""",
+                re.VERBOSE,
+            ),
+            "compval": "redistribute",
+            "setval": _tmplt_af_redistribute,
+            "result": {
+                "address_family": {
+                    "{{ afi|d() + '_' + safi|d() + '_' + vrf|d() }}": {
+                        "redistribute": [
+                            {
+                                "application": {
+                                    "name": "{{ application.split(' ')[1] if application is defined }}",
+                                    "metric": "{{ application.split('metric ')[1].split(' ')[0] if application is defined and 'metric' in application }}",
+                                    "route_map": "{{ application.split('route-map ')[1].split(' ')[0] if application is defined and 'route-map' in application }}",
+                                },
+                                "bgp": {
+                                    "as_number": "{{ bgp.split(' ')[1] if bgp is defined }}",
+                                    "metric": "{{ bgp.split('metric ')[1].split(' ')[0] if bgp is defined and 'metric' in bgp }}",
+                                    "route_map": "{{ bgp.split('route-map ')[1].split(' ')[0] if bgp is defined and 'route-map' in bgp }}",
+                                },
+                                "connected": {
+                                    "set": "{{ True if connected is defined and 'connected' in connected }}",
+                                    "metric": "{{ connected.split('metric ')[1].split(' ')[0] if connected is defined and 'metric' in connected }}",
+                                    "route_map": "{{ connected.split('route-map ')[1].split(' ')[0] if connected is defined and 'route-map' in connected }}",
+                                },
+                                "eigrp": {
+                                    "as_number": "{{ eigrp.split(' ')[1] if eigrp is defined }}",
+                                    "metric": "{{ eigrp.split('metric ')[1].split(' ')[0] if eigrp is defined and 'metric' in eigrp }}",
+                                    "route_map": "{{ eigrp.split('route-map ')[1].split(' ')[0] if eigrp is defined and 'route-map' in eigrp }}",
+                                },
+                                "isis": {
+                                    "area_tag": "{{ isis.split(' ')[1] if isis is defined }}",
+                                    "clns": "{{ True if isis is defined and 'clns' in isis }}",
+                                    "ip": "{{ True if isis is defined and 'ip' in isis }}",
+                                    "metric": "{{ isis.split('metric ')[1].split(' ')[0] if isis is defined and 'metric' in isis }}",
+                                    "route_map": "{{ isis.split('route-map ')[1].split(' ')[0] if isis is defined and 'route-map' in isis }}",
+                                },
+                                "iso_igrp": {
+                                    "area_tag": "{{ iso_igrp.split(' ')[1] if iso_igrp is defined }}",
+                                    "route_map": "{{ iso_igrp.split('route-map ')[1].split(' ')[0] if iso_igrp is defined and 'route-map' in iso_igrp }}",
+                                },
+                                "lisp": {
+                                    "metric": "{{ lisp.split('metric ')[1].split(' ')[0] if lisp is defined and 'metric' in lisp }}",
+                                    "route_map": "{{ lisp.split('route-map ')[1].split(' ')[0] if lisp is defined and 'route-map' in lisp }}",
+                                },
+                                "mobile": {
+                                    "metric": "{{ mobile.split('metric ')[1].split(' ')[0] if mobile is defined and 'metric' in mobile }}",
+                                    "route_map": "{{ mobile.split('route-map ')[1].split(' ')[0] if mobile is defined and 'route-map' in mobile }}",
+                                },
+                                "odr": {
+                                    "metric": "{{ odr.split('metric ')[1].split(' ')[0] if odr is defined and 'metric' in odr }}",
+                                    "route_map": "{{ odr.split('route-map ')[1].split(' ')[0] if odr is defined and 'route-map' in odr }}",
+                                },
+                                "ospf": {
+                                    "process_id": "{{ ospf.split(' ')[1] if ospf is defined }}",
+                                    "match": {
+                                        "external": "{{ True if ospf is defined and 'external' in ospf }}",
+                                        "internal": "{{ True if ospf is defined and 'internal' in ospf }}",
+                                        "nssa_external": "{{ True if ospf is defined and 'nssa-external' in ospf }}",
+                                        "type_1": "{{ True if ospf is defined and '1' in ospf }}",
+                                        "type_2": "{{ True if ospf is defined and '2' in ospf }}",
+                                    },
+                                    "metric": "{{ ospf.split('metric ')[1].split(' ')[0] if ospf is defined and 'metric' in ospf }}",
+                                    "route_map": "{{ ospf.split('route-map ')[1].split(' ')[0] if ospf is defined and 'route-map' in ospf }}",
+                                    "vrf": "{{ ospf.split('vrf ')[1].split(' ')[0] if ospf is defined and 'vrf' in ospf }}",
+                                },
+                                "ospfv3": {
+                                    "process_id": "{{ ospfv3.split(' ')[1] if ospf is defined }}",
+                                    "match": {
+                                        "external": "{{ True if ospfv3 is defined and 'external' in ospfv3 }}",
+                                        "internal": "{{ True if ospfv3 is defined and 'internal' in ospfv3 }}",
+                                        "nssa_external": "{{ True if ospfv3 is defined and 'nssa-external' in ospfv3 }}",
+                                        "type_1": "{{ True if ospfv3 is defined and '1' in ospfv3 }}",
+                                        "type_2": "{{ True if ospfv3 is defined and '2' in ospfv3 }}",
+                                    },
+                                    "metric": "{{ ospfv3.split('metric ')[1].split(' ')[0] if ospfv3 is defined and 'metric' in ospfv3 }}",
+                                    "route_map": "{{ ospfv3.split('route-map ')[1].split(' ')[0] if ospfv3 is defined and 'route-map' in ospfv3 }}",
+                                    "vrf": "{{ ospfv3.split('vrf ')[1].split(' ')[0] if ospfv3 is defined and 'vrf' in ospfv3 }}",
+                                },
+                                "rip": {
+                                    "metric": "{{ rip.split('metric ')[1].split(' ')[0] if rip is defined and 'metric' in rip }}",
+                                    "route_map": "{{ rip.split('route-map ')[1].split(' ')[0] if rip is defined and 'route-map' in rip }}",
+                                },
+                                "static": {
+                                    "clns": "{{ True if static is defined and 'clns' in static }}",
+                                    "ip": "{{ True if static is defined and 'ip' in static }}",
+                                    "metric": "{{ static.split('metric ')[1].split(' ')[0] if static is defined and 'metric' in static }}",
+                                    "route_map": "{{ static.split('route-map ')[1].split(' ')[0] if static is defined and 'route-map' in static }}",
+                                },
+                                "vrf": {
+                                    "name": "{{ vrf.split('vrf ')[1].split(' ')[0] if vrf is defined and 'vrf' in vrf and 'global' not in vrf }}",
+                                    "global": "{{ True if vrf is defined and 'vrf' in vrf and 'global' in vrf }}",
+                                },
+                            }
+                        ]
+                    }
+                }
+            }
         },
     ]

--- a/plugins/modules/ios_bgp_address_family.py
+++ b/plugins/modules/ios_bgp_address_family.py
@@ -244,7 +244,7 @@ options:
               tag:
                 description: Neighbor tag
                 type: str
-              ipv6_adddress:
+              ipv6_address:
                 description: Neighbor ipv6 address (X:X:X:X::X)
                 type: str
               activate:

--- a/plugins/modules/ios_bgp_address_family.py
+++ b/plugins/modules/ios_bgp_address_family.py
@@ -244,9 +244,11 @@ options:
               tag:
                 description: Neighbor tag
                 type: str
-              ipv6_address:
+              ipv6_adddress:
                 description: Neighbor ipv6 address (X:X:X:X::X)
                 type: str
+                aliases:
+                  - ipv6_address
               activate:
                 description: Enable the Address Family for this Neighbor
                 type: bool

--- a/plugins/modules/ios_bgp_address_family.py
+++ b/plugins/modules/ios_bgp_address_family.py
@@ -712,6 +712,7 @@ options:
                     description:
                       - Send Standard Community attribute.
                       - Maintains backwards compatibility for configurations that do not specify a send-community type.
+                    type: bool
                   both:
                     description: Send Standard and Extended Community attributes
                     type: bool
@@ -891,7 +892,7 @@ options:
                 type: dict
                 suboptions:
                   set:
-                    description: 
+                    description:
                       - Redistribute automatically established IP connected routes.
                       - This only needs to be set if metric or route_map aren't used.
                     type: bool

--- a/plugins/modules/ios_bgp_address_family.py
+++ b/plugins/modules/ios_bgp_address_family.py
@@ -708,6 +708,10 @@ options:
                 description: Send Community attribute to this neighbor
                 type: dict
                 suboptions:
+                  set:
+                    description:
+                      - Send Standard Community attribute.
+                      - Maintains backwards compatibility for configurations that do not specify a send-community type.
                   both:
                     description: Send Standard and Extended Community attributes
                     type: bool
@@ -886,6 +890,11 @@ options:
                 description: Connected
                 type: dict
                 suboptions:
+                  set:
+                    description: 
+                      - Redistribute automatically established IP connected routes.
+                      - This only needs to be set if metric or route_map aren't used.
+                    type: bool
                   metric:
                     description: Metric for redistributed routes
                     type: int

--- a/tests/unit/modules/network/ios/fixtures/ios_bgp_address_family.cfg
+++ b/tests/unit/modules/network/ios/fixtures/ios_bgp_address_family.cfg
@@ -1,6 +1,17 @@
 router bgp 65000
  bgp log-neighbor-changes
  bgp nopeerup-delay cold-boot 20
+ neighbor TEST-PEER-GROUP peer-group
+ neighbor 2001:db8::1 peer-group TEST-PEER-GROUP
+ neighbor 2001:db8::1 description TEST-PEER-GROUP-DESCRIPTION
+ !
+ address-family ipv4
+  bgp redistribute-internal
+  redistribute connected
+  redistribute ospf 200 metric 100 match internal external 1 external 2
+  neighbor TEST-PEER-GROUP send-community
+  neighbor TEST-PEER-GROUP next-hop-self all
+  neighbor 2001:db8::1 activate
  !
  address-family ipv4 multicast
   table-map test_tableMap filter
@@ -23,6 +34,7 @@ router bgp 65000
   network 198.51.110.10 mask 255.255.255.255 backdoor
   aggregate-address 192.0.2.1 255.255.255.255 as-confed-set
   neighbor 198.51.100.1 remote-as 10
+  neighbor 198.51.100.1 local-as 20
   neighbor 198.51.100.1 activate
   neighbor 198.51.100.1 next-hop-self all
   neighbor 198.51.100.1 aigp send cost-community 100 poi igp-cost transitive

--- a/tests/unit/modules/network/ios/test_ios_bgp_address_family.py
+++ b/tests/unit/modules/network/ios/test_ios_bgp_address_family.py
@@ -510,7 +510,7 @@ class TestIosBgpAddressFamilyModule(TestIosModule):
                                     send_community=dict(set=True),
                                 ),
                                 dict(
-                                    ipv6_address="2001:db8::1", activate=True,
+                                    ipv6_address="2001:db8::1", activate=True
                                 ),
                             ],
                         ),

--- a/tests/unit/modules/network/ios/test_ios_bgp_address_family.py
+++ b/tests/unit/modules/network/ios/test_ios_bgp_address_family.py
@@ -489,9 +489,7 @@ class TestIosBgpAddressFamilyModule(TestIosModule):
                     address_family=[
                         dict(
                             afi="ipv4",
-                            bgp=dict(
-                                redistribute_internal=True,
-                            ),
+                            bgp=dict(redistribute_internal=True),
                             redistribute=[
                                 dict(
                                     connected=dict(set=True),
@@ -501,7 +499,7 @@ class TestIosBgpAddressFamilyModule(TestIosModule):
                                             internal=True,
                                             type_1=True,
                                             type_2=True,
-                                        ),
+                                        )
                                     ),
                                 )
                             ],
@@ -512,9 +510,8 @@ class TestIosBgpAddressFamilyModule(TestIosModule):
                                     send_community=dict(set=True),
                                 ),
                                 dict(
-                                    ipv6_address="2001:db8::1",
-                                    activate=True,
-                                )
+                                    ipv6_address="2001:db8::1", activate=True,
+                                ),
                             ],
                         ),
                         dict(

--- a/tests/unit/modules/network/ios/test_ios_bgp_address_family.py
+++ b/tests/unit/modules/network/ios/test_ios_bgp_address_family.py
@@ -351,11 +351,13 @@ class TestIosBgpAddressFamilyModule(TestIosModule):
         commands = [
             "router bgp 65000",
             "address-family ipv4 multicast vrf blue",
+            "redistribute connected metric 10",
             "no bgp dampening 1 1 1 1",
             "bgp slow-peer detection threshold 200",
             "no neighbor 198.51.100.1 activate",
             "no neighbor 198.51.100.1 next-hop-self all",
             "no neighbor 198.51.100.1 remote-as 10",
+            "no neighbor 198.51.100.1 local-as 20",
             "no neighbor 198.51.100.1 aigp send cost-community 100 poi igp-cost transitive",
             "no neighbor 198.51.100.1 route-server-client",
             "no neighbor 198.51.100.1 slow-peer detection threshold 150",
@@ -422,6 +424,7 @@ class TestIosBgpAddressFamilyModule(TestIosModule):
                                         dict(detection=dict(threshold=150))
                                     ],
                                     remote_as=10,
+                                    local_as=dict(number=20),
                                     route_maps=[
                                         dict(name="test-out", out=True)
                                     ],
@@ -486,6 +489,36 @@ class TestIosBgpAddressFamilyModule(TestIosModule):
                     address_family=[
                         dict(
                             afi="ipv4",
+                            bgp=dict(
+                                redistribute_internal=True,
+                            ),
+                            redistribute=[
+                                dict(
+                                    connected=dict(set=True),
+                                    ospf=dict(
+                                        match=dict(
+                                            external=True,
+                                            internal=True,
+                                            type_1=True,
+                                            type_2=True,
+                                        ),
+                                    ),
+                                )
+                            ],
+                            neighbor=[
+                                dict(
+                                    tag="TEST-PEER-GROUP",
+                                    nexthop_self=dict(all=True),
+                                    send_community=dict(set=True),
+                                ),
+                                dict(
+                                    ipv6_address="2001:db8::1",
+                                    activate=True,
+                                )
+                            ],
+                        ),
+                        dict(
+                            afi="ipv4",
                             safi="multicast",
                             vrf="blue",
                             aggregate_address=[
@@ -533,6 +566,7 @@ class TestIosBgpAddressFamilyModule(TestIosModule):
                                         dict(detection=dict(threshold=150))
                                     ],
                                     remote_as=10,
+                                    local_as=dict(number=20),
                                     route_maps=[
                                         dict(name="test-out", out=True)
                                     ],
@@ -593,6 +627,7 @@ class TestIosBgpAddressFamilyModule(TestIosModule):
         set_module_args(dict(state="deleted"))
         commands = [
             "router bgp 65000",
+            "no address-family ipv4",
             "no address-family ipv4 multicast vrf blue",
             "no address-family ipv4 mdt",
             "no address-family ipv4 multicast",
@@ -845,6 +880,12 @@ class TestIosBgpAddressFamilyModule(TestIosModule):
             "no address-family ipv4 mdt",
             "no address-family ipv4 multicast vrf blue",
             "address-family ipv4",
+            "no bgp redistribute-internal",
+            "no redistribute connected",
+            "no redistribute ospf 200 metric 100 match internal external 1 external 2",
+            "no neighbor TEST-PEER-GROUP send-community",
+            "no neighbor TEST-PEER-GROUP next-hop-self all",
+            "no neighbor 2001:db8::1 activate",
             "neighbor 192.31.39.212 activate",
             "neighbor 192.31.39.212 soft-reconfiguration inbound",
             "neighbor 192.31.47.206 activate",


### PR DESCRIPTION
##### SUMMARY
Add `set` option in `send_community` to allow backwards compatiblity with older configs.
Add `set` option in `redistribute.connected` to allow ospf redistribution.
Fix issue with ipv6 and peer-group neighbor identification.
Add ability to pull `redistribute` information for address families to conform to argspec.
Fix issue with not pulling `local_as` when defined for neighbors.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
ios_bgp_address_family

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
