### PR TITLE
[facts] - facts to show operating state of the appliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This collection has been tested against Cisco IOS XE Version 17.3 on CML.
 <!--start requires_ansible-->
 ## Ansible version compatibility
 
-This collection has been tested against the following Ansible versions: **>=2.9.10**.
+This collection has been tested against following Ansible versions: **>=2.9.10**.
 
 For collections that support Ansible 2.9, please ensure you update your `network_os` to use the
 fully qualified collection name (for example, `cisco.ios.ios`).

--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 [![CI](https://zuul-ci.org/gated.svg)](https://dashboard.zuul.ansible.com/t/ansible/project/github.com/ansible-collections/cisco.ios) <!--[![Codecov](https://img.shields.io/codecov/c/github/ansible-collections/vyos)](https://codecov.io/gh/ansible-collections/cisco.ios)-->
 
-The Ansible Cisco IOS collection includes a variety of Ansible content to help automate the management of Cisco IOS network appliances.
+The Ansible Cisco IOS collection includes a variety of Ansible content to help automate the management of Cisco IOS and Cisco IOS XE network appliances.
 
-This collection has been tested against Cisco IOSXE Version 17.3 on CML.
+This collection has been tested against Cisco IOS XE Version 17.3 on CML.
 
 <!--start requires_ansible-->
 ## Ansible version compatibility
 
-This collection has been tested against following Ansible versions: **>=2.9.10**.
+This collection has been tested against the following Ansible versions: **>=2.9.10**.
 
 For collections that support Ansible 2.9, please ensure you update your `network_os` to use the
 fully qualified collection name (for example, `cisco.ios.ios`).

--- a/changelogs/fragments/docs_and_operatingstate.yaml
+++ b/changelogs/fragments/docs_and_operatingstate.yaml
@@ -1,0 +1,4 @@
+doc_changes:
+  - ios_command - add examples for complex variables while using command module.
+minor_changes:
+  - ios_facts - default facts to show operating state data autonomous or controller mode.

--- a/docs/cisco.ios.ios_command_module.rst
+++ b/docs/cisco.ios.ios_command_module.rst
@@ -231,7 +231,7 @@ Examples
     #     },
     #     "stdout": [
     #         "Cisco IOS XE Software, Version 17.03.04a\nCisco IOS Software [Amsterdam], Virtual XE Software Configuration register is 0x2102",
-    #         "Loopback999 is up, line protocol is up \n  Hardware is Loopback\n  Description: this is a test\n  MTU 1514 bytes, BW 8000000 Kbit/sec, DLY 5000 usec, \n     reliability 255/255, txload 1/255, rxload 1/255\n  Encapsulation LOOPBACK, loopback not set\n  Keepalive set (10 sec)\n  Last input never, output never, output hang never\n  Last clearing of \"show interface\" counters never\n  Input queue: 0/75/0/0 (size/max/drops/flushes); Total output drops: 0\n  Queueing strategy: fifo\n  Output queue: 0/0 (size/max)\n  5 minute input rate 0 bits/sec, 0 packets/sec\n  5 minute output rate 0 bits/sec, 0 packets/sec\n     0 packets input, 0 bytes, 0 no buffer\n     Received 0 broadcasts (0 IP multicasts)\n     0 runts, 0 giants, 0 throttles \n     0 input errors, 0 CRC, 0 frame, 0 overrun, 0 ignored, 0 abort\n     0 packets output, 0 bytes, 0 underruns\n     Output 0 broadcasts (0 IP multicasts)\n     0 output errors, 0 collisions, 0 interface resets\n     0 unknown protocol drops\n     0 output buffer failures, 0 output buffers swapped out"
+    #         "Loopback999 is up, line protocol is up ...failures, 0 output buffers swapped out"
     #     ],
     #     "stdout_lines": [
     #         [

--- a/docs/cisco.ios.ios_command_module.rst
+++ b/docs/cisco.ios.ios_command_module.rst
@@ -139,22 +139,137 @@ Examples
 
 .. code-block:: yaml
 
-    - name: run show version on remote devices
+    - name: Run show version on remote devices
       cisco.ios.ios_command:
-        commands: show version
+        commands: show version'
 
-    - name: run show version and check to see if output contains IOS
+    # output-
+
+    # ok: [iosxeappliance] => {
+    #     "changed": false,
+    #     "invocation": {
+    #         "module_args": {
+    #             "commands": [
+    #                 "show version"
+    #             ],
+    #             "interval": 1,
+    #             "match": "all",
+    #             "retries": 10,
+    #             "wait_for": null
+    #         }
+    #     },
+    #     "stdout": [
+    #         "Cisco IOS XE Software, Version 17.03.04a\nCisco IOS Software [Amsterdam], Virtual XE Software ... register is 0x2102"
+    #     ],
+    #     "stdout_lines": [
+    #         [
+    #             "Cisco IOS XE Software, Version 17.03.04a",
+    #             "Cisco IOS Software [Amsterdam], Virtual XE Software",
+    #             "..."
+    #             "Configuration register is 0x2102"
+    #         ]
+    #     ]
+    # }
+
+    - name: Run show version and check to see if output contains IOS
       cisco.ios.ios_command:
         commands: show version
         wait_for: result[0] contains IOS
 
-    - name: run multiple commands on remote nodes
+    # output-
+
+    # ok: [iosxeappliance] => {
+    #     "changed": false,
+    #     "invocation": {
+    #         "module_args": {
+    #             "commands": [
+    #                 "show version"
+    #             ],
+    #             "interval": 1,
+    #             "match": "all",
+    #             "retries": 10,
+    #             "wait_for": [
+    #                 "result[0] contains IOS"
+    #             ]
+    #         }
+    #     },
+    #     "stdout": [
+    #         "Cisco IOS XE Software, Version 17.03.04a\nCisco IOS Software [Amsterdam], Virtual XE Software ... register is 0x2102"
+    #     ],
+    #     "stdout_lines": [
+    #         [
+    #             "Cisco IOS XE Software, Version 17.03.04a",
+    #             "Cisco IOS Software [Amsterdam], Virtual XE Software",
+    #             "..."
+    #             "Configuration register is 0x2102"
+    #         ]
+    #     ]
+    # }
+
+    - name: Run multiple commands on remote nodes
       cisco.ios.ios_command:
         commands:
         - show version
         - show interfaces
 
-    - name: run multiple commands and evaluate the output
+    # output-
+
+
+    # ok: [iosxeappliance] => {
+    #     "changed": false,
+    #     "invocation": {
+    #         "module_args": {
+    #             "commands": [
+    #                 "show version",
+    #                 "show interfaces"
+    #             ],
+    #             "interval": 1,
+    #             "match": "all",
+    #             "retries": 10,
+    #             "wait_for": null
+    #         }
+    #     },
+    #     "stdout": [
+    #         "Cisco IOS XE Software, Version 17.03.04a\nCisco IOS Software [Amsterdam], Virtual XE Software Configuration register is 0x2102",
+    #         "Loopback999 is up, line protocol is up \n  Hardware is Loopback\n  Description: this is a test\n  MTU 1514 bytes, BW 8000000 Kbit/sec, DLY 5000 usec, \n     reliability 255/255, txload 1/255, rxload 1/255\n  Encapsulation LOOPBACK, loopback not set\n  Keepalive set (10 sec)\n  Last input never, output never, output hang never\n  Last clearing of \"show interface\" counters never\n  Input queue: 0/75/0/0 (size/max/drops/flushes); Total output drops: 0\n  Queueing strategy: fifo\n  Output queue: 0/0 (size/max)\n  5 minute input rate 0 bits/sec, 0 packets/sec\n  5 minute output rate 0 bits/sec, 0 packets/sec\n     0 packets input, 0 bytes, 0 no buffer\n     Received 0 broadcasts (0 IP multicasts)\n     0 runts, 0 giants, 0 throttles \n     0 input errors, 0 CRC, 0 frame, 0 overrun, 0 ignored, 0 abort\n     0 packets output, 0 bytes, 0 underruns\n     Output 0 broadcasts (0 IP multicasts)\n     0 output errors, 0 collisions, 0 interface resets\n     0 unknown protocol drops\n     0 output buffer failures, 0 output buffers swapped out"
+    #     ],
+    #     "stdout_lines": [
+    #         [
+    #             "Cisco IOS XE Software, Version 17.03.04a",
+    #             "Cisco IOS Software [Amsterdam], Virtual XE Software",
+    #             "..."
+    #             "Configuration register is 0x2102"
+    #         ],
+    #         [
+    #             "Loopback999 is up, line protocol is up ",
+    #             "  Hardware is Loopback",
+    #             "  Description: this is a test",
+    #             "  MTU 1514 bytes, BW 8000000 Kbit/sec, DLY 5000 usec, ",
+    #             "     reliability 255/255, txload 1/255, rxload 1/255",
+    #             "  Encapsulation LOOPBACK, loopback not set",
+    #             "  Keepalive set (10 sec)",
+    #             "  Last input never, output never, output hang never",
+    #             "  Last clearing of \"show interface\" counters never",
+    #             "  Input queue: 0/75/0/0 (size/max/drops/flushes); Total output drops: 0",
+    #             "  Queueing strategy: fifo",
+    #             "  Output queue: 0/0 (size/max)",
+    #             "  5 minute input rate 0 bits/sec, 0 packets/sec",
+    #             "  5 minute output rate 0 bits/sec, 0 packets/sec",
+    #             "     0 packets input, 0 bytes, 0 no buffer",
+    #             "     Received 0 broadcasts (0 IP multicasts)",
+    #             "     0 runts, 0 giants, 0 throttles ",
+    #             "     0 input errors, 0 CRC, 0 frame, 0 overrun, 0 ignored, 0 abort",
+    #             "     0 packets output, 0 bytes, 0 underruns",
+    #             "     Output 0 broadcasts (0 IP multicasts)",
+    #             "     0 output errors, 0 collisions, 0 interface resets",
+    #             "     0 unknown protocol drops",
+    #             "     0 output buffer failures, 0 output buffers swapped out"
+    #         ]
+    #     ]
+    # }
+
+
+    - name: Run multiple commands and evaluate the output
       cisco.ios.ios_command:
         commands:
         - show version
@@ -163,15 +278,117 @@ Examples
         - result[0] contains IOS
         - result[1] contains Loopback0
 
-    - name: run commands that require answering a prompt
+    # output-
+    # failed play as result[1] contains Loopback0 is false
+
+    # fatal: [iosxeappliance]: FAILED! => {
+    #     "changed": false,
+    #     "failed_conditions": [
+    #         "result[1] contains Loopback0"
+    #     ],
+    #     "invocation": {
+    #         "module_args": {
+    #             "commands": [
+    #                 "show version",
+    #                 "show interfaces"
+    #             ],
+    #             "interval": 1,
+    #             "match": "all",
+    #             "retries": 10,
+    #             "wait_for": [
+    #                 "result[0] contains IOS",
+    #                 "result[1] contains Loopback0"
+    #             ]
+    #         }
+    #     },
+    #     "msg": "One or more conditional statements have not been satisfied"
+    # }
+
+    - name: Run commands that require answering a prompt
       cisco.ios.ios_command:
         commands:
-        - command: 'clear counters GigabitEthernet0/1'
+        - command: 'clear counters GigabitEthernet2'
           prompt: 'Clear "show interface" counters on this interface \[confirm\]'
           answer: 'y'
-        - command: 'clear counters GigabitEthernet0/2'
+        - command: 'clear counters GigabitEthernet3'
           prompt: '[confirm]'
           answer: "\r"
+
+    # output-
+
+    # ok: [iosxeappliance] => {
+    #     "changed": false,
+    #     "invocation": {
+    #         "module_args": {
+    #             "commands": [
+    #                 {
+    #                     "answer": "y",
+    #                     "check_all": false,
+    #                     "command": "clear counters GigabitEthernet2",
+    #                     "newline": true,
+    #                     "output": null,
+    #                     "prompt": "Clear \"show interface\" counters on this interface \\[confirm\\]",
+    #                     "sendonly": false
+    #                 },
+    #                 {
+    #                     "answer": "\r",
+    #                     "check_all": false,
+    #                     "command": "clear counters GigabitEthernet3",
+    #                     "newline": true,
+    #                     "output": null,
+    #                     "prompt": "[confirm]",
+    #                     "sendonly": false
+    #                 }
+    #             ],
+    #             "interval": 1,
+    #             "match": "all",
+    #             "retries": 10,
+    #             "wait_for": null
+    #         }
+    #     },
+    #     "stdout": [
+    #         "Clear \"show interface\" counters on this interface [confirm]y",
+    #         "Clear \"show interface\" counters on this interface [confirm]"
+    #     ],
+    #     "stdout_lines": [
+    #         [
+    #             "Clear \"show interface\" counters on this interface [confirm]y"
+    #         ],
+    #         [
+    #             "Clear \"show interface\" counters on this interface [confirm]"
+    #         ]
+    #     ]
+    # }
+
+    - name: Run commands with complex values like special characters in variables
+      cisco.ios.ios_command:
+        commands: ["{{ 'test aaa group TEST ' ~ user ~ ' ' ~ password ~ ' new-code' }}"]
+      vars:
+        user: "dummy"
+        password: "!dummy"
+
+    # ok: [iosxeappliance] => {
+    #     "changed": false,
+    #     "invocation": {
+    #         "module_args": {
+    #             "commands": [
+    #                 "test aaa group group test !dummy new-code"
+    #             ],
+    #             "interval": 1,
+    #             "match": "all",
+    #             "retries": 10,
+    #             "wait_for": null
+    #         }
+    #     },
+    #     "stdout": [
+    #         "User was successfully authenticated."
+    #     ],
+    #     "stdout_lines": [
+    #         [
+    #             "User was successfully authenticated."
+    #         ]
+    #     ]
+    # }
 
 
 

--- a/docs/cisco.ios.ios_facts_module.rst
+++ b/docs/cisco.ios.ios_facts_module.rst
@@ -83,7 +83,7 @@ Parameters
                 </td>
                 <td>
                         <div>When supplied, this argument restricts the facts collected to a given subset.</div>
-                        <div>Possible values for this argument include <code>all</code>, <code>min</code>, <code>hardware</code>, <code>config</code>, and <code>interfaces</code>.</div>
+                        <div>Possible values for this argument include <code>all</code>, <code>min</code>, <code>default</code>, <code>hardware</code>, <code>config</code>, and <code>interfaces</code>.</div>
                         <div>Specify a list of values to include a larger subset.</div>
                         <div>Use a value with an initial <code>!</code> to collect all facts except that subset.</div>
                 </td>

--- a/plugins/module_utils/network/ios/facts/legacy/base.py
+++ b/plugins/module_utils/network/ios/facts/legacy/base.py
@@ -57,6 +57,7 @@ class Default(FactsBase):
         data = self.responses[0]
         if data:
             self.facts["iostype"] = self.parse_iostype(data)
+            self.facts["operatingmode"] = self.parse_operatingmode(data, self.facts["iostype"])
             self.facts["serialnum"] = self.parse_serialnum(data)
             self.parse_stacks(data)
         data = self.responses[1] + self.responses[2]
@@ -70,6 +71,14 @@ class Default(FactsBase):
             return "IOS-XE"
         else:
             return "IOS"
+
+    def parse_operatingmode(self, data, iostype):
+        # for older ios versions default being autonomous where operating mode classification not present
+        match = re.search(r"Router\soperating\smode: (\S+)", data)
+        if (match and "autonomous" in match.group(1).lower()) or iostype == "IOS":
+            return "autonomous"
+        else:
+            return "controller"
 
     def parse_serialnum(self, data):
         match = re.search(r"board ID (\S+)", data)

--- a/plugins/modules/ios_command.py
+++ b/plugins/modules/ios_command.py
@@ -86,22 +86,137 @@ options:
     type: int
 """
 EXAMPLES = r"""
-- name: run show version on remote devices
+- name: Run show version on remote devices
   cisco.ios.ios_command:
-    commands: show version
+    commands: show version'
 
-- name: run show version and check to see if output contains IOS
+# output-
+
+# ok: [iosxeappliance] => {
+#     "changed": false,
+#     "invocation": {
+#         "module_args": {
+#             "commands": [
+#                 "show version"
+#             ],
+#             "interval": 1,
+#             "match": "all",
+#             "retries": 10,
+#             "wait_for": null
+#         }
+#     },
+#     "stdout": [
+#         "Cisco IOS XE Software, Version 17.03.04a\nCisco IOS Software [Amsterdam], Virtual XE Software ... register is 0x2102"
+#     ],
+#     "stdout_lines": [
+#         [
+#             "Cisco IOS XE Software, Version 17.03.04a",
+#             "Cisco IOS Software [Amsterdam], Virtual XE Software",
+#             "..."
+#             "Configuration register is 0x2102"
+#         ]
+#     ]
+# }
+
+- name: Run show version and check to see if output contains IOS
   cisco.ios.ios_command:
     commands: show version
     wait_for: result[0] contains IOS
 
-- name: run multiple commands on remote nodes
+# output-
+
+# ok: [iosxeappliance] => {
+#     "changed": false,
+#     "invocation": {
+#         "module_args": {
+#             "commands": [
+#                 "show version"
+#             ],
+#             "interval": 1,
+#             "match": "all",
+#             "retries": 10,
+#             "wait_for": [
+#                 "result[0] contains IOS"
+#             ]
+#         }
+#     },
+#     "stdout": [
+#         "Cisco IOS XE Software, Version 17.03.04a\nCisco IOS Software [Amsterdam], Virtual XE Software ... register is 0x2102"
+#     ],
+#     "stdout_lines": [
+#         [
+#             "Cisco IOS XE Software, Version 17.03.04a",
+#             "Cisco IOS Software [Amsterdam], Virtual XE Software",
+#             "..."
+#             "Configuration register is 0x2102"
+#         ]
+#     ]
+# }
+
+- name: Run multiple commands on remote nodes
   cisco.ios.ios_command:
     commands:
     - show version
     - show interfaces
 
-- name: run multiple commands and evaluate the output
+# output-
+
+
+# ok: [iosxeappliance] => {
+#     "changed": false,
+#     "invocation": {
+#         "module_args": {
+#             "commands": [
+#                 "show version",
+#                 "show interfaces"
+#             ],
+#             "interval": 1,
+#             "match": "all",
+#             "retries": 10,
+#             "wait_for": null
+#         }
+#     },
+#     "stdout": [
+#         "Cisco IOS XE Software, Version 17.03.04a\nCisco IOS Software [Amsterdam], Virtual XE Software Configuration register is 0x2102",
+#         "Loopback999 is up, line protocol is up \n  Hardware is Loopback\n  Description: this is a test\n  MTU 1514 bytes, BW 8000000 Kbit/sec, DLY 5000 usec, \n     reliability 255/255, txload 1/255, rxload 1/255\n  Encapsulation LOOPBACK, loopback not set\n  Keepalive set (10 sec)\n  Last input never, output never, output hang never\n  Last clearing of \"show interface\" counters never\n  Input queue: 0/75/0/0 (size/max/drops/flushes); Total output drops: 0\n  Queueing strategy: fifo\n  Output queue: 0/0 (size/max)\n  5 minute input rate 0 bits/sec, 0 packets/sec\n  5 minute output rate 0 bits/sec, 0 packets/sec\n     0 packets input, 0 bytes, 0 no buffer\n     Received 0 broadcasts (0 IP multicasts)\n     0 runts, 0 giants, 0 throttles \n     0 input errors, 0 CRC, 0 frame, 0 overrun, 0 ignored, 0 abort\n     0 packets output, 0 bytes, 0 underruns\n     Output 0 broadcasts (0 IP multicasts)\n     0 output errors, 0 collisions, 0 interface resets\n     0 unknown protocol drops\n     0 output buffer failures, 0 output buffers swapped out"
+#     ],
+#     "stdout_lines": [
+#         [
+#             "Cisco IOS XE Software, Version 17.03.04a",
+#             "Cisco IOS Software [Amsterdam], Virtual XE Software",
+#             "..."
+#             "Configuration register is 0x2102"
+#         ],
+#         [
+#             "Loopback999 is up, line protocol is up ",
+#             "  Hardware is Loopback",
+#             "  Description: this is a test",
+#             "  MTU 1514 bytes, BW 8000000 Kbit/sec, DLY 5000 usec, ",
+#             "     reliability 255/255, txload 1/255, rxload 1/255",
+#             "  Encapsulation LOOPBACK, loopback not set",
+#             "  Keepalive set (10 sec)",
+#             "  Last input never, output never, output hang never",
+#             "  Last clearing of \"show interface\" counters never",
+#             "  Input queue: 0/75/0/0 (size/max/drops/flushes); Total output drops: 0",
+#             "  Queueing strategy: fifo",
+#             "  Output queue: 0/0 (size/max)",
+#             "  5 minute input rate 0 bits/sec, 0 packets/sec",
+#             "  5 minute output rate 0 bits/sec, 0 packets/sec",
+#             "     0 packets input, 0 bytes, 0 no buffer",
+#             "     Received 0 broadcasts (0 IP multicasts)",
+#             "     0 runts, 0 giants, 0 throttles ",
+#             "     0 input errors, 0 CRC, 0 frame, 0 overrun, 0 ignored, 0 abort",
+#             "     0 packets output, 0 bytes, 0 underruns",
+#             "     Output 0 broadcasts (0 IP multicasts)",
+#             "     0 output errors, 0 collisions, 0 interface resets",
+#             "     0 unknown protocol drops",
+#             "     0 output buffer failures, 0 output buffers swapped out"
+#         ]
+#     ]
+# }
+
+
+- name: Run multiple commands and evaluate the output
   cisco.ios.ios_command:
     commands:
     - show version
@@ -110,16 +225,120 @@ EXAMPLES = r"""
     - result[0] contains IOS
     - result[1] contains Loopback0
 
-- name: run commands that require answering a prompt
+# output-
+# failed play as result[1] contains Loopback0 is false
+
+# fatal: [iosxeappliance]: FAILED! => {
+#     "changed": false,
+#     "failed_conditions": [
+#         "result[1] contains Loopback0"
+#     ],
+#     "invocation": {
+#         "module_args": {
+#             "commands": [
+#                 "show version",
+#                 "show interfaces"
+#             ],
+#             "interval": 1,
+#             "match": "all",
+#             "retries": 10,
+#             "wait_for": [
+#                 "result[0] contains IOS",
+#                 "result[1] contains Loopback0"
+#             ]
+#         }
+#     },
+#     "msg": "One or more conditional statements have not been satisfied"
+# }
+
+- name: Run commands that require answering a prompt
   cisco.ios.ios_command:
     commands:
-    - command: 'clear counters GigabitEthernet0/1'
+    - command: 'clear counters GigabitEthernet2'
       prompt: 'Clear "show interface" counters on this interface \[confirm\]'
       answer: 'y'
-    - command: 'clear counters GigabitEthernet0/2'
+    - command: 'clear counters GigabitEthernet3'
       prompt: '[confirm]'
       answer: "\r"
+
+# output-
+
+# ok: [iosxeappliance] => {
+#     "changed": false,
+#     "invocation": {
+#         "module_args": {
+#             "commands": [
+#                 {
+#                     "answer": "y",
+#                     "check_all": false,
+#                     "command": "clear counters GigabitEthernet2",
+#                     "newline": true,
+#                     "output": null,
+#                     "prompt": "Clear \"show interface\" counters on this interface \\[confirm\\]",
+#                     "sendonly": false
+#                 },
+#                 {
+#                     "answer": "\r",
+#                     "check_all": false,
+#                     "command": "clear counters GigabitEthernet3",
+#                     "newline": true,
+#                     "output": null,
+#                     "prompt": "[confirm]",
+#                     "sendonly": false
+#                 }
+#             ],
+#             "interval": 1,
+#             "match": "all",
+#             "retries": 10,
+#             "wait_for": null
+#         }
+#     },
+#     "stdout": [
+#         "Clear \"show interface\" counters on this interface [confirm]y",
+#         "Clear \"show interface\" counters on this interface [confirm]"
+#     ],
+#     "stdout_lines": [
+#         [
+#             "Clear \"show interface\" counters on this interface [confirm]y"
+#         ],
+#         [
+#             "Clear \"show interface\" counters on this interface [confirm]"
+#         ]
+#     ]
+# }
+
+- name: Run commands with complex values like special characters in variables
+  cisco.ios.ios_command:
+    commands: ["{{ 'test aaa group TEST ' ~ user ~ ' ' ~ password ~ ' new-code' }}"]
+  vars:
+    user: "dummy"
+    password: "!dummy"
+
+# ok: [iosxeappliance] => {
+#     "changed": false,
+#     "invocation": {
+#         "module_args": {
+#             "commands": [
+#                 "test aaa group group test !dummy new-code"
+#             ],
+#             "interval": 1,
+#             "match": "all",
+#             "retries": 10,
+#             "wait_for": null
+#         }
+#     },
+#     "stdout": [
+#         "User was successfully authenticated."
+#     ],
+#     "stdout_lines": [
+#         [
+#             "User was successfully authenticated."
+#         ]
+#     ]
+# }
+
 """
+
 RETURN = """
 stdout:
   description: The set of responses from the commands

--- a/plugins/modules/ios_command.py
+++ b/plugins/modules/ios_command.py
@@ -178,7 +178,7 @@ EXAMPLES = r"""
 #     },
 #     "stdout": [
 #         "Cisco IOS XE Software, Version 17.03.04a\nCisco IOS Software [Amsterdam], Virtual XE Software Configuration register is 0x2102",
-#         "Loopback999 is up, line protocol is up \n  Hardware is Loopback\n  Description: this is a test\n  MTU 1514 bytes, BW 8000000 Kbit/sec, DLY 5000 usec, \n     reliability 255/255, txload 1/255, rxload 1/255\n  Encapsulation LOOPBACK, loopback not set\n  Keepalive set (10 sec)\n  Last input never, output never, output hang never\n  Last clearing of \"show interface\" counters never\n  Input queue: 0/75/0/0 (size/max/drops/flushes); Total output drops: 0\n  Queueing strategy: fifo\n  Output queue: 0/0 (size/max)\n  5 minute input rate 0 bits/sec, 0 packets/sec\n  5 minute output rate 0 bits/sec, 0 packets/sec\n     0 packets input, 0 bytes, 0 no buffer\n     Received 0 broadcasts (0 IP multicasts)\n     0 runts, 0 giants, 0 throttles \n     0 input errors, 0 CRC, 0 frame, 0 overrun, 0 ignored, 0 abort\n     0 packets output, 0 bytes, 0 underruns\n     Output 0 broadcasts (0 IP multicasts)\n     0 output errors, 0 collisions, 0 interface resets\n     0 unknown protocol drops\n     0 output buffer failures, 0 output buffers swapped out"
+#         "Loopback999 is up, line protocol is up ...failures, 0 output buffers swapped out"
 #     ],
 #     "stdout_lines": [
 #         [

--- a/plugins/modules/ios_facts.py
+++ b/plugins/modules/ios_facts.py
@@ -43,7 +43,7 @@ options:
   gather_subset:
     description:
     - When supplied, this argument restricts the facts collected to a given subset.
-    - Possible values for this argument include C(all), C(min), C(hardware), C(config),
+    - Possible values for this argument include C(all), C(min), C(default), C(hardware), C(config),
       and C(interfaces).
     - Specify a list of values to include a larger subset.
     - Use a value with an initial C(!) to collect all facts except that subset.

--- a/tests/unit/modules/network/ios/test_ios_facts.py
+++ b/tests/unit/modules/network/ios/test_ios_facts.py
@@ -82,6 +82,7 @@ class TestIosFactsModule(TestIosModule):
         result = self.execute_module()
         self.assertEqual(result["ansible_facts"]["ansible_net_model"], "WS-C3750-24TS")
         self.assertEqual(result["ansible_facts"]["ansible_net_serialnum"], "CAT0726R0ZU")
+        self.assertEqual(result["ansible_facts"]["ansible_net_operatingmode"], "autonomous")
         self.assertEqual(
             result["ansible_facts"]["ansible_net_stacked_models"],
             ["WS-C3750-24TS-E", "WS-C3750-24TS-E", "WS-C3750G-12S-E"],


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
facts to show operating state of the device 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
older IOS versions without Operation state
```paste below
ok: [abc] => {
    "ansible_facts": {
        "ansible_net_api": "cliconf",
        "ansible_net_gather_network_resources": [],
        "ansible_net_gather_subset": [
            "default"
        ],
        "ansible_net_hostname": "testme",
        "ansible_net_image": "flash0:/vios_l2-adventerprisek9-m",
        "ansible_net_iostype": "IOS",
        "ansible_net_model": "IOSv",
        "ansible_net_operatingmode": "autonomous",
        "ansible_net_python_version": "3.10.8",
        "ansible_net_serialnum": "9BB7BJD12FA",
        "ansible_net_system": "ios",
        "ansible_net_version": "15.2(20170321:233949)",
        "ansible_network_resources": {}
    },
    "changed": false,
    "invocation": {
        "module_args": {
            "available_network_resources": false,
            "gather_network_resources": null,
            "gather_subset": [
                "default"
            ]
        }
    }
}
```
Versions with operation state
```
ok: [def] => {
    "ansible_facts": {
        "ansible_net_api": "cliconf",
        "ansible_net_gather_network_resources": [],
        "ansible_net_gather_subset": [
            "default"
        ],
        "ansible_net_hostname": "testAppliance",
        "ansible_net_image": "bootflash:packages.conf",
        "ansible_net_iostype": "IOS-XE",
        "ansible_net_model": "CSR1000V",
        "ansible_net_operatingmode": "autonomous",
        "ansible_net_python_version": "3.10.8",
        "ansible_net_serialnum": "9JEFDUWP0QV",
        "ansible_net_system": "ios",
        "ansible_net_version": "17.03.04a",
        "ansible_network_resources": {}
    },
    "changed": false,
    "invocation": {
        "module_args": {
            "available_network_resources": false,
            "gather_network_resources": null,
            "gather_subset": [
                "default"
            ]
        }
    }
}
```
