### PR TITLE
IOS Interface Template Support

### DIFF
--- a/changelogs/fragments/ios_interface_templates
+++ b/changelogs/fragments/ios_interface_templates
@@ -1,1 +1,0 @@
-Provides support for Cisco IOS Template engine in base interfaces module

--- a/changelogs/fragments/ios_interface_templates
+++ b/changelogs/fragments/ios_interface_templates
@@ -1,0 +1,1 @@
+Provides support for Cisco IOS Template engine in base interfaces module

--- a/changelogs/fragments/ios_interface_templates.yml
+++ b/changelogs/fragments/ios_interface_templates.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - ios_interfaces - Add template attribute to provide support for cisco ios templates.

--- a/docs/cisco.ios.ios_interfaces_module.rst
+++ b/docs/cisco.ios.ios_interfaces_module.rst
@@ -180,6 +180,22 @@ Parameters
                         <div>Interface link speed. Applicable for Ethernet interfaces only.</div>
                 </td>
             </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>template</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>IOS template name.</div>
+                </td>
+            </tr>
 
             <tr>
                 <td colspan="2">

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -13,4 +13,4 @@ issues: https://github.com/ansible-collections/cisco.ios/issues
 tags: [cisco, ios, iosxe, networking]
 # NOTE(pabelanger): We create an empty version key to keep ansible-galaxy
 # happy. We dynamically inject version info based on git information.
-version: "4.5.1-dev"
+version: "4.6.0-dev"

--- a/plugins/module_utils/network/ios/argspec/interfaces/interfaces.py
+++ b/plugins/module_utils/network/ios/argspec/interfaces/interfaces.py
@@ -43,6 +43,7 @@ class InterfacesArgs(object):  # pylint: disable=R0903
                 "mtu": {"type": "int"},
                 "mode": {"choices": ["layer2", "layer3"], "type": "str"},
                 "duplex": {"type": "str", "choices": ["full", "half", "auto"]},
+                "template": {"type": "str"},
             },
         },
         "running_config": {"type": "str"},

--- a/plugins/module_utils/network/ios/config/interfaces/interfaces.py
+++ b/plugins/module_utils/network/ios/config/interfaces/interfaces.py
@@ -48,7 +48,7 @@ class Interfaces(ResourceModule):
             resource="interfaces",
             tmplt=InterfacesTemplate(),
         )
-        self.parsers = ["description", "speed", "mtu", "duplex"]
+        self.parsers = ["description", "speed", "mtu", "duplex", "template"]
 
     def execute_module(self):
         """Execute the module

--- a/plugins/module_utils/network/ios/rm_templates/interfaces.py
+++ b/plugins/module_utils/network/ios/rm_templates/interfaces.py
@@ -129,5 +129,19 @@ class InterfacesTemplate(NetworkTemplate):
                 },
             },
         },
+        {
+            "name": "template",
+            "getval": re.compile(
+                r"""
+                \s+source\stemplate\s(?P<template>.+$)
+                """, re.VERBOSE,
+            ),
+            "setval": "source template {{ template }}",
+            "result": {
+                '{{ name }}': {
+                    'template': '{{ template }}',
+                },
+            },
+        },
     ]
     # fmt: on

--- a/plugins/modules/ios_interfaces.py
+++ b/plugins/modules/ios_interfaces.py
@@ -78,6 +78,10 @@ options:
         - full
         - half
         - auto
+      template:
+        description:
+        - IOS template name.
+        type: str
   running_config:
     description:
       - This option is used only with state I(parsed).

--- a/tests/unit/modules/network/ios/test_ios_interfaces.py
+++ b/tests/unit/modules/network/ios/test_ios_interfaces.py
@@ -79,6 +79,7 @@ class TestIosInterfacesModule(TestIosModule):
              speed 1000
              mtu 1500
              no negotiation auto
+             source template ANSIBLE
             interface GigabitEthernet3
              description Ansible UT interface 3
              no ip address
@@ -91,6 +92,7 @@ class TestIosInterfacesModule(TestIosModule):
              no ip address
              shutdown
              negotiation auto
+             source template ANSIBLE
             interface GigabitEthernet5
              description Ansible UT interface 5
              no ip address
@@ -99,6 +101,7 @@ class TestIosInterfacesModule(TestIosModule):
              ipv6 dhcp server
             interface GigabitEthernet6
              description Ansible UT interface 6
+             source template NOCHANGE
             """,
         )
         set_module_args(
@@ -108,11 +111,13 @@ class TestIosInterfacesModule(TestIosModule):
                         "description": "This interface should be disabled",
                         "enabled": True,
                         "name": "GigabitEthernet1",
+                        "template": "ANSIBLE",
                     },
                     {
                         "description": "This interface should be enabled",
                         "enabled": False,
                         "name": "GigabitEthernet0/1",
+                        "template": "DISABLED",
                     },
                     {"mode": "layer3", "name": "GigabitEthernet6"},
                 ],
@@ -122,9 +127,11 @@ class TestIosInterfacesModule(TestIosModule):
         commands = [
             "interface GigabitEthernet0/1",
             "description This interface should be enabled",
+            "source template DISABLED",
             "shutdown",
             "interface GigabitEthernet1",
             "description This interface should be disabled",
+            "source template ANSIBLE",
             "interface GigabitEthernet6",
             "no switchport",
         ]
@@ -189,6 +196,7 @@ class TestIosInterfacesModule(TestIosModule):
              no shutdown
              ip address dhcp
              negotiation auto
+             source template ANSIBLE
             interface GigabitEthernet0/1
              description Ansible UT interface 2
              ip address dhcp
@@ -227,17 +235,21 @@ class TestIosInterfacesModule(TestIosModule):
                         "name": "GigabitEthernet6",
                         "description": "Ansible UT interface 6",
                         "mode": "layer2",
+                        "template": "ANSIBLE",
                     },
                 ],
                 "state": "replaced",
             },
         )
         commands = [
+            "interface GigabitEthernet1",
+            "no source template ANSIBLE",
             "interface GigabitEthernet0/1",
             "no description Ansible UT interface 2",
             "speed 1200",
             "mtu 1800",
             "interface GigabitEthernet6",
+            "source template ANSIBLE",
             "switchport",
         ]
         result = self.execute_module(changed=True)
@@ -328,6 +340,7 @@ class TestIosInterfacesModule(TestIosModule):
             interface GigabitEthernet6
              description Ansible UT interface 6
              no switchport
+             source template ANSIBLE_INTERFACE_6
             """,
         )
         set_module_args(
@@ -363,6 +376,7 @@ class TestIosInterfacesModule(TestIosModule):
             "shutdown",
             "interface GigabitEthernet6",
             "no description Ansible UT interface 6",
+            "no source template ANSIBLE_INTERFACE_6",
             "shutdown",
             "switchport",
             "interface GigabitEthernet1",
@@ -386,6 +400,7 @@ class TestIosInterfacesModule(TestIosModule):
              no shutdown
              ip address dhcp
              negotiation auto
+             source template ANSIBLE
             interface GigabitEthernet0/1
              description Ansible UT interface 2
              ip address dhcp
@@ -416,6 +431,7 @@ class TestIosInterfacesModule(TestIosModule):
         commands = [
             "interface GigabitEthernet1",
             "no description Ansible UT interface 1",
+            "no source template ANSIBLE",
             "shutdown",
         ]
         result = self.execute_module(changed=True)
@@ -564,6 +580,7 @@ class TestIosInterfacesModule(TestIosModule):
                     interface GigabitEthernet7
                      description Ansible UT interface 7
                      no switchport
+                     source template ANSIBLE
                     """,
                 ),
                 state="parsed",
@@ -603,6 +620,7 @@ class TestIosInterfacesModule(TestIosModule):
                 "mode": "layer3",
                 "description": "Ansible UT interface 7",
                 "enabled": True,
+                "template": "ANSIBLE",
             },
         ]
         self.assertEqual(parsed_list, result["parsed"])
@@ -643,6 +661,7 @@ class TestIosInterfacesModule(TestIosModule):
                         "description": "Ansible UT interface 5",
                         "duplex": "full",
                         "enabled": True,
+                        "template": "ANSIBLE",
                     },
                     {
                         "name": "twentyFiveGigE1",
@@ -720,6 +739,7 @@ class TestIosInterfacesModule(TestIosModule):
             "interface GigabitEthernet5",
             "description Ansible UT interface 5",
             "duplex full",
+            "source template ANSIBLE",
             "no shutdown",
             "interface TwentyFiveGigE1",
             "description Ansible UT TwentyFiveGigE",


### PR DESCRIPTION
##### SUMMARY
This does not support direct templating. Instead this is support for IOS's built in templating engine and static assignment of templates introduced in 15.2E. https://www.cisco.com/c/en/us/td/docs/ios-xml/ios/ibns/configuration/15-e/ibns-15-e-book/ibns-int-temp.html

This is related to a previous issue I raised #677 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
cisco.ios.interfaces

##### ADDITIONAL INFORMATION

Example Ansible Task

```
- name: Apply Employee Templates to Ports
  cisco.ios.ios_interfaces:
    config:
    - name: GigabitEthernet0/1
      template: EMPLOYEE_TEMPLATE
    - name: GigabitEthernet0/2
      template: EMPLOYEE_TEMPLATE
    - name: GigabitEthernet0/3
      template: EMPLOYEE_TEMPLATE
    state: replaced  
```

Example Result on Switch

```
# Before
interface GigabitEthernet0/1
!
interface GigabitEthernet0/2
!
interface GigabitEthernet0/3
!

# After
interface GigabitEthernet0/1
  source template EMPLOYEE_TEMPLATE
!
interface GigabitEthernet0/2
  source template EMPLOYEE_TEMPLATE
!
interface GigabitEthernet0/3
  source template EMPLOYEE_TEMPLATE
!
```
