### PR TITLE
Update l2_interfaces.py

### DIFF
--- a/plugins/module_utils/network/ios/argspec/l2_interfaces/l2_interfaces.py
+++ b/plugins/module_utils/network/ios/argspec/l2_interfaces/l2_interfaces.py
@@ -39,6 +39,7 @@ class L2_InterfacesArgs(object):
             "elements": "dict",
             "options": {
                 "name": {"type": "str", "required": True},
+                "description": {"type": "str"},
                 "mode": {"type": "str", "choices": ["access", "trunk"]},
                 "access": {
                     "type": "dict",


### PR DESCRIPTION
Added interface description argument parameter to support filtering by port interface description.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Needed a way to apply configurations to specific interface ports based on description.  This simplified the playbook design to be able to filter interfaces by port description when executing configuration changes.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios.l2_interfaces

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
Example playbook using the l2_interfaces module feature request:

```
- name: Configure Switch Interfaces for ISE and MAB
  hosts: all
  gather_facts: false
  connection: network_cli
  vars:
    vlans_to_ignore:
      - 999
      - 995
    port_desc2search: "Room112"

  tasks:
     - name: IOS Facts
       ios_facts:
        gather_subset:
        - 'min'
        gather_network_resources:
        - l2_interfaces
       register: interfaces_avail
    # - debug: var=interfaces_avail

     - name: Change ISE port configurations
       #Only change port if IOS and ACCESS mode found
       cisco.ios.ios_config:
           parents: "interface {{ item.name }}" # Take the  interface from loop(with_items), then execute the lines(commands)
           lines:
              - "authentication event server dead action authorize vlan 998"
              - "authentication event no-response action authorize vlan 998"
              - "authentication order mab"
              - "authentication port-control auto"
              - "mab"
           save_when: changed
       with_items: "{{ ansible_network_resources.l2_interfaces }}"
       when: 
         - ansible_network_os == 'ios'
         - item.mode is defined and item.mode == 'access' 
         - item.access.vlan is defined and item.access.vlan not in vlans_to_ignore
         - item.description is defined and item.description is search(port_desc2search) 
       register: print_output
```
