### PR TITLE
[facts] default value for `gather_subset` is changed to `min` instead of `!config` 

### DIFF
--- a/changelogs/fragments/gather_subset_update.yml
+++ b/changelogs/fragments/gather_subset_update.yml
@@ -1,0 +1,3 @@
+---
+major_changes:
+  - "`facts` - default value for `gather_subset` is changed to min instead of !config."

--- a/plugins/modules/ios_facts.py
+++ b/plugins/modules/ios_facts.py
@@ -233,9 +233,9 @@ def main():
         argument_spec=argument_spec, supports_check_mode=True
     )
     warnings = []
-    if module.params["gather_subset"] == "!config":
+    if module.params["gather_subset"] == "min":
         warnings.append(
-            "default value for `gather_subset` will be changed to `min` from `!config` v2.11 onwards"
+            "default value for `gather_subset` is changed to `min` instead of `!config`"
         )
 
     ansible_facts = {}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
default value for `gather_subset` is changed to `min` instead of `!config` 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios_facts

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
