### PR TITLE
[ios_interfaces] add mode to ios_interfaces

### DIFF
--- a/changelogs/fragments/interface_mode.yaml
+++ b/changelogs/fragments/interface_mode.yaml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - ios_interfaces - Add mode attribute in ios_interfaces, which
+    supports layer2 and layer3 as options.

--- a/docs/cisco.ios.ios_interfaces_module.rst
+++ b/docs/cisco.ios.ios_interfaces_module.rst
@@ -317,6 +317,58 @@ Examples
     #  duplex full
     #  speed 100
 
+    # Using merged with mode attribute
+
+    # Before state:
+    # -------------
+    #
+    # vios#show running-config | section ^interface
+    # interface GigabitEthernet0/1
+    #  description Configured by Ansible
+    # interface GigabitEthernet0/2
+    #  description This is test
+    # interface GigabitEthernet0/3
+    #  description This is test
+    #  no switchport
+
+    - name: Merge provided configuration with device configuration
+      cisco.ios.ios_interfaces:
+        config:
+        - name: GigabitEthernet0/2
+          description: Configured and Merged by Ansible Network
+          enabled: true
+          mode: layer2
+        - name: GigabitEthernet0/3
+          description: Configured and Merged by Ansible Network
+          mode: layer3
+        state: merged
+
+    # Commands Fired:
+    # ---------------
+
+    # "commands": [
+    #       "interface GigabitEthernet0/2",
+    #       "description Configured and Merged by Ansible Network",
+    #       "switchport",
+    #       "no shutdown",
+    #       "interface GigabitEthernet0/3",
+    #       "description Configured and Merged by Ansible Network",
+    #       "shutdown",
+    #     ],
+
+    # After state:
+    # ------------
+    #
+    # vios#show running-config | section ^interface
+    # interface GigabitEthernet0/1
+    #  description Configured by Ansible
+    # interface GigabitEthernet0/2
+    #  description Configured and Merged by Ansible Network
+    # interface GigabitEthernet0/3
+    #  description Configured and Merged by Ansible Network
+    #  no switchport
+    #  shutdown
+
     # Using replaced
 
     # Before state:

--- a/docs/cisco.ios.ios_interfaces_module.rst
+++ b/docs/cisco.ios.ios_interfaces_module.rst
@@ -111,6 +111,29 @@ Parameters
                     <td class="elbow-placeholder"></td>
                 <td colspan="1">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>mode</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li>layer2</li>
+                                    <li>layer3</li>
+                        </ul>
+                </td>
+                <td>
+                        <div>Manage Layer2 or Layer3 state of the interface.</div>
+                        <div>For a Layer 2 appliance mode Layer2 adds switchport command ( default impacts idempotency).</div>
+                        <div>For a Layer 2 appliance mode Layer3 adds no switchport command.</div>
+                        <div>For a Layer 3 appliance mode Layer3/2 has no impact rather produces command fails.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>mtu</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">

--- a/docs/cisco.ios.ios_interfaces_module.rst
+++ b/docs/cisco.ios.ios_interfaces_module.rst
@@ -127,7 +127,7 @@ Parameters
                         <div>Manage Layer2 or Layer3 state of the interface.</div>
                         <div>For a Layer 2 appliance mode Layer2 adds switchport command ( default impacts idempotency).</div>
                         <div>For a Layer 2 appliance mode Layer3 adds no switchport command.</div>
-                        <div>For a Layer 3 appliance mode Layer3/2 has no impact rather produces command fails.</div>
+                        <div>For a Layer 3 appliance mode Layer3/2 has no impact rather command fails on apply.</div>
                 </td>
             </tr>
             <tr>

--- a/plugins/module_utils/network/ios/argspec/interfaces/interfaces.py
+++ b/plugins/module_utils/network/ios/argspec/interfaces/interfaces.py
@@ -41,6 +41,7 @@ class InterfacesArgs(object):  # pylint: disable=R0903
                 "enabled": {"type": "bool", "default": True},
                 "speed": {"type": "str"},
                 "mtu": {"type": "int"},
+                "mode": {"choices": ["layer2", "layer3"], "type": "str"},
                 "duplex": {"type": "str", "choices": ["full", "half", "auto"]},
             },
         },

--- a/plugins/module_utils/network/ios/config/interfaces/interfaces.py
+++ b/plugins/module_utils/network/ios/config/interfaces/interfaces.py
@@ -111,6 +111,15 @@ class Interfaces(ResourceModule):
                     # handles deleted as want be blank and only
                     # negates if no shutdown
                     self.addcmd(have, "enabled", False)
+        if want.get("mode") != have.get("mode"):
+            if want.get("mode") == "layer3":
+                self.addcmd(want, "mode", True)
+            else:
+                if want:
+                    self.addcmd(want, "mode", False)
+                elif have.get("mode"):  # can oly have layer2 as switchport no show cli
+                    # handles deleted as want be blank and only
+                    self.addcmd(have, "mode", False)
         if len(self.commands) != begin:
             self.commands.insert(
                 begin,

--- a/plugins/module_utils/network/ios/rm_templates/interfaces.py
+++ b/plugins/module_utils/network/ios/rm_templates/interfaces.py
@@ -76,6 +76,21 @@ class InterfacesTemplate(NetworkTemplate):
                 },
             },
         },
+        { # only applicable for switches
+            "name": "mode",
+            "getval": re.compile(
+                r"""
+                (?P<negate>\sno)?
+                (?P<switchport>\sswitchport)
+                $""", re.VERBOSE,
+            ),
+            "setval": "switchport",
+            "result": {
+                '{{ name }}': {
+                    'mode': "{{ 'layer2' if switchport is defined and negate is not defined else 'layer3' }}",
+                },
+            },
+        },
         {
             "name": "speed",
             "getval": re.compile(

--- a/plugins/module_utils/network/ios/rm_templates/interfaces.py
+++ b/plugins/module_utils/network/ios/rm_templates/interfaces.py
@@ -76,7 +76,7 @@ class InterfacesTemplate(NetworkTemplate):
                 },
             },
         },
-        { # only applicable for switches
+        {  # only applicable for switches
             "name": "mode",
             "getval": re.compile(
                 r"""

--- a/plugins/modules/ios_interfaces.py
+++ b/plugins/modules/ios_interfaces.py
@@ -190,6 +190,58 @@ EXAMPLES = """
 #  duplex full
 #  speed 100
 
+# Using merged with mode attribute
+
+# Before state:
+# -------------
+#
+# vios#show running-config | section ^interface
+# interface GigabitEthernet0/1
+#  description Configured by Ansible
+# interface GigabitEthernet0/2
+#  description This is test
+# interface GigabitEthernet0/3
+#  description This is test
+#  no switchport
+
+- name: Merge provided configuration with device configuration
+  cisco.ios.ios_interfaces:
+    config:
+    - name: GigabitEthernet0/2
+      description: Configured and Merged by Ansible Network
+      enabled: true
+      mode: layer2
+    - name: GigabitEthernet0/3
+      description: Configured and Merged by Ansible Network
+      mode: layer3
+    state: merged
+
+# Commands Fired:
+# ---------------
+
+# "commands": [
+#       "interface GigabitEthernet0/2",
+#       "description Configured and Merged by Ansible Network",
+#       "switchport",
+#       "no shutdown",
+#       "interface GigabitEthernet0/3",
+#       "description Configured and Merged by Ansible Network",
+#       "shutdown",
+#     ],
+
+# After state:
+# ------------
+#
+# vios#show running-config | section ^interface
+# interface GigabitEthernet0/1
+#  description Configured by Ansible
+# interface GigabitEthernet0/2
+#  description Configured and Merged by Ansible Network
+# interface GigabitEthernet0/3
+#  description Configured and Merged by Ansible Network
+#  no switchport
+#  shutdown
+
 # Using replaced
 
 # Before state:

--- a/plugins/modules/ios_interfaces.py
+++ b/plugins/modules/ios_interfaces.py
@@ -61,7 +61,7 @@ options:
         - Manage Layer2 or Layer3 state of the interface.
         - For a Layer 2 appliance mode Layer2 adds switchport command ( default impacts idempotency).
         - For a Layer 2 appliance mode Layer3 adds no switchport command.
-        - For a Layer 3 appliance mode Layer3/2 has no impact rather produces command fails.
+        - For a Layer 3 appliance mode Layer3/2 has no impact rather command fails on apply.
         choices:
         - layer2
         - layer3

--- a/plugins/modules/ios_interfaces.py
+++ b/plugins/modules/ios_interfaces.py
@@ -56,6 +56,16 @@ options:
         - MTU for a specific interface. Applicable for Ethernet interfaces only.
         - Refer to vendor documentation for valid values.
         type: int
+      mode:
+        description:
+        - Manage Layer2 or Layer3 state of the interface.
+        - For a Layer 2 appliance mode Layer2 adds switchport command ( default impacts idempotency).
+        - For a Layer 2 appliance mode Layer3 adds no switchport command.
+        - For a Layer 3 appliance mode Layer3/2 has no impact rather produces command fails.
+        choices:
+        - layer2
+        - layer3
+        type: str
       duplex:
         description:
         - Interface link status. Applicable for Ethernet interfaces only, either in

--- a/tests/unit/modules/network/ios/test_ios_interfaces.py
+++ b/tests/unit/modules/network/ios/test_ios_interfaces.py
@@ -97,6 +97,8 @@ class TestIosInterfacesModule(TestIosModule):
              duplex full
              negotiation auto
              ipv6 dhcp server
+            interface GigabitEthernet6
+             description Ansible UT interface 6
             """,
         )
         set_module_args(
@@ -112,6 +114,10 @@ class TestIosInterfacesModule(TestIosModule):
                         "enabled": False,
                         "name": "GigabitEthernet0/1",
                     },
+                    {
+                        "mode": "layer3",
+                        "name": "GigabitEthernet6",
+                    },
                 ],
                 "state": "merged",
             },
@@ -122,6 +128,8 @@ class TestIosInterfacesModule(TestIosModule):
             "shutdown",
             "interface GigabitEthernet1",
             "description This interface should be disabled",
+            "interface GigabitEthernet6",
+            "no switchport",
         ]
         result = self.execute_module(changed=True)
         self.assertEqual(result["commands"], commands)
@@ -208,6 +216,9 @@ class TestIosInterfacesModule(TestIosModule):
              duplex full
              negotiation auto
              ipv6 dhcp server
+            interface GigabitEthernet6
+             description Ansible UT interface 6
+             no switchport
             """,
         )
         set_module_args(
@@ -215,6 +226,11 @@ class TestIosInterfacesModule(TestIosModule):
                 "config": [
                     {"description": "Ansible UT interface 1", "name": "GigabitEthernet1"},
                     {"name": "GigabitEthernet0/1", "speed": 1200, "mtu": 1800},
+                    {
+                        "name": "GigabitEthernet6",
+                        "description": "Ansible UT interface 6",
+                        "mode": "layer2",
+                    },
                 ],
                 "state": "replaced",
             },
@@ -224,6 +240,8 @@ class TestIosInterfacesModule(TestIosModule):
             "no description Ansible UT interface 2",
             "speed 1200",
             "mtu 1800",
+            "interface GigabitEthernet6",
+            "switchport",
         ]
         result = self.execute_module(changed=True)
         self.assertEqual(result["commands"], commands)
@@ -310,6 +328,9 @@ class TestIosInterfacesModule(TestIosModule):
              duplex full
              negotiation auto
              ipv6 dhcp server
+            interface GigabitEthernet6
+             description Ansible UT interface 6
+             no switchport
             """,
         )
         set_module_args(
@@ -343,6 +364,10 @@ class TestIosInterfacesModule(TestIosModule):
             "no description Ansible UT interface 5",
             "no duplex full",
             "shutdown",
+            "interface GigabitEthernet6",
+            "no description Ansible UT interface 6",
+            "shutdown",
+            "switchport",
             "interface GigabitEthernet1",
             "description Ansible UT interface try 1",
             "speed 1000",
@@ -536,6 +561,12 @@ class TestIosInterfacesModule(TestIosModule):
                      duplex full
                      negotiation auto
                      ipv6 dhcp server
+                    interface GigabitEthernet6
+                     description Ansible UT interface 6
+                     switchport
+                    interface GigabitEthernet7
+                     description Ansible UT interface 7
+                     no switchport
                     """,
                 ),
                 state="parsed",
@@ -562,6 +593,18 @@ class TestIosInterfacesModule(TestIosModule):
                 "name": "GigabitEthernet5",
                 "description": "Ansible UT interface 5",
                 "duplex": "full",
+                "enabled": True,
+            },
+            {
+                "name": "GigabitEthernet6",
+                "mode": "layer2",
+                "description": "Ansible UT interface 6",
+                "enabled": True,
+            },
+            {
+                "name": "GigabitEthernet7",
+                "mode": "layer3",
+                "description": "Ansible UT interface 7",
                 "enabled": True,
             },
         ]


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
add mode to attribute to ios_interfaces

-  Manage Layer2 or Layer3 state of the interface.
-  For a Layer 2 appliance mode Layer2 adds switchport command ( default impacts idempotency).
-  For a Layer 2 appliance mode Layer3 adds no switchport command.
-  For a Layer 3 appliance mode Layer3/2 has no impact rather produces command fails.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios_interfaces

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

```paste below
PLAYBOOK 
-------------------------------------------------------------------------------
  tasks:
  - name: Merge provided configuration with device configuration check mode
    cisco.ios.ios_interfaces:
      config:
      - name: GigabitEthernet2
        description: Configured and Merged by Ansible Network
        enabled: true
        mode: layer2
      - name: GigabitEthernet3
        description: Configured and Merged by Ansible Network
        mode: layer3
      state: merged
    check_mode: true

  - name: Merge provided configuration with device configuration
    cisco.ios.ios_interfaces:
      config:
      - name: GigabitEthernet2
        description: Configured and Merged by Ansible Network
        enabled: true
        mode: layer2
      - name: GigabitEthernet3
        description: Configured and Merged by Ansible Network
        mode: layer3
      state: merged
```

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
OUTPUT 
-------------------------------------------------------------------------------
ansible-playbook [core 2.14.1]

TASK [Merge provided configuration with device configuration check mode] *******
changed: [abcd] => changed=true 
  after:
  - enabled: true
    name: GigabitEthernet1
  - description: Configured and Merged by Ansible Network
    enabled: true
    name: GigabitEthernet2
    speed: '1000'
  - enabled: true
    name: GigabitEthernet3
    speed: '1000'
  - enabled: false
    name: GigabitEthernet4
  - enabled: true
    name: Loopback888
  - enabled: true
    name: Loopback999
  before:
  - enabled: true
    name: GigabitEthernet1
  - description: Configured and Merged by Ansible Network
    enabled: true
    name: GigabitEthernet2
    speed: '1000'
  - enabled: true
    name: GigabitEthernet3
    speed: '1000'
  - enabled: false
    name: GigabitEthernet4
  - enabled: true
    name: Loopback888
  - enabled: true
    name: Loopback999
  commands:
  - interface GigabitEthernet2
  - switchport
  - interface GigabitEthernet3
  - description Configured and Merged by Ansible Network
  - no switchport
  invocation:
    module_args:
      config:
      - description: Configured and Merged by Ansible Network
        duplex: null
        enabled: true
        mode: layer2
        mtu: null
        name: GigabitEthernet2
        speed: null
      - description: Configured and Merged by Ansible Network
        duplex: null
        enabled: true
        mode: layer3
        mtu: null
        name: GigabitEthernet3
        speed: null
      running_config: null
      state: merged

TASK [Merge provided configuration with device configuration] ******************
fatal: [abcd]: FAILED! => changed=false 
  module_stderr: |-
    switchport
    switchport
     ^
    % Invalid input detected at '^' marker.
  
    Router(config-if)#
  module_stdout: ''
  msg: |-
    MODULE FAILURE
    See stdout/stderr for the exact error
```
