### PR TITLE
remote_as not mandatory for neighbors

### DIFF
--- a/changelogs/fragments/bgp_global_evpn_fix.yml
+++ b/changelogs/fragments/bgp_global_evpn_fix.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - ios_bgp_global - remote_as not mendatory for neighbors.

--- a/plugins/module_utils/network/ios/facts/bgp_global/bgp_global.py
+++ b/plugins/module_utils/network/ios/facts/bgp_global/bgp_global.py
@@ -55,10 +55,7 @@ class Bgp_globalFacts(object):
         objs = bgp_global_parser.parse()
         neighbor_list = objs.get("neighbors", {})
         if neighbor_list:
-            objs["neighbors"] = sorted(
-                list(neighbor_list.values()),
-                key=lambda k, pk="neighbor_address": k[pk],
-            )
+            objs["neighbors"] = list(neighbor_list.values())
 
         obj = utils.remove_empties(objs)
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
remote_as not mandatory for neighbors
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios_bgp_global

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Configuration reference from a l2 appliance.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
router bgp 65001
 template peer-policy LEAF-EVPN-PEER-POLICY
  send-community both
 exit-peer-policy
 !
 template peer-policy SPINE-EVPN-PEER-POLICY
  route-reflector-client
  send-community both
 exit-peer-policy
 !
 template peer-session EVPN-PEER-SESSION
  remote-as 65001
  update-source Loopback0
 exit-peer-session
 !
 bgp router-id 172.16.255.14
 bgp log-neighbor-changes
 no bgp default ipv4-unicast
 neighbor 172.16.255.3 remote-as 100
 neighbor 172.16.255.3 inherit peer-session EVPN-PEER-SESSION
 neighbor 172.16.255.4 remote-as 101
 neighbor 172.16.255.4 inherit peer-session EVPN-PEER-SESSION
 !
 address-family ipv4
 exit-address-family
 !
 address-family l2vpn evpn
  neighbor 172.16.255.3 activate
  neighbor 172.16.255.3 send-community extended
  neighbor 172.16.255.3 inherit peer-policy LEAF-EVPN-PEER-POLICY
  neighbor 172.16.255.4 activate
  neighbor 172.16.255.4 send-community extended
  neighbor 172.16.255.4 inherit peer-policy LEAF-EVPN-PEER-POLICY
 exit-address-family
 !
 address-family ipv4 vrf blue
  advertise l2vpn evpn
  redistribute static
  redistribute connected
 exit-address-family
 !
 address-family ipv4 vrf green
  advertise l2vpn evpn
  redistribute static
  redistribute connected
 exit-address-family

```
