### PR TITLE
[ios_acls] prevent rendering of mac access-lists in facts

### DIFF
--- a/changelogs/fragments/fix_acls_rendering_mac.yaml
+++ b/changelogs/fragments/fix_acls_rendering_mac.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - ios_acls - prevent rendering of mac access-lists in facts.

--- a/plugins/module_utils/network/ios/rm_templates/acls.py
+++ b/plugins/module_utils/network/ios/rm_templates/acls.py
@@ -159,6 +159,30 @@ class AclsTemplate(NetworkTemplate):
             "shared": True,
         },
         {
+            "name": "_mac_acls_name",  #
+            "getval": re.compile(
+                r"""^(?P<acl_type>Standard|Extended|Reflexive)*
+                    \s*(?P<afi>MAC)*
+                    \s*access
+                    \s*list*
+                    \s*(?P<acl_name>.+)*
+                    $""",
+                re.VERBOSE,
+            ),
+            "compval": "name",
+            "setval": "",
+            "result": {
+                "acls": {
+                    "{{ acl_name|d() }}": {
+                        "name": "{{ acl_name }}",
+                        "acl_type": "{{ acl_type.lower() if acl_type is defined }}",
+                        "afi": "{{ afi }}",
+                    },
+                },
+            },
+            "shared": True,
+        },
+        {
             "name": "remarks",
             "getval": re.compile(
                 r"""\s+remark

--- a/tests/unit/modules/network/ios/test_ios_acls.py
+++ b/tests/unit/modules/network/ios/test_ios_acls.py
@@ -1122,6 +1122,10 @@ class TestIosAclsModule(TestIosModule):
                         20 permit tcp host 10.1.1.1 host 10.5.5.5 eq www
                         30 permit icmp any any
                         40 permit udp host 10.6.6.6 10.10.10.0 0.0.0.255 eq domain
+                    Extended MAC access list system-cpp-bpdu-range
+                        permit any 0180.c200.0000 0000.0000.0003
+                    Extended MAC access list system-cpp-cdp
+                        permit any host 0100.0ccc.cccc
                     """,
                 ),
                 state="parsed",


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Prevent rendering of mac based access-lists in facts
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios_acls

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
