### PR TITLE
[WIP] add support for src plus match:exact

### DIFF
--- a/plugins/cliconf/ios.py
+++ b/plugins/cliconf/ios.py
@@ -241,29 +241,85 @@ class Cliconf(CliconfBase):
                 % (diff_replace, ", ".join(option_values["diff_replace"])),
             )
 
-        # prepare candidate configuration
-        candidate_obj = NetworkConfig(indent=1)
-        want_src, want_banners = self._extract_banners(candidate)
-        candidate_obj.load(want_src)
+        cand_pattern = r'(?P<parent>^\w.*\n?)(?P<child>(?:\s+.*\n?)*)'
+        candidates = re.findall(cand_pattern, candidate, re.M)
 
-        if running and diff_match != "none":
-            # running configuration
-            have_src, have_banners = self._extract_banners(running)
-            running_obj = NetworkConfig(indent=1, contents=have_src, ignore_lines=diff_ignore_lines)
-            configdiffobjs = candidate_obj.difference(
-                running_obj,
-                path=path,
-                match=diff_match,
-                replace=diff_replace,
-            )
+        diff["config_diff"] = ""
+        diff["banner_diff"] = {}
 
+        # exact plus src support. src can have multiple sections as candidates
+        # e.g policy-map foo, policy-map bar, policy-map baz etc.
+        if candidates and not path and diff_match == "exact":
+            for _candidate in candidates:
+                path = [_candidate[0].strip()]
+                _candidate = "".join(_candidate)
+                _candidate_obj = NetworkConfig(indent=1)
+                _candidate_obj.load(_candidate)
+
+                running_obj = NetworkConfig(
+                    indent=1,
+                    contents=running,
+                    ignore_lines=diff_ignore_lines,
+                )
+
+                try:
+                    have_lines = running_obj.get_block(path)
+                except ValueError:
+                    have_lines = []
+                want_lines = _candidate_obj.get_block(path)
+
+                negates = ''
+                negated_parents = []
+                for line in have_lines:
+                    if not line in want_lines:
+                        negates += ''.join(f'{i}\n' for i in line.parents
+                                           if not i in negates)
+
+                        if line.has_children:
+                            negated_parents.append(line.text)
+
+                        if not any(i in negated_parents
+                                   for i in line.parents):
+                            negates += f'no {line}\n'
+
+                diff["config_diff"] += negates
+
+                wants = ''
+                for line in want_lines:
+                    if not line in have_lines:
+                        wants += ''.join(f'{i}\n' for i in line.parents
+                                         if not i in wants)
+                        wants += f'{line}\n'
+
+                diff["config_diff"] += wants
+
+            diff["config_diff"] = diff["config_diff"].rstrip()
         else:
-            configdiffobjs = candidate_obj.items
-            have_banners = {}
+            # The "original" code moved to this else-section
+            # prepare candidate configuration
+            candidate_obj = NetworkConfig(indent=1)
+            want_src, want_banners = self._extract_banners(candidate)
+            candidate_obj.load(want_src)
 
-        diff["config_diff"] = dumps(configdiffobjs, "commands") if configdiffobjs else ""
-        banners = self._diff_banners(want_banners, have_banners)
-        diff["banner_diff"] = banners if banners else {}
+            if running and diff_match != "none":
+                # running configuration
+                have_src, have_banners = self._extract_banners(running)
+                running_obj = NetworkConfig(indent=1, contents=have_src, ignore_lines=diff_ignore_lines)
+                configdiffobjs = candidate_obj.difference(
+                    running_obj,
+                    path=path,
+                    match=diff_match,
+                    replace=diff_replace,
+                )
+
+            else:
+                configdiffobjs = candidate_obj.items
+                have_banners = {}
+
+            diff["config_diff"] = dumps(configdiffobjs, "commands") if configdiffobjs else ""
+            banners = self._diff_banners(want_banners, have_banners)
+            diff["banner_diff"] = banners if banners else {}
+
         return diff
 
     @enable_mode

--- a/plugins/modules/ios_config.py
+++ b/plugins/modules/ios_config.py
@@ -448,7 +448,7 @@ def main():
     mutually_exclusive = [("lines", "src"), ("parents", "src")]
     required_if = [
         ("match", "strict", ["lines"]),
-        ("match", "exact", ["lines"]),
+        ("match", "exact", ["lines", "src"], True),
         ("replace", "block", ["lines"]),
         ("diff_against", "intended", ["intended_config"]),
     ]


### PR DESCRIPTION
##### SUMMARY

Fixes #655
Fixes #740
Fixes #771
Fixes #129 (related)

Add support for device configuration to exactly match the provided template configuration guaranteeing consistency and idempotency.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
cisco.ios.ios_config

##### ADDITIONAL INFORMATION

Feature best described by using an example:

###### play
```
- name: Make sure running-config exactly matches the template
  cisco.ios.ios_config:
    match: exact
    src: template.j2
```
###### template.j2
```
class-map match-all FOO
 description I am FOO
 match dscp af41
class-map match-all BAR
 description I am BAR
 match dscp af31
```
###### running-config before
```
class-map match-all FOO
 match dscp af42
 match dscp af43
```
###### commands fired
```
class-map match-all FOO
 no match dscp af42
 no match dscp af43
 description I am FOO
 match dscp af41
class-map match-all BAR
 description I am BAR
 match dscp af31
```

###### running-config after
```
class-map match-all FOO
 description I am FOO
 match dscp af41 
class-map match-all BAR
 description I am BAR
 match dscp af31 
```

Consecutive Runs:
changed: false aka Idempotent!
