### PR TITLE
[ospf_interfaces], fix wrong facts generation when hello-multiplier is configured

### DIFF
--- a/changelogs/fragments/ospf_interface_minimal.yaml
+++ b/changelogs/fragments/ospf_interface_minimal.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - ios_ospf_interfaces - fix dead-interval rendering wrong facts when hello-multiplier is configured.

--- a/plugins/module_utils/network/ios/rm_templates/ospf_interfaces.py
+++ b/plugins/module_utils/network/ios/rm_templates/ospf_interfaces.py
@@ -22,11 +22,6 @@ from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.r
 )
 
 
-def _tmplt_ospf_interface(config_data):
-    command = "interface {name}".format(**config_data)
-    return command
-
-
 def _tmplt_ospf_interface_process(config_data):
     if "process" in config_data:
         if config_data.get("afi") == "ipv4":
@@ -431,11 +426,9 @@ class Ospf_InterfacesTemplate(NetworkTemplate):
             "name": "dead_interval",
             "getval": re.compile(
                 r"""
-                \s+(?P<afi>ip|ipv6)*
-                \s*ospf*
-                \s*(?P<dead_interval>dead-interval)*
-                \s*(?P<seconds>\d+)*
-                \s*(?P<minimal>minimal\shello-multiplier\s\d+)*
+                \s((?P<afi>ip|ipv6)\sospf\sdead-interval)?
+                (\s(?P<seconds>\d+))?
+                (\sminimal\shello-multiplier\s(?P<minimal>\d+))?
                 $""",
                 re.VERBOSE,
             ),
@@ -447,9 +440,7 @@ class Ospf_InterfacesTemplate(NetworkTemplate):
                             "afi": "{{ 'ipv4' if afi == 'ip' else 'ipv6' }}",
                             "dead_interval": {
                                 "time": "{{ seconds }}",
-                                "minimal": {
-                                    "hello_multiplier": "{{ minimal.split(' ')[2] }}",
-                                },
+                                "minimal": "{{ minimal }}",
                             },
                         },
                     },


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
fix ospf interfaces on the configuration of dead-interval,  wrong facts generated when hello-multiplier is configured

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios_ospf_interfaces 

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
