### PR TITLE
ios_facts test verify sub-interface index > 999

### DIFF
--- a/changelogs/fragments/ios_facts_tests.yml
+++ b/changelogs/fragments/ios_facts_tests.yml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - ios_facts - Add tests to verify sub-interface index greater than 999

--- a/tests/unit/modules/network/ios/fixtures/ios_facts_show_interfaces
+++ b/tests/unit/modules/network/ios/fixtures/ios_facts_show_interfaces
@@ -1,4 +1,4 @@
-GigabitEthernet0/0 is up, line protocol is up
+GigabitEthernet0/0/0.1012 is up, line protocol is up
   Hardware is iGbE, address is 5e00.0003.0000 (bia 5e00.0003.0000)
   Description: OOB Management
   Internet address is 10.8.38.66/24
@@ -24,6 +24,35 @@ GigabitEthernet0/0 is up, line protocol is up
      1304895 packets output, 119337031 bytes, 0 underruns
      0 output errors, 0 collisions, 3 interface resets
      1083697 unknown protocol drops
+     0 babbles, 0 late collision, 0 deferred
+     1 lost carrier, 0 no carrier, 0 pause output
+     0 output buffer failures, 0 output buffers swapped out
+GigabitEthernet0/0 is up, line protocol is up
+  Hardware is iGbE, address is 5e00.0008.0000 (bia 5e00.0008.0000)
+  Description: OOB Management
+  Internet address is 10.8.38.66/24
+  MTU 1500 bytes, BW 1000000 Kbit/sec, DLY 10 usec,
+     reliability 253/255, txload 1/255, rxload 1/255
+  Encapsulation ARPA, loopback not set
+  Keepalive set (10 sec)
+  Full Duplex, Auto Speed, link type is auto, media type is RJ45
+  output flow-control is unsupported, input flow-control is unsupported
+  ARP type: ARPA, ARP Timeout 04:00:00
+  Last input 00:00:00, output 00:00:00, output hang never
+  Last clearing of "show interface" counters never
+  Input queue: 0/75/0/0 (size/max/drops/flushes); Total output drops: 0
+  Queueing strategy: fifo
+  Output queue: 0/40 (size/max)
+  5 minute input rate 3000 bits/sec, 2 packets/sec
+  5 minute output rate 2000 bits/sec, 2 packets/sec
+     8463791 packets input, 1445150230 bytes, 0 no buffer
+     Received 0 broadcasts (0 IP multicasts)
+     0 runts, 0 giants, 0 throttles
+     0 input errors, 0 CRC, 0 frame, 0 overrun, 0 ignored
+     0 watchdog, 0 multicast, 0 pause input
+     3521571 packets output, 348781823 bytes, 0 underruns
+     0 output errors, 0 collisions, 1 interface resets
+     4150764 unknown protocol drops
      0 babbles, 0 late collision, 0 deferred
      1 lost carrier, 0 no carrier, 0 pause output
      0 output buffer failures, 0 output buffers swapped out

--- a/tests/unit/modules/network/ios/test_ios_facts.py
+++ b/tests/unit/modules/network/ios/test_ios_facts.py
@@ -95,7 +95,9 @@ class TestIosFactsModule(TestIosModule):
         set_module_args(dict(gather_subset="interfaces"))
         result = self.execute_module()
         self.assertEqual(
-            result["ansible_facts"]["ansible_net_interfaces"]["GigabitEthernet0/0/0.1012"]["macaddress"],
+            result["ansible_facts"]["ansible_net_interfaces"]["GigabitEthernet0/0/0.1012"][
+                "macaddress"
+            ],
             "5e00.0003.0000",
         )
         self.assertEqual(

--- a/tests/unit/modules/network/ios/test_ios_facts.py
+++ b/tests/unit/modules/network/ios/test_ios_facts.py
@@ -95,8 +95,12 @@ class TestIosFactsModule(TestIosModule):
         set_module_args(dict(gather_subset="interfaces"))
         result = self.execute_module()
         self.assertEqual(
-            result["ansible_facts"]["ansible_net_interfaces"]["GigabitEthernet0/0"]["macaddress"],
+            result["ansible_facts"]["ansible_net_interfaces"]["GigabitEthernet0/0/0.1012"]["macaddress"],
             "5e00.0003.0000",
+        )
+        self.assertEqual(
+            result["ansible_facts"]["ansible_net_interfaces"]["GigabitEthernet0/0"]["macaddress"],
+            "5e00.0008.0000",
         )
         self.assertEqual(
             result["ansible_facts"]["ansible_net_interfaces"]["GigabitEthernet1"]["macaddress"],


### PR DESCRIPTION
##### SUMMARY
This unit test aim to verify sub-interface index name greater than 999.
(For example: GigabitEthernet0/0/0.1012)

Addresses issue : #972 

##### ISSUE TYPE
- Test
