### PR TITLE
[WIP] ios_static_routes: 'summarized' state

### DIFF
--- a/docs/cisco.ios.ios_static_routes_module.rst
+++ b/docs/cisco.ios.ios_static_routes_module.rst
@@ -956,6 +956,7 @@ Examples
     # ip route 198.51.102.0 255.255.255.252 198.51.101.1
 
 
+
 Return Values
 -------------
 Common return values are documented `here <https://docs.ansible.com/ansible/latest/reference_appendices/common_return_values.html#common-return-values>`_, the following are the fields unique to this module:

--- a/plugins/module_utils/network/ios/argspec/static_routes/static_routes.py
+++ b/plugins/module_utils/network/ios/argspec/static_routes/static_routes.py
@@ -93,6 +93,7 @@ class Static_RoutesArgs(object):
                 "gathered",
                 "rendered",
                 "parsed",
+                "summarized",
             ],
             "default": "merged",
             "type": "str",

--- a/plugins/module_utils/network/ios/config/static_routes/static_routes.py
+++ b/plugins/module_utils/network/ios/config/static_routes/static_routes.py
@@ -17,6 +17,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 import copy
+
 from ipaddress import IPv4Network, IPv6Network
 
 from ansible.module_utils.six import iteritems
@@ -165,62 +166,79 @@ class Static_Routes(ConfigBase):
         return commands
 
     def remove_sub_routes(self, want, have):
-        """ Check if for the desired static routes there are any summary routes,
+        """Check if for the desired static routes there are any summary routes,
             remove routes with destinations that are a subnet of any existing route
         :rtype: list
         :returns: the 'want' dictionary without routes for which summary routes exists
         """
         # Iterate over VRFs
         for vrf in want:
-            vrf_name = vrf['vrf']
+            vrf_name = vrf["vrf"]
             # Iterate over address families
-            for af in vrf['address_families']:
+            for af in vrf["address_families"]:
                 # Iterate over routes in 'want' and remove them if a summary route is found
-                for wanted_route in reversed(af['routes']):
+                for wanted_route in reversed(af["routes"]):
                     summary_route_found = False
                     # Iterate over routes in 'have'
                     # Default VRF case:
                     if vrf_name is None:
                         # Find route item without VRF key
-                        default_vrf = next((route for route in have if 'vrf' not in route), None)
+                        default_vrf = next((route for route in have if "vrf" not in route), None)
                         # Find routes of respective address family
-                        default_af_routes = [route for route in default_vrf['address_families'] if route['afi'] == af['afi']]
+                        default_af_routes = [
+                            route
+                            for route in default_vrf["address_families"]
+                            if route["afi"] == af["afi"]
+                        ]
                         for existing_route in default_af_routes:
                             # Check if wanted route is a subnet of existing route, except for default route
-                            if af['afi'] == 'ipv4':
-                                if existing_route['routes'][0]['dest'] != '0.0.0.0/0':
-                                    if IPv4Network(wanted_route['dest']).subnet_of(IPv4Network(existing_route['routes'][0]['dest'])):
+                            if af["afi"] == "ipv4":
+                                if existing_route["routes"][0]["dest"] != "0.0.0.0/0":
+                                    if IPv4Network(wanted_route["dest"]).subnet_of(
+                                        IPv4Network(existing_route["routes"][0]["dest"])
+                                    ):
                                         summary_route_found = True
-                            elif af['afi'] == 'ipv6':
-                                if existing_route['routes'][0]['dest'] != '::/0':
-                                    if IPv6Network(wanted_route['dest']).subnet_of(IPv6Network(existing_route['routes'][0]['dest'])):
+                            elif af["afi"] == "ipv6":
+                                if existing_route["routes"][0]["dest"] != "::/0":
+                                    if IPv6Network(wanted_route["dest"]).subnet_of(
+                                        IPv6Network(existing_route["routes"][0]["dest"])
+                                    ):
                                         summary_route_found = True
                     # Non-default VRF case:
                     else:
                         # Find and iterate over route items for respective VRF and address family
-                        vrf_af_routes = [route for route in have if 'vrf' in route and route['vrf'] == vrf_name
-                                         and route['address_families'][0]['afi'] == af['afi']]
+                        vrf_af_routes = [
+                            route
+                            for route in have
+                            if "vrf" in route
+                            and route["vrf"] == vrf_name
+                            and route["address_families"][0]["afi"] == af["afi"]
+                        ]
                         for existing_route in vrf_af_routes:
-                            dest = existing_route['address_families'][0]['routes'][0]['dest']
+                            dest = existing_route["address_families"][0]["routes"][0]["dest"]
                             # Check if wanted route is a subnet of existing route, except for default route
-                            if af['afi'] == 'ipv4':
-                                if dest != '0.0.0.0/0':
-                                    if IPv4Network(wanted_route['dest']).subnet_of(IPv4Network(dest)):
+                            if af["afi"] == "ipv4":
+                                if dest != "0.0.0.0/0":
+                                    if IPv4Network(wanted_route["dest"]).subnet_of(
+                                        IPv4Network(dest)
+                                    ):
                                         summary_route_found = True
-                            elif af['afi'] == 'ipv6':
-                                if dest != '::/0':
-                                    if IPv6Network(wanted_route['dest']).subnet_of(IPv6Network(dest)):
+                            elif af["afi"] == "ipv6":
+                                if dest != "::/0":
+                                    if IPv6Network(wanted_route["dest"]).subnet_of(
+                                        IPv6Network(dest)
+                                    ):
                                         summary_route_found = True
                     # Remove wanted route if existing summary route has been found
                     if summary_route_found is True:
-                        af['routes'].remove(wanted_route)
+                        af["routes"].remove(wanted_route)
             # Remove address family with empty route list
-            for af in list(vrf['address_families']):
-                if len(af['routes']) == 0:
-                    vrf['address_families'].remove(af)
+            for af in list(vrf["address_families"]):
+                if len(af["routes"]) == 0:
+                    vrf["address_families"].remove(af)
         # Remove VRFs with empty address family list
         for vrf in list(want):
-            if len(vrf['address_families']) == 0:
+            if len(vrf["address_families"]) == 0:
                 want.remove(vrf)
         return want
 

--- a/plugins/module_utils/network/ios/config/static_routes/static_routes.py
+++ b/plugins/module_utils/network/ios/config/static_routes/static_routes.py
@@ -17,6 +17,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 import copy
+from ipaddress import IPv4Network, IPv6Network
 
 from ansible.module_utils.six import iteritems
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.cfg.base import (
@@ -71,6 +72,7 @@ class Static_Routes(ConfigBase):
         result = {"changed": False}
         commands = list()
         warnings = list()
+        self.ACTION_STATES.append("summarized")
 
         if self.state in self.ACTION_STATES:
             existing_static_routes_facts = self.get_static_routes_facts()
@@ -153,7 +155,74 @@ class Static_Routes(ConfigBase):
             commands = self._state_merged(want, have)
         elif state == "replaced":
             commands = self._state_replaced(want, have)
+        # New code for 'summarized' state:
+        elif state == "summarized":
+            # Call function to remove subroutes
+            want_nosubroutes = self.remove_sub_routes(want, have)
+            # And call _state_merged if 'want' is not empty
+            if want_nosubroutes:
+                commands = self._state_merged(want_nosubroutes, have)
         return commands
+
+    def remove_sub_routes(self, want, have):
+        """ Check if for the desired static routes there are any summary routes,
+            remove routes with destinations that are a subnet of any existing route
+        :rtype: list
+        :returns: the 'want' dictionary without routes for which summary routes exists
+        """
+        # Iterate over VRFs
+        for vrf in want:
+            vrf_name = vrf['vrf']
+            # Iterate over address families
+            for af in vrf['address_families']:
+                # Iterate over routes in 'want' and remove them if a summary route is found
+                for wanted_route in reversed(af['routes']):
+                    summary_route_found = False
+                    # Iterate over routes in 'have'
+                    # Default VRF case:
+                    if vrf_name is None:
+                        # Find route item without VRF key
+                        default_vrf = next((route for route in have if 'vrf' not in route), None)
+                        # Find routes of respective address family
+                        default_af_routes = [route for route in default_vrf['address_families'] if route['afi'] == af['afi']]
+                        for existing_route in default_af_routes:
+                            # Check if wanted route is a subnet of existing route, except for default route
+                            if af['afi'] == 'ipv4':
+                                if existing_route['routes'][0]['dest'] != '0.0.0.0/0':
+                                    if IPv4Network(wanted_route['dest']).subnet_of(IPv4Network(existing_route['routes'][0]['dest'])):
+                                        summary_route_found = True
+                            elif af['afi'] == 'ipv6':
+                                if existing_route['routes'][0]['dest'] != '::/0':
+                                    if IPv6Network(wanted_route['dest']).subnet_of(IPv6Network(existing_route['routes'][0]['dest'])):
+                                        summary_route_found = True
+                    # Non-default VRF case:
+                    else:
+                        # Find and iterate over route items for respective VRF and address family
+                        vrf_af_routes = [route for route in have if 'vrf' in route and route['vrf'] == vrf_name
+                                         and route['address_families'][0]['afi'] == af['afi']]
+                        for existing_route in vrf_af_routes:
+                            dest = existing_route['address_families'][0]['routes'][0]['dest']
+                            # Check if wanted route is a subnet of existing route, except for default route
+                            if af['afi'] == 'ipv4':
+                                if dest != '0.0.0.0/0':
+                                    if IPv4Network(wanted_route['dest']).subnet_of(IPv4Network(dest)):
+                                        summary_route_found = True
+                            elif af['afi'] == 'ipv6':
+                                if dest != '::/0':
+                                    if IPv6Network(wanted_route['dest']).subnet_of(IPv6Network(dest)):
+                                        summary_route_found = True
+                    # Remove wanted route if existing summary route has been found
+                    if summary_route_found is True:
+                        af['routes'].remove(wanted_route)
+            # Remove address family with empty route list
+            for af in list(vrf['address_families']):
+                if len(af['routes']) == 0:
+                    vrf['address_families'].remove(af)
+        # Remove VRFs with empty address family list
+        for vrf in list(want):
+            if len(vrf['address_families']) == 0:
+                want.remove(vrf)
+        return want
 
     def _state_replaced(self, want, have):
         """The command generator when state is replaced


### PR DESCRIPTION
##### SUMMARY

Customer Requirement:

Our customer would like to add static routes only if there are no existing static summary routes. In other words, not add a route if its destination is a subnet of any existing route. Example: 192.168.50.0/30 shall not be added if there is a static route with destination 192.168.50.0/24.

It requires a subnet check for each route to be added. This could be done in an Ansible playbook using a loop and the ansible.netcommon.ipsubnet module, however each iteration takes ~ 0.5 - 1 sec, so that for a large number of routes it is quite slow. The customer is looking for a better performance.

Proposed Feature:

Add a functionality to check for summary routes to the ios_static_routes module. Introduce a "summarized" state that can be thought of as "merged without subroutes". In cisco.ios/plugins/module_utils/network/ios/config/static_routes/static_routes.py, add a case for the new state to 'set_state()', and add a 'remove_sub_routes()' function to remove sub-routes from the 'want' dictionary. 

We are kindly looking for your feedback and advise.

##### ISSUE TYPE

- New Feature Pull Request

##### COMPONENT NAME

cisco.ios.ios_static_routes

##### EXAMPLE

Existing Config:

```
csr1000v-1#show running-config | include ip route|ipv6 route
ip route 198.51.100.0 255.255.255.0 198.51.101.1
```

Playbook Task:

```
- name: Merge configuration if no summary route exists
  cisco.ios.ios_static_routes:
    config:
    - address_families:
      - afi: ipv4
        routes:
        - dest: 198.51.100.0/30
          next_hops:
          - forward_router_address: 198.51.101.1
        - dest: 198.51.102.0/30
          next_hops:
          - forward_router_address: 198.51.101.1
    state: summarized
```

Resulting Config:

```
csr1000v-1#show running-config | include ip route|ipv6 route
ip route 198.51.100.0 255.255.255.0 198.51.101.1
ip route 198.51.102.0 255.255.255.252 198.51.101.1
```

Note: A route for 198.51.100.0/30 has not been added as one for 198.51.100.0/24 already exists.

#### TESTS

So far I have manually tested the remove_sub_routes() function for the following cases:

- 'want' dictionary with one sub-route and one new route per VRF (default and non-default VRF), IPv4 only
- 'want' dictionary with two VRFs (default and non-default VRF), IPv4 and IPv6
- 'want' dictionary with one sub-route in default VRF, resulting in empty VRF
- 'want' dictionary with one sub-route in both VRFs, resulting in empty dictionary

Second, I have tested the adapted ios_static_routes module in an Ansible playbook with 'state: summarized' applied to a CSR1000v running IOS XE version 16.9.3 as shown in the example above.

I would be happy to add integration and unit tests if the feature was accepted.