### PR TITLE
[ntp] fix to handle server attributes gracefully on no match

### DIFF
--- a/changelogs/fragments/bug_fix_ntp.yaml
+++ b/changelogs/fragments/bug_fix_ntp.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "`ios_ntp` - Handle regex matching server attributes gracefully."

--- a/plugins/modules/ios_ntp.py
+++ b/plugins/modules/ios_ntp.py
@@ -127,22 +127,20 @@ from ansible_collections.cisco.ios.plugins.module_utils.network.ios.ios import (
 
 def parse_server(line, dest):
     if dest == "server":
+        vrf, server = None, None
         match = re.search(
             "(ntp\\sserver\\s)(vrf\\s\\w+\\s)?(\\d+\\.\\d+\\.\\d+\\.\\d+)",
             line,
             re.M,
         )
 
-        if match.group(2) and match.group(3):
+        if match and match.group(2) and match.group(3):
             vrf = match.group(2)
             server = match.group(3)
-
             return vrf, server
 
-        if match.group(3):
-            vrf = None
+        if match and match.group(3):
             server = match.group(3)
-
             return vrf, server
 
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
 NTP fix to handle server attributes gracefully on no match
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios_ntp

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
