### PR TITLE
Limit Python 3.6 as minimum in tests

### DIFF
--- a/changelogs/fragments/cap_python.yml
+++ b/changelogs/fragments/cap_python.yml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - Limit Python 3.6 as minimum in tests

--- a/tests/config.yml
+++ b/tests/config.yml
@@ -1,0 +1,2 @@
+modules:
+  python_requires: '>= 3.6'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Limit Python 3.6 as a minimum in tests
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

