### PR TITLE
[bgp_global] render correct configuration for timers under neighbor

### DIFF
--- a/changelogs/fragments/bgp_global_timer_render.yml
+++ b/changelogs/fragments/bgp_global_timer_render.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - ios_bgp_global - fix configuration of timers under neighbors.

--- a/changelogs/fragments/bgp_global_timer_render.yml
+++ b/changelogs/fragments/bgp_global_timer_render.yml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - ios_bgp_global - fix configuration of timers under neighbor.
+  - ios_bgp_global - fix configuration of timers under neighbor. (https://github.com/ansible-collections/cisco.ios/issues/794)

--- a/changelogs/fragments/bgp_global_timer_render.yml
+++ b/changelogs/fragments/bgp_global_timer_render.yml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - ios_bgp_global - fix configuration of timers under neighbors.
+  - ios_bgp_global - fix configuration of timers under neighbor.

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -13,4 +13,4 @@ issues: https://github.com/ansible-collections/cisco.ios/issues
 tags: [cisco, ios, iosxe, networking]
 # NOTE(pabelanger): We create an empty version key to keep ansible-galaxy
 # happy. We dynamically inject version info based on git information.
-version: "4.4.1"
+version: "4.4.2-dev"

--- a/plugins/module_utils/network/ios/config/bgp_global/bgp_global.py
+++ b/plugins/module_utils/network/ios/config/bgp_global/bgp_global.py
@@ -271,7 +271,7 @@ class Bgp_global(ResourceModule):
             "path_attribute.treat_as_withdraw",
             "shutdown",
             "soft_reconfiguration",
-            "timers",
+            "ntimers",
             "transport.connection_mode",
             "transport.multi_session",
             "transport.path_mtu_discovery",
@@ -379,6 +379,9 @@ class Bgp_global(ResourceModule):
                 if k == "neighbors":
                     for neb in tmp_data.get("neighbors"):
                         neb = self._bgp_global_list_to_dict(neb)
+                        _ntimer = neb.pop("timers", {})
+                        if _ntimer:
+                            neb["ntimers"] = _ntimer
                 tmp_data[k] = {str(i[p_key[k]]): i for i in tmp_data[k]}
             elif tmp_data.get("distributes") and k == "distributes":
                 tmp_data[k] = {str("".join([i.get(j, "") for j in _v])): i for i in tmp_data[k]}

--- a/plugins/module_utils/network/ios/rm_templates/bgp_global.py
+++ b/plugins/module_utils/network/ios/rm_templates/bgp_global.py
@@ -1701,7 +1701,7 @@ class Bgp_globalTemplate(NetworkTemplate):
             "result": {"neighbors": {"{{ neighbor_address }}": {"soft_reconfiguration": True}}},
         },
         {
-            "name": "timers",
+            "name": "ntimers",
             "getval": re.compile(
                 r"""
                 \sneighbor\s(?P<neighbor_address>\S+)\stimers
@@ -1712,9 +1712,9 @@ class Bgp_globalTemplate(NetworkTemplate):
                 re.VERBOSE,
             ),
             "setval": "neighbor {{ neighbor_address }} timers"
-            "{{ (' ' + timers.interval|string) if timers.interval is defined else '' }}"
-            "{{ (' ' + timers.holdtime|string) if timers.holdtime is defined else '' }}"
-            "{{ (' ' + timers.min_holdtime|string) if timers.min_holdtime is defined else '' }}",
+            "{{ (' ' + ntimers.interval|string) if ntimers.interval is defined else '' }}"
+            "{{ (' ' + ntimers.holdtime|string) if ntimers.holdtime is defined else '' }}"
+            "{{ (' ' + ntimers.min_holdtime|string) if ntimers.min_holdtime is defined else '' }}",
             "result": {
                 "neighbors": {
                     "{{ neighbor_address }}": {

--- a/tests/unit/modules/network/ios/test_ios_bgp_global.py
+++ b/tests/unit/modules/network/ios/test_ios_bgp_global.py
@@ -167,7 +167,14 @@ class TestIosBgpGlobalModule(TestIosModule):
                     "maximum_paths": {"ibgp": 22},
                     "maximum_secondary_paths": {"ibgp": 22, "paths": 12},
                     "neighbors": [
-                        {"neighbor_address": "192.0.2.3", "remote_as": "300"},
+                        {
+                            "neighbor_address": "192.0.2.3",
+                            "remote_as": "300",
+                            "timers": {
+                                "holdtime": 20,
+                                "interval": 10,
+                            },
+                        },
                         {
                             "aigp": {
                                 "send": {
@@ -248,11 +255,12 @@ class TestIosBgpGlobalModule(TestIosModule):
             "neighbor 192.0.2.4 remote-as 100.1",
             "neighbor 192.0.2.4 aigp send cost-community 100 poi igp-cost transitive",
             "neighbor 192.0.2.3 remote-as 300",
+            "neighbor 192.0.2.3 timers 10 20",
             "redistribute connected metric 22",
-            "redistribute application ap112 metric 33 route-map mp1",
-            "redistribute application ap1 metric 22",
             "redistribute mobile metric 211",
+            "redistribute application ap1 metric 22",
             "redistribute static metric 33 route-map mp1",
+            "redistribute application ap112 metric 33 route-map mp1",
         ]
         result = self.execute_module(changed=True)
         self.assertEqual(sorted(result["commands"]), sorted(commands))


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
render correct configuration for timers under neighbours
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
  - name: "Configure BGP Global"
    cisco.ios.ios_bgp_global:
      config:
        as_number: '65000'
        timers:
          holdtime: 30
        bgp:
          log_neighbor_changes: true
          router_id:
            address: 10.2.1.1
        neighbors:
          - neighbor_address: 10.254.1.2
            remote_as: '65000'
            timers:
              holdtime: 30
              interval: 10
```
