### PR TITLE
filter out reflexive acls from facts

### DIFF
--- a/changelogs/fragments/reflexive_acls_fix.yaml
+++ b/changelogs/fragments/reflexive_acls_fix.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "'ios_acls'- filters out dynamically generated reflexive type acls."

--- a/plugins/module_utils/network/ios/facts/acls/acls.py
+++ b/plugins/module_utils/network/ios/facts/acls/acls.py
@@ -85,7 +85,10 @@ class AclsFacts(object):
 
         if current.get("acls"):
             for k, v in iteritems(current.get("acls")):
-                if v.get("afi") == "ipv4":
+                if v.get("afi") == "ipv4" and v.get("acl_type") in [
+                    "standard",
+                    "extended",
+                ]:
                     del v["afi"]
                     temp_v4.append(v)
                 elif v.get("afi") == "ipv6":

--- a/plugins/module_utils/network/ios/rm_templates/acls.py
+++ b/plugins/module_utils/network/ios/rm_templates/acls.py
@@ -167,7 +167,7 @@ class AclsTemplate(NetworkTemplate):
         {
             "name": "acls_name",
             "getval": re.compile(
-                r"""^(?P<acl_type>Standard|Extended)*
+                r"""^(?P<acl_type>Standard|Extended|Reflexive)*
                     \s*(?P<afi>IP|IPv6)*
                     \s*access*
                     \s*list*

--- a/tests/unit/modules/network/ios/test_ios_acls.py
+++ b/tests/unit/modules/network/ios/test_ios_acls.py
@@ -484,6 +484,10 @@ class TestIosAclsModule(TestIosModule):
                 10 permit tcp 198.51.100.0 0.0.0.255 any eq 22 log (tag = testLog)
                 20 deny icmp 192.0.2.0 0.0.0.255 192.0.3.0 0.0.0.255 echo dscp ef ttl eq 10
                 30 deny icmp object-group test_network_og any echo dscp ef ttl eq 10
+            Reflexive IP access list MIRROR
+                permit tcp host 0.0.0.0 eq 22 host 192.168.0.1 eq 50200 (2 matches) (time left 123)
+                permit tcp host 0.0.0.0 eq 22 host 192.168.0.1 eq 50201 (2 matches) (time left 345)
+                permit tcp host 0.0.0.0 eq 22 host 192.168.0.1 eq 50202 (2 matches) (time left 678)
             IPv6 access list R1_TRAFFIC
                 deny tcp any eq www any eq telnet ack dscp af11 sequence 10
             """


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
filter out reflexive acls from facts, as they are dynamically generated over certain versions of IOS.
The presence of the ACLs causes wrong rendering of the facts.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios_acls
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
