### PR TITLE
ios_service - Bug with private-config-encryption

### DIFF
--- a/changelogs/fragments/bug_ios_service-private_config_encryption.yml
+++ b/changelogs/fragments/bug_ios_service-private_config_encryption.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - ios_service - Put condition to add `private_config_encryption` in default services

--- a/plugins/module_utils/network/ios/config/service/service.py
+++ b/plugins/module_utils/network/ios/config/service/service.py
@@ -105,8 +105,8 @@ class Service(ResourceModule):
             "password_recovery": True,
         }
 
-        if 'private_config_encryption' in haved:
-            service_default['private_config_encryption'] = True
+        if "private_config_encryption" in haved:
+            service_default["private_config_encryption"] = True
 
         # if state is merged, merge want onto have and then compare
         if self.state == "merged":

--- a/plugins/module_utils/network/ios/config/service/service.py
+++ b/plugins/module_utils/network/ios/config/service/service.py
@@ -103,8 +103,10 @@ class Service(ResourceModule):
             "prompt": True,
             "slave_log": True,
             "password_recovery": True,
-            "private_config_encryption": True,
         }
+
+        if 'private_config_encryption' in haved:
+            service_default['private_config_encryption'] = True
 
         # if state is merged, merge want onto have and then compare
         if self.state == "merged":

--- a/tests/unit/modules/network/ios/test_ios_service.py
+++ b/tests/unit/modules/network/ios/test_ios_service.py
@@ -369,7 +369,6 @@ class TestIosServiceModule(TestIosModule):
 
         self.assertEqual(sorted(result["commands"]), sorted(replaced))
 
-
     ####################
 
     def test_ios_service_parsed(self):

--- a/tests/unit/modules/network/ios/test_ios_service.py
+++ b/tests/unit/modules/network/ios/test_ios_service.py
@@ -301,7 +301,6 @@ class TestIosServiceModule(TestIosModule):
         playbook = {
             "config": {
                 "call_home": True,
-                "private_config_encryption": True,
                 "timestamps": [
                     {
                         "msg": "debug",
@@ -327,6 +326,49 @@ class TestIosServiceModule(TestIosModule):
         self.maxDiff = None
 
         self.assertEqual(sorted(result["commands"]), sorted(replaced))
+
+    def test_ios_service_replaced_idempotent_old(self):
+        self.execute_show_command.return_value = dedent(
+            """\
+            service slave-log
+            service timestamps debug datetime msec
+            service timestamps log datetime msec
+            service prompt config
+            service counters max age 0
+            service dhcp
+            service call-home
+            service password-recovery
+            """,
+        )
+        playbook = {
+            "config": {
+                "call_home": True,
+                "timestamps": [
+                    {
+                        "msg": "debug",
+                        "timestamp": "datetime",
+                        "datetime_options": {
+                            "msec": True,
+                        },
+                    },
+                    {
+                        "msg": "log",
+                        "timestamp": "datetime",
+                        "datetime_options": {
+                            "msec": True,
+                        },
+                    },
+                ],
+            },
+        }
+        replaced = []
+        playbook["state"] = "replaced"
+        set_module_args(playbook)
+        result = self.execute_module(changed=False)
+        self.maxDiff = None
+
+        self.assertEqual(sorted(result["commands"]), sorted(replaced))
+
 
     ####################
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fix bug #910 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
Add a conditionnal where private_config_encryption is set to `True` for default value only if present in haved configution