### PR TITLE
ios_snmp_server: improvment for snmp-server module

### DIFF
--- a/changelogs/fragments/ios_snmp_server_doc_changes.yml
+++ b/changelogs/fragments/ios_snmp_server_doc_changes.yml
@@ -1,4 +1,4 @@
 ---
-minor_changes:
+doc_changes:
   - ios_snmp_server - Add the option to configure the match option for context
   - ios_snmp_server - Fixed issue with the ifindex persistent that is not correctly detected from current config

--- a/changelogs/fragments/ios_snmp_server_doc_changes.yml
+++ b/changelogs/fragments/ios_snmp_server_doc_changes.yml
@@ -1,4 +1,4 @@
 ---
-doc_changes:
+minor_changes:
   - ios_snmp_server - Add the option to configure the match option for context
   - ios_snmp_server - Fixed issue with the ifindex persistent that is not correctly detected from current config

--- a/changelogs/fragments/ios_snmp_server_doc_changes.yml
+++ b/changelogs/fragments/ios_snmp_server_doc_changes.yml
@@ -1,0 +1,4 @@
+---
+doc_changes:
+  - ios_snmp_server - Add the option to configure the match option for context
+  - ios_snmp_server - Fixed issue with the ifindex persistent that is not correctly detected from current config

--- a/tests/unit/modules/network/ios/test_ios_snmp_server.py
+++ b/tests/unit/modules/network/ios/test_ios_snmp_server.py
@@ -636,6 +636,7 @@ class TestIosSnmpServerModule(TestIosModule):
             },
         }
         merged = [
+            "snmp ifmib ifindex persist",
             "snmp-server accounting commands default",
             "snmp-server chassis-id this is a chassis id string",
             "snmp-server contact this is contact string",
@@ -708,7 +709,6 @@ class TestIosSnmpServerModule(TestIosModule):
             "snmp-server user paul familypaul v3 access ipv6 ipv6only",
             "snmp-server user replaceUser replaceUser v3 access 22",
             "snmp-server user flow mfamily v3 access 27",
-            "snmp ifmib ifindex persist",
         ]
         playbook["state"] = "merged"
         set_module_args(playbook)
@@ -1084,6 +1084,7 @@ class TestIosSnmpServerModule(TestIosModule):
             snmp-server inform pending 2
             snmp-server view no-write.test testiso excluded
             snmp-server view test-view! test-test included
+            snmp ifmib ifindex persist
             """,
         )
 
@@ -1336,7 +1337,6 @@ class TestIosSnmpServerModule(TestIosModule):
             "snmp-server view newView TestFamilyName included",
             "no snmp-server enable traps vtp",
             "no snmp-server view test-view! test-test included",
-            "snmp ifmib ifindex persist",
         ]
         playbook["state"] = "overridden"
         set_module_args(playbook)

--- a/tests/unit/modules/network/ios/test_ios_snmp_server.py
+++ b/tests/unit/modules/network/ios/test_ios_snmp_server.py
@@ -149,6 +149,7 @@ class TestIosSnmpServerModule(TestIosModule):
             snmp-server password-policy policy3 define min-len 12 max-len 12 upper-case 12 special-char 22 digits 23 change 11
             snmp-server accounting commands default
             snmp-server inform pending 2
+            snmp-server ifindex persist
             """,
         )
 
@@ -214,6 +215,7 @@ class TestIosSnmpServerModule(TestIosModule):
                     {"community_string": "check", "host": "172.16.2.99", "traps": ["slb"]},
                     {"community_string": "checktrap", "host": "172.16.2.99", "traps": ["isis"]},
                 ],
+                "if_index": True,
                 "inform": {"pending": 2},
                 "ip": {"dscp": 2},
                 "location": "thi sis a good location",
@@ -477,6 +479,7 @@ class TestIosSnmpServerModule(TestIosModule):
                     {"community_string": "check", "host": "172.16.2.99", "traps": ["slb"]},
                     {"community_string": "checktrap", "host": "172.16.2.99", "traps": ["isis"]},
                 ],
+                "if_index": True,
                 "inform": {"pending": 2},
                 "ip": {"dscp": 2},
                 "location": "thi sis a good location",
@@ -705,6 +708,7 @@ class TestIosSnmpServerModule(TestIosModule):
             "snmp-server user paul familypaul v3 access ipv6 ipv6only",
             "snmp-server user replaceUser replaceUser v3 access 22",
             "snmp-server user flow mfamily v3 access 27",
+            "snmp ifmib ifindex persist",
         ]
         playbook["state"] = "merged"
         set_module_args(playbook)
@@ -1145,6 +1149,7 @@ class TestIosSnmpServerModule(TestIosModule):
                     {"community_string": "check", "host": "172.16.2.99", "traps": ["slb"]},
                     {"community_string": "checktrap", "host": "172.16.2.99", "traps": ["isis"]},
                 ],
+                "if_index": True,
                 "inform": {"pending": 2},
                 "ip": {"dscp": 2},
                 "location": "thi sis a good location",
@@ -1331,6 +1336,7 @@ class TestIosSnmpServerModule(TestIosModule):
             "snmp-server view newView TestFamilyName included",
             "no snmp-server enable traps vtp",
             "no snmp-server view test-view! test-test included",
+            "snmp ifmib ifindex persist",
         ]
         playbook["state"] = "overridden"
         set_module_args(playbook)

--- a/tests/unit/modules/network/ios/test_ios_snmp_server.py
+++ b/tests/unit/modules/network/ios/test_ios_snmp_server.py
@@ -636,7 +636,7 @@ class TestIosSnmpServerModule(TestIosModule):
             },
         }
         merged = [
-            "snmp ifmib ifindex persist",
+            "snmp-server ifindex persist",
             "snmp-server accounting commands default",
             "snmp-server chassis-id this is a chassis id string",
             "snmp-server contact this is contact string",


### PR DESCRIPTION
- add the possibility manage the match part of the context for snmp-server group this part could be usefull on cisco devices to retrieve the MAC table of all VLANs with SNMPv3

- Fixe an issue with snmp-server ifindex: the command working fine but the result in command could be also seen with the command `snmp ifmib ifindex persist`

##### SUMMARY
Performing two change in ios_snmp_server module:
- Add the possibility to manage the `match` part for `context` in `snmp-server group` command
- I have also seen a weird bug with the if_index parameter:
  the parameter is correctly sent to the switch but, on many switches, we should also check the command `snmp ifmib ifindex persist`to validate if the command is present

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
ios_snmp_server

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before add the context match
```
snmp-server group group1 v3 auth context vlan-
```

After:
```
snmp-server group group1 v3 auth
snmp-server group group1 v3 auth context vlan match prefix
```

And the output of the complete commands on Cisco switches
```
fhv-pry-msw01#sh run | section ^snmp
snmp-server group group1 v3 auth
snmp-server group group1 v3 auth context vlan- match prefix
snmp-server location nowhere
snmp-server contact noreply@example.org
snmp-server enable traps license
snmp-server enable traps stackwise
snmp-server enable traps envmon fan shutdown supply status
snmp ifmib ifindex persist
```

and the result for the gathered output:
```
        "gathered": {
            "contact": "noreply@example.org",
            "groups": [
                {
                    "group": "group1",
                    "read": "snmp-view-full",
                    "version": "v3",
                    "version_option": "auth"
                },
                {
                    "context": "vlan-",
                    "group": "group1",
                    "match": "prefix",
                    "version": "v3",
                    "version_option": "auth"
                }
            ],
            "if_index": true,
            "location": "nowhere",
            "views": [
                {
                    "family_name": "iso",
                    "included": true,
                    "name": "snmp-view-full"
                }
            ]
        }
```