### PR TITLE
Fixed Issues with setting filter_list , as_path_acl on bgp_address_fa…

### DIFF
--- a/changelogs/fragments/bgp_address_family_bug.yml
+++ b/changelogs/fragments/bgp_address_family_bug.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - bgp_address_family - fix deleted string with int concat issue in bgp_address_family.

--- a/plugins/module_utils/network/ios/rm_templates/bgp_address_family.py
+++ b/plugins/module_utils/network/ios/rm_templates/bgp_address_family.py
@@ -1145,7 +1145,7 @@ class Bgp_address_familyTemplate(NetworkTemplate):
                 re.VERBOSE,
             ),
             "setval": "neighbor {{ neighbor_address }} filter-list"
-            "{{ (' ' + filter_list.as_path_acl) if filter_list.as_path_acl is defined else '' }}"
+            "{{ (' ' + filter_list.as_path_acl|string) if filter_list.as_path_acl is defined else '' }}"
             "{{ (' in') if filter_list.in|d(False) else '' }}"
             "{{ (' out') if filter_list.out|d(False) else '' }}",
             "result": {


### PR DESCRIPTION
##### SUMMARY
Fixes issue  #913 where we Get an error when I try to set as_path_acl on a BGP neighbor using bgp_address_family module. Error is "module_stderr": "can only concatenate str (not "int") to str"

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
bgp_address_family


