### PR TITLE
Fix become raises error when exec prompt timestamp is configured

### DIFF
--- a/changelogs/fragments/fix_become_with_exec_prompt_timestamp.yml
+++ b/changelogs/fragments/fix_become_with_exec_prompt_timestamp.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "Fix become raises error when exec prompt timestamp is configured."

--- a/plugins/terminal/ios.py
+++ b/plugins/terminal/ios.py
@@ -70,7 +70,7 @@ class TerminalModule(TerminalBase):
                 "unable to fetch privilege, with error: %s" % (e.message)
             )
 
-        prompt = self.privilege_level_re.match(result)
+        prompt = self.privilege_level_re.search(result)
         if not prompt:
             raise AnsibleConnectionFailure(
                 "unable to check privilege level [%s]" % result


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This resolves #462
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
