### PR TITLE
ios_acls - make sequence optional for rendering of standard acls.

### DIFF
--- a/changelogs/fragments/fix_acls_old.yml
+++ b/changelogs/fragments/fix_acls_old.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - ios_acls - make sequence optional for rendering of standard acls.

--- a/plugins/module_utils/network/ios/rm_templates/acls.py
+++ b/plugins/module_utils/network/ios/rm_templates/acls.py
@@ -73,7 +73,9 @@ def _tmplt_access_list_entries(aces):
                 command += " {protocol_number}".format(**aces["protocol_options"])
             else:
                 command += " {0}".format(list(aces["protocol_options"])[0])
-                proto_option = aces["protocol_options"].get(list(aces["protocol_options"])[0])
+                proto_option = aces["protocol_options"].get(
+                    list(aces["protocol_options"])[0]
+                )
         elif aces.get("protocol"):
             command += " {protocol}".format(**aces)
         if aces.get("source"):
@@ -182,9 +184,6 @@ class AclsTemplate(NetworkTemplate):
                     $""",
                 re.VERBOSE,
             ),
-            # "setval": "{{ sequence|string if sequence is defined else '' }}"
-            # "{{ (' ') if sequence is defined else '' }}"
-            # "remark {{ remarks }}",
             "setval": remarks_with_sequence,
             "result": {
                 "acls": {
@@ -237,7 +236,10 @@ class AclsTemplate(NetworkTemplate):
                     "{{ acl_name|d() }}": {
                         "name": "{{ acl_name }}",
                         "aces": [
-                            {"sequence": "{{ sequence }}", "remarks": ["{{ remarks }}"]},
+                            {
+                                "sequence": "{{ sequence }}",
+                                "remarks": ["{{ remarks }}"],
+                            },
                         ],
                     },
                 },
@@ -246,7 +248,7 @@ class AclsTemplate(NetworkTemplate):
         {
             "name": "aces_ipv4_standard",
             "getval": re.compile(
-                r"""(\s*(?P<sequence>\d+))
+                r"""(\s*(?P<sequence>\d+))?
                         (\s(?P<grant>deny|permit))
                         (\s+(?P<address>((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)))?
                         (\s(?P<wildcard>((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)))?

--- a/plugins/module_utils/network/ios/rm_templates/acls.py
+++ b/plugins/module_utils/network/ios/rm_templates/acls.py
@@ -74,7 +74,7 @@ def _tmplt_access_list_entries(aces):
             else:
                 command += " {0}".format(list(aces["protocol_options"])[0])
                 proto_option = aces["protocol_options"].get(
-                    list(aces["protocol_options"])[0]
+                    list(aces["protocol_options"])[0],
                 )
         elif aces.get("protocol"):
             command += " {protocol}".format(**aces)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The collection supports cisco ios xe 17.x 
The acls facts are processed on the basis of the `show running-config | section access-list` command
The command is updated replacing `show access-lists` command in order to incorporate the functionality of remarks, as native IOS XE supports it with the ios_acls module. 
In an older EOL'd version of ios 15.x, the command does not render any sequence number,  essential for the module to process.
If support for older iosxe versions are needed it is advised to use cisco.ios 5.1.0
```
host15v#show running-config | section access-list
ip access-list standard SNMP_sec
 permit 10.255.236.0 0.0.3.255
```
In a supported appliance version, ios xe 17.x
```
foo#show running-config | section access-list
ip access-list standard SNMP-sec
 10 permit 10.255.236.0 0.0.3.255
```

The sequence check in facts processing is relaxed, not extending support for EOL'd versions of IOS.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios_acls

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
