### PR TITLE
[acls] Handle ACL config parsing when match/matches are present

### DIFF
--- a/changelogs/fragments/acl_550.yaml
+++ b/changelogs/fragments/acl_550.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "`ios_acl` - Handle ACL config parsing when match/matches are present."

--- a/plugins/module_utils/network/ios/facts/acls/acls.py
+++ b/plugins/module_utils/network/ios/facts/acls/acls.py
@@ -55,7 +55,7 @@ class AclsFacts(object):
         """removes matches or extra config info that is added on acl match"""
         re_data = ""
         for da in data.split("\n"):
-            if "matches" in da:
+            if "match" in da:
                 mod_da = re.sub(r"\([^()]*\)", "", da)
                 re_data += mod_da[:-1] + "\n"
             else:

--- a/tests/unit/modules/network/ios/test_ios_acls.py
+++ b/tests/unit/modules/network/ios/test_ios_acls.py
@@ -783,7 +783,7 @@ class TestIosAclsModule(TestIosModule):
         set_module_args(
             dict(
                 running_config="""Standard IP access list R1_TRAFFIC\n10 permit 10.11.12.13 (2 matches)\n
-                40 permit 128.0.0.0, wildcard bits 63.255.255.255 (2 matches)""",
+                40 permit 128.0.0.0, wildcard bits 63.255.255.255 (2 matches)\n60 permit 134.107.136.0, wildcard bits 0.0.0.255 (1 match)""",
                 state="parsed",
             )
         )
@@ -807,6 +807,14 @@ class TestIosAclsModule(TestIosModule):
                                 "source": {
                                     "address": "128.0.0.0",
                                     "wildcard_bits": "63.255.255.255",
+                                },
+                            },
+                            {
+                                "grant": "permit",
+                                "sequence": 60,
+                                "source": {
+                                    "address": "134.107.136.0",
+                                    "wildcard_bits": "0.0.0.255",
                                 },
                             },
                         ],


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Handle ACL config parsing when match/matches are present.
Turns out the appliance is good with grammar as it says `match` when the matching count is _1_ and `matches` when it is more than 1
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios_acls
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
