### PR TITLE
Add `ansible_net_cpu_utilization` to `ios_facts` docs

### DIFF
--- a/changelogs/fragments/cpu_util.yml
+++ b/changelogs/fragments/cpu_util.yml
@@ -1,4 +1,7 @@
+---
 minor_changes:
   - ios_facts - Add CPU utilization. (https://github.com/ansible-collections/cisco.ios/issues/779)
 bugfixes:
   - ios_facts - Fix facts gathering when memory statistics head is not hexadecimal. (https://github.com/ansible-collections/cisco.ios/issues/776)
+doc_changes:
+  - ios_facts - Add ansible_net_cpu_utilization.

--- a/docs/cisco.ios.ios_facts_module.rst
+++ b/docs/cisco.ios.ios_facts_module.rst
@@ -228,21 +228,6 @@ Common return values are documented `here <https://docs.ansible.com/ansible/late
             <tr>
                 <td colspan="1">
                     <div class="ansibleOptionAnchor" id="return-"></div>
-                    <b>ansible_net_cpu_utilization</b>
-                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
-                    <div style="font-size: small">
-                      <span style="color: purple">integer</span>
-                    </div>
-                </td>
-                <td>when hardware is configured</td>
-                <td>
-                            <div>The current CPU utilization of the device</div>
-                    <br/>
-                </td>
-            </tr>
-            <tr>
-                <td colspan="1">
-                    <div class="ansibleOptionAnchor" id="return-"></div>
                     <b>ansible_net_filesystems</b>
                     <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
                     <div style="font-size: small">

--- a/docs/cisco.ios.ios_facts_module.rst
+++ b/docs/cisco.ios.ios_facts_module.rst
@@ -228,6 +228,21 @@ Common return values are documented `here <https://docs.ansible.com/ansible/late
             <tr>
                 <td colspan="1">
                     <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>ansible_net_cpu_utilization</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">integer</span>
+                    </div>
+                </td>
+                <td>when hardware is configured</td>
+                <td>
+                            <div>The current CPU utilization of the device</div>
+                    <br/>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
                     <b>ansible_net_filesystems</b>
                     <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
                     <div style="font-size: small">

--- a/docs/cisco.ios.ios_facts_module.rst
+++ b/docs/cisco.ios.ios_facts_module.rst
@@ -231,7 +231,7 @@ Common return values are documented `here <https://docs.ansible.com/ansible/late
                     <b>ansible_net_cpu_utilization</b>
                     <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
                     <div style="font-size: small">
-                      <span style="color: purple">integer</span>
+                      <span style="color: purple">dictionary</span>
                     </div>
                 </td>
                 <td>when hardware is configured</td>

--- a/plugins/modules/ios_facts.py
+++ b/plugins/modules/ios_facts.py
@@ -184,6 +184,10 @@ ansible_net_memtotal_mb:
   description: The total memory on the remote device in Mb
   returned: when hardware is configured
   type: int
+ansible_net_cpu_utilization:
+  description: The current CPU utilization of the device
+  returned: when hardware is configured
+  type: int
 
 # config
 ansible_net_config:

--- a/plugins/modules/ios_facts.py
+++ b/plugins/modules/ios_facts.py
@@ -187,7 +187,7 @@ ansible_net_memtotal_mb:
 ansible_net_cpu_utilization:
   description: The current CPU utilization of the device
   returned: when hardware is configured
-  type: int
+  type: dict
 
 # config
 ansible_net_config:


### PR DESCRIPTION
##### SUMMARY
This PR adds `ansible_net_cpu_utilization`, which was introduced in #816, to the docs of `ios_facts`.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
`ios_facts`

##### ADDITIONAL INFORMATION
None.