### PR TITLE
[acls] fix precedence type for ace

### DIFF
--- a/changelogs/fragments/692-fix-community-issues.yaml
+++ b/changelogs/fragments/692-fix-community-issues.yaml
@@ -1,9 +1,9 @@
 bugfixes:
-  - ios.ios_route_maps - fix idempotency for `set community` operations.
+  - ios_route_maps - fix idempotency for `set community` operations.
     (https://github.com/ansible-collections/cisco.ios/issues/635)
-  - ios.ios_route_maos - fix replaced state support.
+  - ios_route_maos - fix replaced state support.
     (https://github.com/ansible-collections/cisco.ios/issues/680)
 
 minor_changes:
-  - ios.ios_route_maps - added 32-bit number support
+  - ios_route_maps - added 32-bit number support
     (https://github.com/ansible-collections/cisco.ios/pull/692)

--- a/changelogs/fragments/708-fix-interface-vrf-assignment.yaml
+++ b/changelogs/fragments/708-fix-interface-vrf-assignment.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - cisco.ios.ios_vrf - fix issue where assigning interfaces to existing vrfs doesn't work (https://github.com/ansible-collections/cisco.ios/issues/707)
+  - ios_vrf - fix issue where assigning interfaces to existing vrfs doesn't work (https://github.com/ansible-collections/cisco.ios/issues/707)

--- a/changelogs/fragments/717_acls_bug_fix.yaml
+++ b/changelogs/fragments/717_acls_bug_fix.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+  - ios_acls - fix precedence attribute to take a string value as input.
+  - ios_acls - fix parsers to accept precedence value in correct format.

--- a/docs/cisco.ios.ios_acls_module.rst
+++ b/docs/cisco.ios.ios_acls_module.rst
@@ -1214,7 +1214,7 @@ Parameters
                     <b>precedence</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
-                        <span style="color: purple">integer</span>
+                        <span style="color: purple">string</span>
                     </div>
                 </td>
                 <td>

--- a/plugins/module_utils/network/ios/argspec/acls/acls.py
+++ b/plugins/module_utils/network/ios/argspec/acls/acls.py
@@ -122,7 +122,7 @@ class AclsArgs(object):  # pylint: disable=R0903
                                     },
                                     "type": "dict",
                                 },
-                                "precedence": {"type": "int"},
+                                "precedence": {"type": "str"},
                                 "protocol": {"type": "str"},
                                 "protocol_options": {
                                     "options": {

--- a/plugins/module_utils/network/ios/rm_templates/acls.py
+++ b/plugins/module_utils/network/ios/rm_templates/acls.py
@@ -250,7 +250,7 @@ class AclsTemplate(NetworkTemplate):
                         (\s(?P<log_input>log-input\s\(tag\s=\s\S+\)|log-input))?
                         (\s(?P<log>log\s\(tag\s=\s\S+\)|log))?
                         (\soption\s(?P<option>\S+|\d+))?
-                        (\sprecedence\s(?P<precedence>\S+|\d+))?
+                        (\sprecedence\s(?P<precedence>\S+))?
                         (\stime-range\s(?P<time_range>\S+))?
                         (\stos\s(?P<tos>\S+|\d+))?
                         (\sttl\seq\s(?P<ttl_eq>\d+))?

--- a/plugins/modules/ios_acls.py
+++ b/plugins/modules/ios_acls.py
@@ -212,7 +212,7 @@ options:
                 type: dict
               precedence:
                 description: Match packets with given precedence value.
-                type: int
+                type: str
               protocol:
                 description:
                   - Specify the protocol to match.

--- a/tests/integration/targets/ios_acl_interfaces/tests/cli/_populate_config.yaml
+++ b/tests/integration/targets/ios_acl_interfaces/tests/cli/_populate_config.yaml
@@ -1,8 +1,28 @@
 ---
-- name: Populate configuration
-  vars:
-    lines:
-      "interface GigabitEthernet 2\nip access-group 110 in\nip access-group 123 out\nipv6 traffic-filter temp_v6 in\nipv6 traffic-filter test_v6 out\ninterface\
-      \ GigabitEthernet 3\nip access-group 110 in\nip access-group 123 out\n"
-  ansible.netcommon.cli_config:
-    config: "{{ lines }}"
+- name: Merge the provided configuration with the existing running configuration
+  register: result
+  cisco.ios.ios_acl_interfaces:
+    config:
+      - access_groups:
+          - acls:
+              - direction: in
+                name: 110
+              - direction: out
+                name: 123
+            afi: ipv4
+          - acls:
+              - direction: in
+                name: temp_v6
+              - direction: out
+                name: test_v6
+            afi: ipv6
+        name: GigabitEthernet2
+      - access_groups:
+          - acls:
+              - direction: in
+                name: 110
+              - direction: out
+                name: 123
+            afi: ipv4
+        name: GigabitEthernet3
+    state: merged

--- a/tests/integration/targets/ios_acls/tests/cli/_remove_config.yaml
+++ b/tests/integration/targets/ios_acls/tests/cli/_remove_config.yaml
@@ -1,8 +1,16 @@
 ---
-- name: Remove configuration
-  vars:
-    lines:
-      "no ip access-list standard std_acl\nno ip access-list extended test_acl\nno ip access-list extended 110\nno ip access-list extended 123\nno ip access-list\
-      \ extended 150\nno ipv6 access-list R1_TRAFFIC\n"
-  ansible.netcommon.cli_config:
-    config: "{{ lines }}"
+# - name: Remove configuration
+#   vars:
+#     lines:
+#       "no ip access-list standard std_acl\nno ip access-list extended test_acl\nno ip access-list extended 110\nno ip access-list extended 123\nno ip access-list\
+#       \ extended 150\nno ipv6 access-list R1_TRAFFIC\n"
+#   ansible.netcommon.cli_config:
+#     config: "{{ lines }}"
+
+- name: Delete ACL attributes based on AFI
+  register: result
+  cisco.ios.ios_acls: &id002
+    config:
+      - afi: ipv4
+      - afi: ipv6
+    state: deleted

--- a/tests/integration/targets/ios_acls/tests/cli/_remove_config.yaml
+++ b/tests/integration/targets/ios_acls/tests/cli/_remove_config.yaml
@@ -1,12 +1,4 @@
 ---
-# - name: Remove configuration
-#   vars:
-#     lines:
-#       "no ip access-list standard std_acl\nno ip access-list extended test_acl\nno ip access-list extended 110\nno ip access-list extended 123\nno ip access-list\
-#       \ extended 150\nno ipv6 access-list R1_TRAFFIC\n"
-#   ansible.netcommon.cli_config:
-#     config: "{{ lines }}"
-
 - name: Delete ACL attributes based on AFI
   register: result
   cisco.ios.ios_acls: &id002

--- a/tests/unit/modules/network/ios/test_ios_acls.py
+++ b/tests/unit/modules/network/ios/test_ios_acls.py
@@ -94,7 +94,7 @@ class TestIosAclsModule(TestIosModule):
                                         protocol="ip",
                                         sequence=10,
                                         source=dict(any=True),
-                                    )
+                                    ),
                                 ],
                                 acl_type="extended",
                             ),

--- a/tests/unit/modules/network/ios/test_ios_acls.py
+++ b/tests/unit/modules/network/ios/test_ios_acls.py
@@ -92,11 +92,12 @@ class TestIosAclsModule(TestIosModule):
                                         grant="permit",
                                         precedence="immediate",
                                         protocol="ip",
-                                        sequence=10,
+                                        sequence=20,
                                         source=dict(any=True),
                                     ),
                                 ],
                                 acl_type="extended",
+                                name="test_pre",
                             ),
                             dict(
                                 name="std_acl",
@@ -184,7 +185,7 @@ class TestIosAclsModule(TestIosModule):
             "permit tcp host 10.1.1.2 host 172.16.1.1 eq telnet",
             "deny ip any any log-input test_logInput",
             "ip access-list extended test_pre",
-            "10 permit ip any any precedence immediate",
+            "20 permit ip any any precedence immediate",
         ]
         self.assertEqual(sorted(result["commands"]), sorted(commands))
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
fix precedence type for ace 
argspec had it as int but it never generated int in the config hence facts.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- 
##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios_acls

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
        "ansible_network_resources": {
            "acls": [
                {
                    "acls": [
                        {
                            "aces": [
                                {
                                    "grant": "deny",
                                    "sequence": 10,
                                    "source": {
                                        "address": "192.168.1.0",
                                        "wildcard_bits": "0.0.0.255"
                                    }
                                },
                                {
                                    "grant": "deny",
                                    "sequence": 20,
                                    "source": {
                                        "address": "192.168.2.0",
                                        "wildcard_bits": "0.0.0.255"
                                    }
                                }
                            ],
                            "acl_type": "standard",
                            "name": "std_acl"
                        },
                        {
                            "aces": [
                                {
                                    "destination": {
                                        "any": true
                                    },
                                    "grant": "permit",
                                    "precedence": "internet",
                                    "protocol": "ip",
                                    "sequence": 10,
                                    "source": {
                                        "any": true
                                    }
                                }
                            ],
                            "acl_type": "extended",
                            "name": "test_perecedece"
                        }
                    ],
                    "afi": "ipv4"
                },
```
