### PR TITLE
Fix ospfv2 integration test issues

### DIFF
--- a/changelogs/fragments/fix_ospfv2_integration_test.yml
+++ b/changelogs/fragments/fix_ospfv2_integration_test.yml
@@ -1,3 +1,3 @@
 ---
-bugfixes:
+trivial:
   - ios_ospfv2 - fix initial_vrf_setup in integration tests which was not working due to missing parent attribute.

--- a/changelogs/fragments/fix_ospfv2_integration_test.yml
+++ b/changelogs/fragments/fix_ospfv2_integration_test.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - ios_ospfv2 - fix initial_vrf_setup in integration tests which was not working due to missing parent attribute.

--- a/tests/integration/targets/ios_ospfv2/tests/cli/_initial_vrf_setup.yaml
+++ b/tests/integration/targets/ios_ospfv2/tests/cli/_initial_vrf_setup.yaml
@@ -1,16 +1,9 @@
 ---
 - name: Create and setup VRF configuration
-  vars:
+  cisco.ios.ios_config:
     lines:
-      - ip vrf blue
       - rd 100:1
       - route-target export 100:1
       - route-target import 100:1
-      - exit
-      - ip vrf ospf_vrf
-      - rd 100:2
-      - route-target export 100:2
-      - route-target import 100:2
-      - exit
-  cisco.ios.ios_config:
-    config: "{{ lines }}"
+    parents:
+      - ip vrf blue


### PR DESCRIPTION
##### SUMMARY
Address the issue of encountering an unexpected module failure related to invalid input while attempting to run iOS OSPFv2 integration tests from the Controller with the EE container.

fixes: #928 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
