### PR TITLE
[ios_acls] Fix AttributeError on dictionary check

### DIFF
--- a/changelogs/fragments/acl_proto_options_fix.yml
+++ b/changelogs/fragments/acl_proto_options_fix.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+    - acls parser didn't only checked if the proto_options variable existed without validating that it was a dictionary before trying to use it as one.

--- a/plugins/module_utils/network/ios/rm_templates/acls.py
+++ b/plugins/module_utils/network/ios/rm_templates/acls.py
@@ -86,7 +86,7 @@ def _tmplt_access_list_entries(aces):
             command = source_destination_common_config(
                 aces, command, "destination"
             )
-        if proto_option:
+        if isinstance(proto_option, dict):
             command += " {0}".format(
                 list(proto_option.keys())[0].replace("_", "-")
             )


### PR DESCRIPTION
**This is a redo of #516 as I messed up the repo while updating it to the latest code base.**

Check if proto_options is actually a dictionary instead of simply checking if it exists.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This fixes the error `AttributeError: 'bool' object has no attribute 'keys'`, which is a result of simply checking if proto_options exists, rather than making sure it is actually a dictionary.

Adding protocol_options to every entry isn't an option as that results in `Unsupported attribute for standard ACL - protocol_options.`

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios_acls

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
An example task that results in the error would be
```
- name: CISCO | IOS | Deploying ACL template
  cisco.ios.ios_acls:
    state: overridden
    config:
      - afi: ipv4
        acls:
          - name: TEST_ACL
            acl_type: extended
            aces:
              - sequence: 10
                grant: permit
                protocol_options:
                  udp: 'yes'
                source:
                  any: 'yes'
                  port_protocol:
                    eq: 68
                destination:
                  any: 'yes'
                  port_protocol:
                    eq: 69
```