### PR TITLE
fixed documentation in ospfv2 network parameter EXAMPLES

### DIFF
--- a/changelogs/fragments/ospfv2_module_docfix.yml
+++ b/changelogs/fragments/ospfv2_module_docfix.yml
@@ -1,0 +1,4 @@
+---
+---
+doc_changes:
+  - ospfv2 - fix documentation for ospfv2 module (network parameter not in list format)

--- a/changelogs/fragments/ospfv2_module_docfix.yml
+++ b/changelogs/fragments/ospfv2_module_docfix.yml
@@ -1,0 +1,3 @@
+---
+doc_changes:
+  - ospfv2 - fix documentation for ospfv2 module (networks parameter)

--- a/changelogs/fragments/ospfv2_module_docfix.yml
+++ b/changelogs/fragments/ospfv2_module_docfix.yml
@@ -1,4 +1,0 @@
----
----
-doc_changes:
-  - ospfv2 - fix documentation for ospfv2 module (network parameter not in list format)

--- a/docs/cisco.ios.ios_ospfv2_module.rst
+++ b/docs/cisco.ios.ios_ospfv2_module.rst
@@ -4715,9 +4715,9 @@ Examples
               - name: test_prefix_out
                 direction: out
             network:
-              address: 198.51.100.0
-              wildcard_bits: 0.0.0.255
-              area: 5
+              - address: 198.51.100.0
+                wildcard_bits: 0.0.0.255
+                area: 5
             default_information:
               originate: true
             passive_interfaces:
@@ -5187,9 +5187,9 @@ Examples
               - name: test_prefix_out
                 direction: out
             network:
-              address: 198.51.100.0
-              wildcard_bits: 0.0.0.255
-              area: 5
+              - address: 198.51.100.0
+                wildcard_bits: 0.0.0.255
+                area: 5
             default_information:
               originate: true
           - process_id: 200

--- a/plugins/modules/ios_ospfv2.py
+++ b/plugins/modules/ios_ospfv2.py
@@ -1090,9 +1090,9 @@ EXAMPLES = """
           - name: test_prefix_out
             direction: out
         network:
-          address: 198.51.100.0
-          wildcard_bits: 0.0.0.255
-          area: 5
+          - address: 198.51.100.0
+            wildcard_bits: 0.0.0.255
+            area: 5
         default_information:
           originate: true
         passive_interfaces:
@@ -1562,9 +1562,9 @@ EXAMPLES = """
           - name: test_prefix_out
             direction: out
         network:
-          address: 198.51.100.0
-          wildcard_bits: 0.0.0.255
-          area: 5
+          - address: 198.51.100.0
+            wildcard_bits: 0.0.0.255
+            area: 5
         default_information:
           originate: true
       - process_id: 200


### PR DESCRIPTION
##### SUMMARY
The `config.processes.network` parameter  in EXAMPLES from:
```yaml
        network:
          address: 198.51.100.0
          wildcard_bits: 0.0.0.255
          area: 5
```
To a list representation
```yaml
        network:
          - address: 198.51.100.0
            wildcard_bits: 0.0.0.255
            area: 5
```


##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
`cisco.ios.ios_ospfv2` module

