### PR TITLE
Update l2_interfaces.py

### DIFF
--- a/changelogs/fragments/520-l2_interfaces-file.yaml
+++ b/changelogs/fragments/520-l2_interfaces-file.yaml
@@ -1,4 +1,6 @@
+---
 minor_changes:
   - line 42 of plugins/module_utils/network/ios/argspec/l2_interfaces/l2_interfaces.py - added description variable for interface config spec
   - line 112 of plugins/module_utils/network/ios/facts/l2_interfaces/l2_interfaces.py - description variable for configuration parsing of interface description
   - lines 48-52 of plugins/modules/ios_l2_interfaces.py - added Human readable description of the local interface.
+...

--- a/changelogs/fragments/520-l2_interfaces-file.yaml
+++ b/changelogs/fragments/520-l2_interfaces-file.yaml
@@ -1,0 +1,4 @@
+minor_changes:
+  - line 42 of plugins/module_utils/network/ios/argspec/l2_interfaces/l2_interfaces.py - added description variable for interface config spec
+  - line 112 of plugins/module_utils/network/ios/facts/l2_interfaces/l2_interfaces.py - description variable for configuration parsing of interface description
+  - lines 48-52 of plugins/modules/ios_l2_interfaces.py - added Human readable description of the local interface.

--- a/plugins/module_utils/network/ios/argspec/l2_interfaces/l2_interfaces.py
+++ b/plugins/module_utils/network/ios/argspec/l2_interfaces/l2_interfaces.py
@@ -39,6 +39,7 @@ class L2_InterfacesArgs(object):
             "elements": "dict",
             "options": {
                 "name": {"type": "str", "required": True},
+                "description": {"type": "str"},
                 "mode": {"type": "str", "choices": ["access", "trunk"]},
                 "access": {
                     "type": "dict",

--- a/plugins/module_utils/network/ios/facts/l2_interfaces/l2_interfaces.py
+++ b/plugins/module_utils/network/ios/facts/l2_interfaces/l2_interfaces.py
@@ -109,6 +109,7 @@ class L2_InterfacesFacts(object):
         ):
             # populate the facts from the configuration
             config["name"] = normalize_interface(intf)
+            config["description"] = utils.parse_conf_arg(conf, "description")
             has_mode = utils.parse_conf_arg(conf, "switchport mode")
             if has_mode:
                 config["mode"] = has_mode

--- a/plugins/modules/ios_l2_interfaces.py
+++ b/plugins/modules/ios_l2_interfaces.py
@@ -49,7 +49,6 @@ options:
         description:
         - Human readable description of the local interface 
         type: str
-        required: true
       access:
         description:
         - Switchport mode access command to configure the interface as a layer 2 access.

--- a/plugins/modules/ios_l2_interfaces.py
+++ b/plugins/modules/ios_l2_interfaces.py
@@ -47,7 +47,7 @@ options:
         required: true
       description:
         description:
-        - Human readable description of the local interface 
+        - Human readable description of the local interface
         type: str
       access:
         description:

--- a/plugins/modules/ios_l2_interfaces.py
+++ b/plugins/modules/ios_l2_interfaces.py
@@ -45,6 +45,11 @@ options:
         - Full name of the interface excluding any logical unit number, i.e. GigabitEthernet0/1.
         type: str
         required: true
+      description:
+        description:
+        - Human readable description of the local interface 
+        type: str
+        required: true
       access:
         description:
         - Switchport mode access command to configure the interface as a layer 2 access.


### PR DESCRIPTION
Added interface description as available collected value.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Needed a way to apply configurations to specific interface ports based on description.  This simplified the playbook design to be able to filter interfaces by port description when executing configuration changes.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios.l2_interfaces

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
This will enable the ability to filter/change/set the port description on interfaces when interacting with interfaces that are described via the "description" configuration parameter. 

Example playbook using the l2_interfaces module feature request:

```
- name: Configure Switch Interfaces for ISE and MAB
  hosts: all
  gather_facts: false
  connection: network_cli
  vars:
    vlans_to_ignore:
      - 999
      - 995
    port_desc2search: "Room112"

  tasks:
     - name: IOS Facts
       ios_facts:
        gather_subset:
        - 'min'
        gather_network_resources:
        - l2_interfaces
       register: interfaces_avail
    # - debug: var=interfaces_avail

     - name: Change ISE port configurations
       #Only change port if IOS and ACCESS mode found
       cisco.ios.ios_config:
           parents: "interface {{ item.name }}" # Take the  interface from loop(with_items), then execute the lines(commands)
           lines:
              - "authentication event server dead action authorize vlan 998"
              - "authentication event no-response action authorize vlan 998"
              - "authentication order mab"
              - "authentication port-control auto"
              - "mab"
           save_when: changed
       with_items: "{{ ansible_network_resources.l2_interfaces }}"
       when: 
         - ansible_network_os == 'ios'
         - item.mode is defined and item.mode == 'access' 
         - item.access.vlan is defined and item.access.vlan not in vlans_to_ignore
         - item.description is defined and item.description is search(port_desc2search) 
       register: print_output
```
