### PR TITLE
Bugfixes for ios_acls after last commit regarding this module

### DIFF
--- a/changelogs/fragments/ios_acls.yml
+++ b/changelogs/fragments/ios_acls.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - ios_acls - After the commit 43658026568ea4d97b54b696ba99125dc680a64b, the ACL module has significatively changed and so, the parsing of standard ACL is not correct any more. Fixed throught the change of the rm_template for standatf ACE and change of the tests unit to follow this change

--- a/plugins/module_utils/network/ios/facts/acls/acls.py
+++ b/plugins/module_utils/network/ios/facts/acls/acls.py
@@ -129,7 +129,7 @@ class AclsFacts(object):
                 if temp.get("address"):
                     _temp_addr = temp.get("address", "")
                     ace[typ]["address"] = _temp_addr.split(" ")[0]
-                    ace[typ]["wildcard_bits"] = _temp_addr.split(" ")[1]
+                    ace[typ]["wildcard_bits"] = (_temp_addr.split(" ")[1:] or [None])[0]
                 if temp.get("ipv6_address"):
                     _temp_addr = temp.get("ipv6_address", "")
                     if len(_temp_addr.split(" ")) == 2:
@@ -141,21 +141,6 @@ class AclsFacts(object):
 
             def process_protocol_options(each):
                 for each_ace in each.get("aces"):
-                    if each.get("acl_type") == "standard":
-                        if len(each_ace.get("source", {})) == 1 and each_ace.get("source", {}).get(
-                            "address",
-                        ):
-                            each_ace["source"]["host"] = each_ace["source"].pop("address")
-                        if each_ace.get("source", {}).get("address"):
-                            addr = each_ace.get("source", {}).get("address")
-                            if addr[-1] == ",":
-                                each_ace["source"]["address"] = addr[:-1]
-                    else:  # for extended acl
-                        if each_ace.get("source", {}):
-                            factor_source_dest(each_ace, "source")
-                        if each_ace.get("destination", {}):
-                            factor_source_dest(each_ace, "destination")
-
                     if each_ace.get("icmp_igmp_tcp_protocol"):
                         each_ace["protocol_options"] = {
                             each_ace["protocol"]: {

--- a/plugins/module_utils/network/ios/rm_templates/acls.py
+++ b/plugins/module_utils/network/ios/rm_templates/acls.py
@@ -279,7 +279,8 @@ class AclsTemplate(NetworkTemplate):
                         (\s*(?P<any>any))?
                         (\s(?P<log>log))?
                     $""".format(
-                    ipv4addr, ipv4wild
+                    ipv4addr,
+                    ipv4wild,
                 ),
                 re.VERBOSE,
             ),
@@ -349,7 +350,9 @@ class AclsTemplate(NetworkTemplate):
                         (\sttl\slt\s(?P<ttl_lt>\d+))?
                         (\sttl\sneg\s(?P<ttl_neg>\d+))?
                     """.format(
-                    ipv4addr, ipv4wild, ipv6addr
+                    ipv4addr,
+                    ipv4wild,
+                    ipv6addr,
                 ),
                 re.VERBOSE,
             ),

--- a/plugins/module_utils/network/ios/rm_templates/acls.py
+++ b/plugins/module_utils/network/ios/rm_templates/acls.py
@@ -22,28 +22,28 @@ from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.r
 )
 
 
-ipv4seg_addr = r'(?:25[0-5]|(?:2[0-4]|1{0,1}[0-9]){0,1}[0-9])'
-ipv4addr = r'(?:(?:{0}\.){{3,3}}{0})'.format(ipv4seg_addr)
-ipv4seg_mask = r'(?:0|128|192|224|240|248|252|254|255)'
-ipv4mask = r'(?:{0}.0.0.0|255.{0}.0.0|255.255.{0}.0|255.255.255.{0})'.format(ipv4seg_mask)
-ipv4seg_wild = r'(?:0|1|3|7|15|31|63|127|255)'
-ipv4wild = r'(?:0.0.0.{0}|0.0.{0}.255|0.{0}.255.255|{0}.255.255.255)'.format(ipv4seg_wild)
-ipv6seg_addr = r'(?:(?:[0-9a-fA-F]){1,4})'
+ipv4seg_addr = r"(?:25[0-5]|(?:2[0-4]|1{0,1}[0-9]){0,1}[0-9])"
+ipv4addr = r"(?:(?:{0}\.){{3,3}}{0})".format(ipv4seg_addr)
+ipv4seg_mask = r"(?:0|128|192|224|240|248|252|254|255)"
+ipv4mask = r"(?:{0}.0.0.0|255.{0}.0.0|255.255.{0}.0|255.255.255.{0})".format(ipv4seg_mask)
+ipv4seg_wild = r"(?:0|1|3|7|15|31|63|127|255)"
+ipv4wild = r"(?:0.0.0.{0}|0.0.{0}.255|0.{0}.255.255|{0}.255.255.255)".format(ipv4seg_wild)
+ipv6seg_addr = r"(?:(?:[0-9a-fA-F]){1,4})"
 ipv6grp = (
-    r'(?:{0}:){{7,7}}{0}'.format(ipv6seg_addr),
-    r'(?:{0}:){{1,7}}:'.format(ipv6seg_addr),
-    r'(?:{0}:){{1,6}}:{0}'.format(ipv6seg_addr),
-    r'(?:{0}:){{1,5}}(?::{0}){{1,2}}'.format(ipv6seg_addr),
-    r'(?:{0}:){{1,4}}(?::{0}){{1,3}}'.format(ipv6seg_addr),
-    r'(?:{0}:){{1,3}}(?::{0}){{1,4}}'.format(ipv6seg_addr),
-    r'(?:{0}:){{1,2}}(?::{0}){{1,5}}'.format(ipv6seg_addr),
-    r'{0}:(?:(?::{0}){{1,6}})'.format(ipv6seg_addr),
-    r':(?:(?::{0}){{1,7}}|:)'.format(ipv6seg_addr),
-    r'fe80:(?::{0}){{0,4}}%[0-9a-zA-Z]{{1,}}'.format(ipv6seg_addr),
-    r'::(?:ffff(?::0{{1,4}}){{0,1}}:){{0,1}}[^\s:]{0}'.format(ipv4addr),
-    r'(?:{0}:){{1,6}}:[^\s:]{1}'.format(ipv6seg_addr, ipv4addr),
+    r"(?:{0}:){{7,7}}{0}".format(ipv6seg_addr),
+    r"(?:{0}:){{1,7}}:".format(ipv6seg_addr),
+    r"(?:{0}:){{1,6}}:{0}".format(ipv6seg_addr),
+    r"(?:{0}:){{1,5}}(?::{0}){{1,2}}".format(ipv6seg_addr),
+    r"(?:{0}:){{1,4}}(?::{0}){{1,3}}".format(ipv6seg_addr),
+    r"(?:{0}:){{1,3}}(?::{0}){{1,4}}".format(ipv6seg_addr),
+    r"(?:{0}:){{1,2}}(?::{0}){{1,5}}".format(ipv6seg_addr),
+    r"{0}:(?:(?::{0}){{1,6}})".format(ipv6seg_addr),
+    r":(?:(?::{0}){{1,7}}|:)".format(ipv6seg_addr),
+    r"fe80:(?::{0}){{0,4}}%[0-9a-zA-Z]{{1,}}".format(ipv6seg_addr),
+    r"::(?:ffff(?::0{{1,4}}){{0,1}}:){{0,1}}[^\s:]{0}".format(ipv4addr),
+    r"(?:{0}:){{1,6}}:[^\s:]{1}".format(ipv6seg_addr, ipv4addr),
 )
-ipv6addr = '|'.join(['(?:{})'.format(g) for g in ipv6grp[::-1]])
+ipv6addr = "|".join(["(?:{})".format(g) for g in ipv6grp[::-1]])
 
 
 def remarks_with_sequence(remarks_data):
@@ -278,7 +278,9 @@ class AclsTemplate(NetworkTemplate):
                         (\s(?P<wildcard>{1}))?
                         (\s*(?P<any>any))?
                         (\s(?P<log>log))?
-                    $""".format(ipv4addr, ipv4wild),
+                    $""".format(
+                    ipv4addr, ipv4wild
+                ),
                 re.VERBOSE,
             ),
             "compval": "aces",
@@ -346,7 +348,9 @@ class AclsTemplate(NetworkTemplate):
                         (\sttl\sgt\s(?P<ttl_gt>\d+))?
                         (\sttl\slt\s(?P<ttl_lt>\d+))?
                         (\sttl\sneg\s(?P<ttl_neg>\d+))?
-                    """.format(ipv4addr, ipv4wild, ipv6addr),
+                    """.format(
+                    ipv4addr, ipv4wild, ipv6addr
+                ),
                 re.VERBOSE,
             ),
             "setval": _tmplt_access_list_entries,

--- a/plugins/module_utils/network/ios/rm_templates/acls.py
+++ b/plugins/module_utils/network/ios/rm_templates/acls.py
@@ -43,7 +43,7 @@ ipv6grp = (
     r"::(?:ffff(?::0{{1,4}}){{0,1}}:){{0,1}}[^\s:]{0}".format(ipv4addr),
     r"(?:{0}:){{1,6}}:[^\s:]{1}".format(ipv6seg_addr, ipv4addr),
 )
-ipv6addr = "|".join(["(?:{})".format(g) for g in ipv6grp[::-1]])
+ipv6addr = "|".join(["(?:{0})".format(g) for g in ipv6grp[::-1]])
 
 
 def remarks_with_sequence(remarks_data):

--- a/tests/unit/modules/network/ios/test_ios_acls.py
+++ b/tests/unit/modules/network/ios/test_ios_acls.py
@@ -65,88 +65,93 @@ class TestIosAclsModule(TestIosModule):
             """,
         )
 
-        set_module_args({
-            "config": [
-                {
-                    "afi": "ipv4",
-                    "acls": [
-                        {
-                            "name": "test_pre",
-                            "acl_type": "extended",
-                            "aces": [
-                                {
-                                    "destination": {"any": True},
-                                    "grant": "permit",
-                                    "precedence": "immediate",
-                                    "protocol": "ip",
-                                    "sequence": 20,
-                                    "source": {"any": True},
-                                },
-                            ],
-                        },
-                        {
-                            "name": "std_acl",
-                            "acl_type": "standard",
-                            "aces": [
-                                {
-                                    "grant": "deny",
-                                    "source": {"address": "192.0.2.0", "wildcard_bits": "0.0.0.255"},
-                                },
-                            ],
-                        },
-                        {
-                            "name": "in_to_out",
-                            "acl_type": "extended",
-                            "aces": [
-                                {
-                                    "grant": "permit",
-                                    "protocol": "tcp",
-                                    "source": {"host": "10.1.1.2"},
-                                    "destination": {
-                                        "host": "172.16.1.1",
-                                        "port_protocol": {"eq": "telnet"}
+        set_module_args(
+            {
+                "config": [
+                    {
+                        "afi": "ipv4",
+                        "acls": [
+                            {
+                                "name": "test_pre",
+                                "acl_type": "extended",
+                                "aces": [
+                                    {
+                                        "destination": {"any": True},
+                                        "grant": "permit",
+                                        "precedence": "immediate",
+                                        "protocol": "ip",
+                                        "sequence": 20,
+                                        "source": {"any": True},
                                     },
-                                },
-                                {
-                                    "grant": "deny",
-                                    "log_input": {"user_cookie": "test_logInput"},
-                                    "protocol": "ip",
-                                    "source": {"any": True},
-                                    "destination": {"any": True},
-                                },
-                            ],
-                        },
-                        {
-                            "name": "test_acl_merge",
-                            "acl_type": "extended",
-                            "aces": [
-                                {
-                                    "grant": "permit",
-                                    "destination": {
-                                        "address": "192.0.2.0",
-                                        "wildcard_bits": "0.0.0.255",
-                                        "port_protocol": {"eq": "80"},
+                                ],
+                            },
+                            {
+                                "name": "std_acl",
+                                "acl_type": "standard",
+                                "aces": [
+                                    {
+                                        "grant": "deny",
+                                        "source": {
+                                            "address": "192.0.2.0",
+                                            "wildcard_bits": "0.0.0.255",
+                                        },
                                     },
-                                    "protocol": "tcp",
-                                    "sequence": 100,
-                                    "source": {"host": "192.0.2.1"},
-                                },
-                                {
-                                    "grant": "deny",
-                                    "protocol_options": {"tcp": {"ack": True}},
-                                    "sequence": 200,
-                                    "source": {"object_group": "test_network_og"},
-                                    "destination": {"object_group": "test_network_og"},
-                                    "dscp": "ef",
-                                    "ttl": {"eq": 10},
-                                },
-                            ],
-                        },
-                    ],
-                },
-            ],
-            "state": "merged",
-        })
+                                ],
+                            },
+                            {
+                                "name": "in_to_out",
+                                "acl_type": "extended",
+                                "aces": [
+                                    {
+                                        "grant": "permit",
+                                        "protocol": "tcp",
+                                        "source": {"host": "10.1.1.2"},
+                                        "destination": {
+                                            "host": "172.16.1.1",
+                                            "port_protocol": {"eq": "telnet"},
+                                        },
+                                    },
+                                    {
+                                        "grant": "deny",
+                                        "log_input": {"user_cookie": "test_logInput"},
+                                        "protocol": "ip",
+                                        "source": {"any": True},
+                                        "destination": {"any": True},
+                                    },
+                                ],
+                            },
+                            {
+                                "name": "test_acl_merge",
+                                "acl_type": "extended",
+                                "aces": [
+                                    {
+                                        "grant": "permit",
+                                        "destination": {
+                                            "address": "192.0.2.0",
+                                            "wildcard_bits": "0.0.0.255",
+                                            "port_protocol": {"eq": "80"},
+                                        },
+                                        "protocol": "tcp",
+                                        "sequence": 100,
+                                        "source": {"host": "192.0.2.1"},
+                                    },
+                                    {
+                                        "grant": "deny",
+                                        "protocol_options": {"tcp": {"ack": True}},
+                                        "sequence": 200,
+                                        "source": {"object_group": "test_network_og"},
+                                        "destination": {"object_group": "test_network_og"},
+                                        "dscp": "ef",
+                                        "ttl": {"eq": 10},
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+                "state": "merged",
+            }
+        )
         result = self.execute_module(changed=True)
         commands = [
             "ip access-list standard std_acl",
@@ -559,83 +564,85 @@ class TestIosAclsModule(TestIosModule):
             Standard IP access list test_acl
             """,
         )
-        set_module_args({
-            "config": [
-                {
-                    "afi": "ipv4",
-                    "acls": [
-                        {
-                            "name": "replace_acl",
-                            "acl_type": "extended",
-                            "aces": [
-                                {
-                                    "grant": "deny",
-                                    "protocol_options": {
-                                        "tcp": {"ack": True},
-                                    },
-                                    "source": {
-                                        "address": "198.51.100.0",
-                                        "wildcard_bits": "0.0.0.255",
-                                    },
-                                    "destination": {
-                                        "address": "198.51.101.0",
-                                        "wildcard_bits": "0.0.0.255",
-                                        "port_protocol": {
-                                            "eq": "telnet",
+        set_module_args(
+            {
+                "config": [
+                    {
+                        "afi": "ipv4",
+                        "acls": [
+                            {
+                                "name": "replace_acl",
+                                "acl_type": "extended",
+                                "aces": [
+                                    {
+                                        "grant": "deny",
+                                        "protocol_options": {
+                                            "tcp": {"ack": True},
+                                        },
+                                        "source": {
+                                            "address": "198.51.100.0",
+                                            "wildcard_bits": "0.0.0.255",
+                                        },
+                                        "destination": {
+                                            "address": "198.51.101.0",
+                                            "wildcard_bits": "0.0.0.255",
+                                            "port_protocol": {
+                                                "eq": "telnet",
+                                            },
+                                        },
+                                        "tos": {
+                                            "min_monetary_cost": True,
                                         },
                                     },
-                                    "tos": {
-                                        "min_monetary_cost": True,
+                                ],
+                            },
+                            {
+                                "name": "test_acl",
+                                "acl_type": "standard",
+                                "aces": [
+                                    {
+                                        "remarks": [
+                                            "Another remark here",
+                                        ],
                                     },
-                                },
-                            ],
-                        },
-                        {
-                            "name": "test_acl",
-                            "acl_type": "standard",
-                            "aces": [
-                                {
-                                    "remarks": [
-                                        "Another remark here",
-                                    ],
-                                },
-                            ],
-                        },
-                        {
-                            "name": "acl-mgmt-networks",
-                            "acl_type": "standard",
-                            "aces": [
-                                {
-                                    "sequence": "10",
-                                    "grant": "permit",
-                                    "source": {
-                                        "address": "10.0.0.0",
-                                        "wildcard_bits": "0.0.1.255",
+                                ],
+                            },
+                            {
+                                "name": "acl-mgmt-networks",
+                                "acl_type": "standard",
+                                "aces": [
+                                    {
+                                        "sequence": "10",
+                                        "grant": "permit",
+                                        "source": {
+                                            "address": "10.0.0.0",
+                                            "wildcard_bits": "0.0.1.255",
+                                        },
                                     },
-                                },
-                                {
-                                    "sequence": "20",
-                                    "grant": "permit",
-                                    "source": {
-                                        "address": "172.16.0.0",
-                                        "wildcard_bits": "0.0.1.255",
+                                    {
+                                        "sequence": "20",
+                                        "grant": "permit",
+                                        "source": {
+                                            "address": "172.16.0.0",
+                                            "wildcard_bits": "0.0.1.255",
+                                        },
                                     },
-                                },
-                                {
-                                    "sequence": "30",
-                                    "grant": "permit",
-                                    "source": {
-                                        "address": "192.168.0.0",
-                                        "wildcard_bits": "0.0.7.255",
+                                    {
+                                        "sequence": "30",
+                                        "grant": "permit",
+                                        "source": {
+                                            "address": "192.168.0.0",
+                                            "wildcard_bits": "0.0.7.255",
+                                        },
                                     },
-                                },
-                            ],
-                        },
-                    ],
-                },
-            ],
-            "state": "replaced",
-        })
+                                ],
+                            },
+                        ],
+                    },
+                ],
+                "state": "replaced",
+            }
+        )
         result = self.execute_module(changed=True)
         commands = [
             "ip access-list extended replace_acl",
@@ -669,142 +676,144 @@ class TestIosAclsModule(TestIosModule):
             """,
         )
         self.execute_show_command_name.return_value = dedent("")
-        set_module_args({
-            "config": [
-                {
-                    "afi": "ipv4",
-                    "acls": [
-                        {
-                            "name": "110",
-                            "acl_type": "extended",
-                            "aces": [
-                                {
-                                    "sequence": 10,
-                                    "grant": "permit",
-                                    "protocol": "tcp",
-                                    "source": {
-                                        "address": "198.51.100.0",
-                                        "wildcard_bits": "0.0.0.255",
+        set_module_args(
+            {
+                "config": [
+                    {
+                        "afi": "ipv4",
+                        "acls": [
+                            {
+                                "name": "110",
+                                "acl_type": "extended",
+                                "aces": [
+                                    {
+                                        "sequence": 10,
+                                        "grant": "permit",
+                                        "protocol": "tcp",
+                                        "source": {
+                                            "address": "198.51.100.0",
+                                            "wildcard_bits": "0.0.0.255",
+                                        },
+                                        "destination": {"any": True, "port_protocol": {"eq": "22"}},
+                                        "log": {"set": True, "user_cookie": "testLog"},
                                     },
-                                    "destination": {"any": True, "port_protocol": {"eq": "22"}},
-                                    "log": {"set": True, "user_cookie": "testLog"},
-                                },
-                                {
-                                    "sequence": 20,
-                                    "grant": "deny",
-                                    "protocol": "icmp",
-                                    "source": {
-                                        "address": "192.0.2.0",
-                                        "wildcard_bits": "0.0.0.255",
+                                    {
+                                        "sequence": 20,
+                                        "grant": "deny",
+                                        "protocol": "icmp",
+                                        "source": {
+                                            "address": "192.0.2.0",
+                                            "wildcard_bits": "0.0.0.255",
+                                        },
+                                        "destination": {
+                                            "address": "192.0.3.0",
+                                            "wildcard_bits": "0.0.0.255",
+                                        },
+                                        "dscp": "ef",
+                                        "ttl": {"eq": 10},
+                                        "protocol_options": {"icmp": {"echo": True}},
                                     },
-                                    "destination": {
-                                        "address": "192.0.3.0",
-                                        "wildcard_bits": "0.0.0.255",
+                                    {
+                                        "sequence": 30,
+                                        "grant": "deny",
+                                        "protocol": "icmp",
+                                        "source": {"object_group": "test_network_og"},
+                                        "destination": {"any": True},
+                                        "dscp": "ef",
+                                        "ttl": {"eq": 10},
                                     },
-                                    "dscp": "ef",
-                                    "ttl": {"eq": 10},
-                                    "protocol_options": {"icmp": {"echo": True}},
-                                },
-                                {
-                                    "sequence": 30,
-                                    "grant": "deny",
-                                    "protocol": "icmp",
-                                    "source": {"object_group": "test_network_og"},
-                                    "destination": {"any": True},
-                                    "dscp": "ef",
-                                    "ttl": {"eq": 10},
-                                },
-                            ],
-                        },
-                        {
-                            "name": "acl-mgmt-networks",
-                            "acl_type": "standard",
-                            "aces": [
-                                {
-                                    "grant": "permit",
-                                    "source": {
-                                        "address": "10.0.0.0",
-                                        "wildcard_bits": "0.0.1.255",
+                                ],
+                            },
+                            {
+                                "name": "acl-mgmt-networks",
+                                "acl_type": "standard",
+                                "aces": [
+                                    {
+                                        "grant": "permit",
+                                        "source": {
+                                            "address": "10.0.0.0",
+                                            "wildcard_bits": "0.0.1.255",
+                                        },
                                     },
-                                },
-                                {
-                                    "grant": "permit",
-                                    "source": {
-                                        "address": "172.16.0.0",
-                                        "wildcard_bits": "0.0.1.255",
+                                    {
+                                        "grant": "permit",
+                                        "source": {
+                                            "address": "172.16.0.0",
+                                            "wildcard_bits": "0.0.1.255",
+                                        },
                                     },
-                                },
-                                {
-                                    "grant": "permit",
-                                    "source": {
-                                        "address": "192.168.0.0",
-                                        "wildcard_bits": "0.0.7.255",
+                                    {
+                                        "grant": "permit",
+                                        "source": {
+                                            "address": "192.168.0.0",
+                                            "wildcard_bits": "0.0.7.255",
+                                        },
                                     },
-                                },
-                            ],
-                        },
-                        {"name": "test_acl", "acl_type": "standard"},
-                        {
-                            "aces": [
-                                {
-                                    "destination": {"any": True},
-                                    "grant": "permit",
-                                    "protocol_options": {"ip": True},
-                                    "sequence": 10,
-                                    "source": {"host": "10.153.14.21"},
-                                },
-                                {
-                                    "destination": {"any": True},
-                                    "grant": "permit",
-                                    "protocol_options": {"ip": True},
-                                    "sequence": 20,
-                                    "source": {"host": "10.153.14.22"},
-                                },
-                            ],
-                            "acl_type": "extended",
-                            "name": "test-idem",
-                        },
-                        {
-                            "name": "test_pre",
-                            "acl_type": "extended",
-                            "aces": [
-                                {
-                                    "sequence": 10,
-                                    "grant": "permit",
-                                    "protocol": "ip",
-                                    "source": {"any": True},
-                                    "destination": {"any": True},
-                                    "precedence": "internet",
-                                },
-                            ],
-                        },
-                    ],
-                },
-                {
-                    "afi": "ipv6",
-                    "acls": [
-                        {
-                            "name": "R1_TRAFFIC",
-                            "aces": [
-                                {
-                                    "sequence": 10,
-                                    "grant": "deny",
-                                    "protocol": "tcp",
-                                    "source": {"any": True, "port_protocol": {"eq": "www"}},
-                                    "destination": {
-                                        "any": True,
-                                        "port_protocol": {"eq": "telnet"},
+                                ],
+                            },
+                            {"name": "test_acl", "acl_type": "standard"},
+                            {
+                                "aces": [
+                                    {
+                                        "destination": {"any": True},
+                                        "grant": "permit",
+                                        "protocol_options": {"ip": True},
+                                        "sequence": 10,
+                                        "source": {"host": "10.153.14.21"},
                                     },
-                                    "dscp": "af11",
-                                    "protocol_options": {"tcp": {"ack": True}},
-                                },
-                            ],
-                        },
-                    ],
-                },
-            ],
-            "state": "replaced",
-        })
+                                    {
+                                        "destination": {"any": True},
+                                        "grant": "permit",
+                                        "protocol_options": {"ip": True},
+                                        "sequence": 20,
+                                        "source": {"host": "10.153.14.22"},
+                                    },
+                                ],
+                                "acl_type": "extended",
+                                "name": "test-idem",
+                            },
+                            {
+                                "name": "test_pre",
+                                "acl_type": "extended",
+                                "aces": [
+                                    {
+                                        "sequence": 10,
+                                        "grant": "permit",
+                                        "protocol": "ip",
+                                        "source": {"any": True},
+                                        "destination": {"any": True},
+                                        "precedence": "internet",
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                    {
+                        "afi": "ipv6",
+                        "acls": [
+                            {
+                                "name": "R1_TRAFFIC",
+                                "aces": [
+                                    {
+                                        "sequence": 10,
+                                        "grant": "deny",
+                                        "protocol": "tcp",
+                                        "source": {"any": True, "port_protocol": {"eq": "www"}},
+                                        "destination": {
+                                            "any": True,
+                                            "port_protocol": {"eq": "telnet"},
+                                        },
+                                        "dscp": "af11",
+                                        "protocol_options": {"tcp": {"ack": True}},
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+                "state": "replaced",
+            }
+        )
         result = self.execute_module(changed=False)
         self.assertEqual(sorted(result["commands"]), [])
 
@@ -881,84 +890,86 @@ class TestIosAclsModule(TestIosModule):
             Standard IP access list test_acl
             """,
         )
-        set_module_args({
-            "config": [
-                {
-                    "afi": "ipv4",
-                    "acls": [
-                        {
-                            "name": "110",
-                            "acl_type": "extended",
-                            "aces": [
-                                {
-                                    "sequence": "10",
-                                    "grant": "permit",
-                                    "protocol": "tcp",
-                                    "source": {
-                                        "address": "198.51.100.0",
-                                        "wildcard_bits": "0.0.0.255",
+        set_module_args(
+            {
+                "config": [
+                    {
+                        "afi": "ipv4",
+                        "acls": [
+                            {
+                                "name": "110",
+                                "acl_type": "extended",
+                                "aces": [
+                                    {
+                                        "sequence": "10",
+                                        "grant": "permit",
+                                        "protocol": "tcp",
+                                        "source": {
+                                            "address": "198.51.100.0",
+                                            "wildcard_bits": "0.0.0.255",
+                                        },
+                                        "destination": {"any": True, "port_protocol": {"eq": "22"}},
+                                        "log": {"set": True, "user_cookie": "testLog"},
                                     },
-                                    "destination": {"any": True, "port_protocol": {"eq": "22"}},
-                                    "log": {"set": True, "user_cookie": "testLog"},
-                                },
-                                {
-                                    "sequence": 20,
-                                    "grant": "deny",
-                                    "protocol": "icmp",
-                                    "source": {
-                                        "address": "192.0.2.0",
-                                        "wildcard_bits": "0.0.0.255",
+                                    {
+                                        "sequence": 20,
+                                        "grant": "deny",
+                                        "protocol": "icmp",
+                                        "source": {
+                                            "address": "192.0.2.0",
+                                            "wildcard_bits": "0.0.0.255",
+                                        },
+                                        "destination": {
+                                            "address": "192.0.3.0",
+                                            "wildcard_bits": "0.0.0.255",
+                                        },
+                                        "dscp": "ef",
+                                        "ttl": {"eq": 10},
+                                        "protocol_options": {"icmp": {"echo": True}},
                                     },
-                                    "destination": {
-                                        "address": "192.0.3.0",
-                                        "wildcard_bits": "0.0.0.255",
+                                    {
+                                        "sequence": 30,
+                                        "grant": "deny",
+                                        "protocol": "icmp",
+                                        "source": {"object_group": "test_network_og"},
+                                        "destination": {"any": True},
+                                        "dscp": "ef",
+                                        "ttl": {"eq": 10},
                                     },
-                                    "dscp": "ef",
-                                    "ttl": {"eq": 10},
-                                    "protocol_options": {"icmp": {"echo": True}},
-                                },
-                                {
-                                    "sequence": 30,
-                                    "grant": "deny",
-                                    "protocol": "icmp",
-                                    "source": {"object_group": "test_network_og"},
-                                    "destination": {"any": True},
-                                    "dscp": "ef",
-                                    "ttl": {"eq": 10},
-                                },
-                            ],
-                        },
-                        {
-                            "name": "test_acl",
-                            "acl_type": "standard"
-                        },
-                    ],
-                },
-                {
-                    "afi": "ipv6",
-                    "acls": [
-                        {
-                            "name": "R1_TRAFFIC",
-                            "aces": [
-                                {
-                                    "sequence": 10,
-                                    "grant": "deny",
-                                    "protocol": "tcp",
-                                    "source": {"any": True, "port_protocol": {"eq": "www"}},
-                                    "destination": {
-                                        "any": True,
-                                        "port_protocol": {"eq": "telnet"},
+                                ],
+                            },
+                            {
+                                "name": "test_acl",
+                                "acl_type": "standard",
+                            },
+                        ],
+                    },
+                    {
+                        "afi": "ipv6",
+                        "acls": [
+                            {
+                                "name": "R1_TRAFFIC",
+                                "aces": [
+                                    {
+                                        "sequence": 10,
+                                        "grant": "deny",
+                                        "protocol": "tcp",
+                                        "source": {"any": True, "port_protocol": {"eq": "www"}},
+                                        "destination": {
+                                            "any": True,
+                                            "port_protocol": {"eq": "telnet"},
+                                        },
+                                        "dscp": "af11",
+                                        "protocol_options": {"tcp": {"ack": True}},
                                     },
-                                    "dscp": "af11",
-                                    "protocol_options": {"tcp": {"ack": True}},
-                                },
-                            ],
-                        },
-                    ],
-                },
-            ],
-            "state": "overridden",
-        })
+                                ],
+                            },
+                        ],
+                    },
+                ],
+                "state": "overridden",
+            }
+        )
         result = self.execute_module(changed=False)
         command = []
         self.assertEqual(sorted(result["commands"]), sorted(command))
@@ -1165,15 +1176,21 @@ class TestIosAclsModule(TestIosModule):
                         "aces": [
                             {
                                 "grant": "permit",
-                                "source": {"address": "10.11.12.13"}
+                                "source": {"address": "10.11.12.13"},
                             },
                             {
                                 "grant": "permit",
-                                "source": {"address": "128.0.0.0", "wildcard_bits": "63.255.255.255"},
+                                "source": {
+                                    "address": "128.0.0.0",
+                                    "wildcard_bits": "63.255.255.255",
+                                },
                             },
                             {
                                 "grant": "permit",
-                                "source": {"address": "134.107.136.0", "wildcard_bits": "0.0.0.255"},
+                                "source": {
+                                    "address": "134.107.136.0",
+                                    "wildcard_bits": "0.0.0.255",
+                                },
                             },
                         ],
                     },
@@ -1402,25 +1419,27 @@ class TestIosAclsModule(TestIosModule):
             """,
         )
         self.execute_show_command_name.return_value = dedent("")
-        set_module_args({
-            "config": [
-                {
-                    "afi": "ipv4",
-                    "acls": [
-                        {
-                            "name": "2",
-                            "aces": [
-                                {
-                                    "grant": "permit",
-                                    "source": {"host": "192.0.2.1"},
-                                },
-                            ],
-                        },
-                    ],
-                }
-            ],
-            "state": "deleted",
-        })
+        set_module_args(
+            {
+                "config": [
+                    {
+                        "afi": "ipv4",
+                        "acls": [
+                            {
+                                "name": "2",
+                                "aces": [
+                                    {
+                                        "grant": "permit",
+                                        "source": {"host": "192.0.2.1"},
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+                "state": "deleted",
+            }
+        )
 
         result = self.execute_module(changed=True)
         commands = ["no ip access-list standard 2"]
@@ -1477,25 +1496,27 @@ class TestIosAclsModule(TestIosModule):
             """,
         )
         self.execute_show_command_name.return_value = dedent("")
-        set_module_args({
-            "config": [
-                {
-                    "afi": "ipv4",
-                    "acls": [
-                        {
-                            "name": "test_acl",
-                            "aces": [
-                                {
-                                    "grant": "permit",
-                                    "source": {"host": "192.0.2.1"},
-                                },
-                            ],
-                        }
-                    ],
-                },
-            ],
-            "state": "merged",
-        })
+        set_module_args(
+            {
+                "config": [
+                    {
+                        "afi": "ipv4",
+                        "acls": [
+                            {
+                                "name": "test_acl",
+                                "aces": [
+                                    {
+                                        "grant": "permit",
+                                        "source": {"host": "192.0.2.1"},
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+                "state": "merged",
+            }
+        )
 
         result = self.execute_module(failed=True)
         self.assertEqual(

--- a/tests/unit/modules/network/ios/test_ios_acls.py
+++ b/tests/unit/modules/network/ios/test_ios_acls.py
@@ -150,7 +150,7 @@ class TestIosAclsModule(TestIosModule):
                     },
                 ],
                 "state": "merged",
-            }
+            },
         )
         result = self.execute_module(changed=True)
         commands = [
@@ -641,7 +641,7 @@ class TestIosAclsModule(TestIosModule):
                     },
                 ],
                 "state": "replaced",
-            }
+            },
         )
         result = self.execute_module(changed=True)
         commands = [
@@ -812,7 +812,7 @@ class TestIosAclsModule(TestIosModule):
                     },
                 ],
                 "state": "replaced",
-            }
+            },
         )
         result = self.execute_module(changed=False)
         self.assertEqual(sorted(result["commands"]), [])
@@ -968,7 +968,7 @@ class TestIosAclsModule(TestIosModule):
                     },
                 ],
                 "state": "overridden",
-            }
+            },
         )
         result = self.execute_module(changed=False)
         command = []
@@ -1438,7 +1438,7 @@ class TestIosAclsModule(TestIosModule):
                     },
                 ],
                 "state": "deleted",
-            }
+            },
         )
 
         result = self.execute_module(changed=True)
@@ -1515,7 +1515,7 @@ class TestIosAclsModule(TestIosModule):
                     },
                 ],
                 "state": "merged",
-            }
+            },
         )
 
         result = self.execute_module(failed=True)


### PR DESCRIPTION
##### SUMMARY
After the commit 43658026568ea4d97b54b696ba99125dc680a64b, the way to restrieve the ACLs has changed and so, the regexp used to match the standard ACE doesn't working anymore:

on IOS-XE, the standard ACL output could be with or without the sequence number:

exemple1:
ip access-list standard acl-mgmt-networks
 10 permit 10.0.0.0 0.0.1.255
 20 permit 172.16.0.0 0.0.1.255
 30 permit 192.168.0.0 0.0.7.255

exemple2:
ip access-list standard acl-mgmt-networks
 permit 10.132.64.0 0.0.1.255
 permit 10.208.232.0 0.0.1.255
 permit 172.31.24.0 0.0.7.255

Fix #973 

##### ISSUE TYPE
- Bugfix Pull Request

