### PR TITLE
SNMP user error fix

### DIFF
--- a/changelogs/fragments/snmp_user_bug.yml
+++ b/changelogs/fragments/snmp_user_bug.yml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - "Fixes error handling for snmp user when snmp agent is not enabled"
+  - "ios_snmp_server - Fixes error handling for snmp user when snmp agent is not enabled"

--- a/changelogs/fragments/snmp_user_bug.yml
+++ b/changelogs/fragments/snmp_user_bug.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "Fixes error handling for snmp user when snmp agent is not enabled"

--- a/plugins/module_utils/network/ios/facts/snmp_server/snmp_server.py
+++ b/plugins/module_utils/network/ios/facts/snmp_server/snmp_server.py
@@ -15,7 +15,7 @@ for a given resource, parsed, and the facts tree is populated
 based on the configuration.
 """
 
-from ansible.errors import AnsibleError
+
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import utils
 
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.argspec.snmp_server.snmp_server import (
@@ -52,7 +52,7 @@ class Snmp_serverFacts(object):
         except Exception as e:
             if "agent not enabled" in str(e):
                 return ""
-            raise AnsibleError("Unable to get snmp user data: %s" % str(e))
+            raise Exception("Unable to get snmp user data: %s" % str(e))
         return _get_snmpv3_user
 
     def sort_list_dicts(self, objs):

--- a/plugins/module_utils/network/ios/facts/snmp_server/snmp_server.py
+++ b/plugins/module_utils/network/ios/facts/snmp_server/snmp_server.py
@@ -15,6 +15,7 @@ for a given resource, parsed, and the facts tree is populated
 based on the configuration.
 """
 
+from ansible.errors import AnsibleError
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import utils
 
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.argspec.snmp_server.snmp_server import (
@@ -46,9 +47,12 @@ class Snmp_serverFacts(object):
 
         Note: The seperate method is needed because the snmpv3 user data is not returned within the snmp-server config
         """
-        _get_snmpv3_user = connection.get("show snmp user")
-        if "%" in _get_snmpv3_user:
-            _get_snmpv3_user = ""
+        try:
+            _get_snmpv3_user = connection.get("show snmp user")
+        except Exception as e:
+            if "agent not enabled" in str(e):
+                return ""
+            raise AnsibleError("Unable to get snmp user data: %s" % str(e))
         return _get_snmpv3_user
 
     def sort_list_dicts(self, objs):

--- a/plugins/module_utils/network/ios/facts/snmp_server/snmp_server.py
+++ b/plugins/module_utils/network/ios/facts/snmp_server/snmp_server.py
@@ -47,6 +47,8 @@ class Snmp_serverFacts(object):
         Note: The seperate method is needed because the snmpv3 user data is not returned within the snmp-server config
         """
         _get_snmpv3_user = connection.get("show snmp user")
+        if "%" in _get_snmpv3_user:
+            _get_snmpv3_user = ""
         return _get_snmpv3_user
 
     def sort_list_dicts(self, objs):

--- a/plugins/terminal/ios.py
+++ b/plugins/terminal/ios.py
@@ -56,6 +56,7 @@ class TerminalModule(TerminalBase):
         re.compile(rb"Command Rejected: ?[\s]+", re.I),
         re.compile(rb"% General session commands not allowed under the address family", re.I),
         re.compile(rb"% BGP: Error initializing topology", re.I),
+        re.compile(rb"%SNMP agent not enabled", re.I),
     ]
 
     terminal_config_prompt = re.compile(r"^.+\(config(-.*)?\)#$")

--- a/tests/integration/targets/ios_snmp_server/tests/cli/_populate_config.yaml
+++ b/tests/integration/targets/ios_snmp_server/tests/cli/_populate_config.yaml
@@ -20,12 +20,3 @@
             host: 192.0.2.12
             udp_port: 25
     state: merged
-- name: Print commands
-  cisco.ios.ios_command:
-    commands:
-      - show running-config | section ^snmp-server
-      - show snmp user
-  register: snmp_output
-- name: Display output
-  debug:
-    var: snmp_output.stdout_lines

--- a/tests/integration/targets/ios_snmp_server/tests/cli/_remove_config.yaml
+++ b/tests/integration/targets/ios_snmp_server/tests/cli/_remove_config.yaml
@@ -1,13 +1,4 @@
 ---
-- name: Print commands
-  cisco.ios.ios_command:
-    commands:
-      - show running-config | section ^snmp-server
-      - show snmp user
-  register: snmp_output
-- name: Display output
-  debug:
-    var: snmp_output.stdout_lines
 - name: Pre post task remove snmp-server configuration
   cisco.ios.ios_snmp_server:
     config:


### PR DESCRIPTION
##### SUMMARY
The command `show snmp user` gives stderror - `%SNMP agent not enabled` when the snmp agent is not enabled

This PR aims to fix the above issue but handling the error

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- `facts/snmp_server.py`
