### PR TITLE
[ios_facts] Line protocol option regex update in legacy facts gathering

### DIFF
--- a/changelogs/fragments/legacy_base_lineprotocol.yml
+++ b/changelogs/fragments/legacy_base_lineprotocol.yml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - "`ios_facts` - Fix Line protocol to gets render correctly on leagcy facts where state information is present."
+  - "`ios_facts` - Fix Line protocol parser for on leagcy facts where state information per interface is present."

--- a/changelogs/fragments/legacy_base_lineprotocol.yml
+++ b/changelogs/fragments/legacy_base_lineprotocol.yml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - "`ios_facts` - Fix Line protocol parser for on leagcy facts where state information per interface is present."
+  - "`ios_facts` - Fix Line protocol parser for leagcy facts where state information per interface is present."

--- a/changelogs/fragments/legacy_base_lineprotocol.yml
+++ b/changelogs/fragments/legacy_base_lineprotocol.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "`ios_facts` - Fix Line protocol to gets render correctly on leagcy facts where state information is present."

--- a/plugins/module_utils/network/ios/facts/legacy/base.py
+++ b/plugins/module_utils/network/ios/facts/legacy/base.py
@@ -381,7 +381,7 @@ class Interfaces(FactsBase):
             return match.group(1)
 
     def parse_lineprotocol(self, data):
-        match = re.search(r"line protocol is (\S+)\s*$", data, re.M)
+        match = re.search(r"line protocol is (\S+).+$", data, re.M)
         if match:
             return match.group(1)
 

--- a/tests/unit/modules/network/ios/fixtures/ios_facts_show_interfaces
+++ b/tests/unit/modules/network/ios/fixtures/ios_facts_show_interfaces
@@ -27,7 +27,7 @@ GigabitEthernet0/0 is up, line protocol is up
      0 babbles, 0 late collision, 0 deferred
      1 lost carrier, 0 no carrier, 0 pause output
      0 output buffer failures, 0 output buffers swapped out
-GigabitEthernet1 is up, line protocol is up
+GigabitEthernet1 is up, line protocol is up 
   Hardware is CSR vNIC, address is 5e00.0006.0000 (bia 5e00.0006.0000)
   Description: OOB Management
   Internet address is 10.8.38.67/24
@@ -59,3 +59,33 @@ GigabitEthernet1 is up, line protocol is up
 Tunnel1110 is up, line protocol is up
   Hardware is Tunnel
   Internet address is 10.10.10.2/30
+TenGigabitEthernet2/5/5 is down, line protocol is down (notconnect)
+  Hardware is C6k 10000Mb 802.3, address is xxxx.xxxx.xxxx (bia xxxx.xxxx.xxxx)
+  Description: free
+  MTU 1500 bytes, BW 1000000 Kbit/sec, DLY 10 usec,
+     reliability 255/255, txload 1/255, rxload 1/255
+  Encapsulation ARPA, loopback not set
+  Keepalive set (10 sec)
+  Full-duplex, 1000Mb/s, media type is 1000BaseLH
+  input flow-control is off, output flow-control is desired
+  Clock mode is auto
+  ARP type: ARPA, ARP Timeout 04:00:00
+  Last input never, output never, output hang never
+  Last clearing of "show interface" counters never
+  Input queue: 0/2000/0/0 (size/max/drops/flushes); Total output drops: 0
+  Queueing strategy: fifo
+  Output queue: 0/40 (size/max)
+  5 minute input rate 0 bits/sec, 0 packets/sec
+  5 minute output rate 0 bits/sec, 0 packets/sec
+     0 packets input, 0 bytes, 0 no buffer
+     Received 0 broadcasts (0 multicasts)
+     0 runts, 0 giants, 0 throttles
+     0 input errors, 0 CRC, 0 frame, 0 overrun, 0 ignored
+     0 watchdog, 0 multicast, 0 pause input
+     0 input packets with dribble condition detected
+     0 packets output, 0 bytes, 0 underruns
+     0 output errors, 0 collisions, 3 interface resets
+     0 unknown protocol drops
+     0 babbles, 0 late collision, 0 deferred
+     0 lost carrier, 0 no carrier, 0 pause output
+     0 output buffer failures, 0 output buffers swapped out

--- a/tests/unit/modules/network/ios/test_ios_facts.py
+++ b/tests/unit/modules/network/ios/test_ios_facts.py
@@ -96,7 +96,7 @@ class TestIosFactsModule(TestIosModule):
             ["CAT0726R0ZU", "CAT0726R10A", "CAT0732R0M4"],
         )
 
-    def test_ios_facts_tunnel_address(self):
+    def test_ios_facts_tunnel_address_and_lineprotocol(self):
         set_module_args(dict(gather_subset="interfaces"))
         result = self.execute_module()
         self.assertEqual(
@@ -115,6 +115,18 @@ class TestIosFactsModule(TestIosModule):
             result["ansible_facts"]["ansible_net_interfaces"]["Tunnel1110"][
                 "macaddress"
             ]
+        )
+        self.assertEqual(
+            result["ansible_facts"]["ansible_net_interfaces"][
+                "GigabitEthernet1"
+            ]["lineprotocol"],
+            "up",
+        )
+        self.assertEqual(
+            result["ansible_facts"]["ansible_net_interfaces"][
+                "TenGigabitEthernet2/5/5"
+            ]["lineprotocol"],
+            "down",
         )
 
     def test_ios_facts_filesystems_info(self):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
line protocol option was unable to get extracted due to the operational state in interface details
`TenGigabitEthernet2/5/5 is down, line protocol is down (notconnect)`
also matches
`GigabitEthernet0/2 is administratively down, line protocol is down`

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios_facts [legacy]
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
