### PR TITLE
Fix #993 - user and group IPv6 ACLs

### DIFF
--- a/changelogs/fragments/snmp_server_ipv6_acl.yml
+++ b/changelogs/fragments/snmp_server_ipv6_acl.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - io_snmp_server - fix group IPv6 ACL command.
+  - io_snmp_server - fix user IPv6 ACL command.

--- a/changelogs/fragments/snmp_server_ipv6_acl.yml
+++ b/changelogs/fragments/snmp_server_ipv6_acl.yml
@@ -1,4 +1,4 @@
 ---
 bugfixes:
-  - io_snmp_server - fix group IPv6 ACL command.
-  - io_snmp_server - fix user IPv6 ACL command.
+  - ios_snmp_server - fix group IPv6 ACL command.
+  - ios_snmp_server - fix user IPv6 ACL command.

--- a/changelogs/fragments/snmp_server_ipv6_acl.yml
+++ b/changelogs/fragments/snmp_server_ipv6_acl.yml
@@ -1,4 +1,3 @@
 ---
 bugfixes:
-  - ios_snmp_server - fix group IPv6 ACL command.
-  - ios_snmp_server - fix user IPv6 ACL command.
+  - ios_snmp_server - fix group and user IPv6 ACL commands.

--- a/plugins/module_utils/network/ios/rm_templates/snmp_server.py
+++ b/plugins/module_utils/network/ios/rm_templates/snmp_server.py
@@ -283,8 +283,7 @@ class Snmp_serverTemplate(NetworkTemplate):
                 (\sread\s(?P<read>\S+))?
                 (\swrite\s(?P<write>\S+))?
                 (\snotify\s(?P<notify>\S+))?
-                (\saccess\s(?P<acl_v4>\S+))?
-                (\saccess\sipv6\s(?P<acl_v6>\S+))?
+                (\saccess(\sipv6\s(?P<acl_v6>\S+))?(\s(?P<acl_v4>\S+|\d+))?)?
                 """, re.VERBOSE,
             ),
             "setval": "snmp-server group "
@@ -296,8 +295,9 @@ class Snmp_serverTemplate(NetworkTemplate):
                       "{{ (' read ' + read) if read is defined else '' }}"
                       "{{ (' write ' + write) if write is defined else '' }}"
                       "{{ (' notify ' + notify) if notify is defined else '' }}"
-                      "{{ (' access ' + acl_v4) if acl_v4 is defined else '' }}"
-                      "{{ (' access ipv6 ' + acl_v6) if acl_v6 is defined else '' }}",
+                      "{{ (' access') if acl_v6 is defined or acl_v4 is defined else '' }}"
+                      "{{ (' ipv6 ' + acl_v6) if acl_v6 is defined else '' }}"
+                      "{{ (' ' + acl_v4|string) if acl_v4 is defined else '' }}",
             "result": {
                 "groups": [
                     {
@@ -398,8 +398,7 @@ class Snmp_serverTemplate(NetworkTemplate):
                 (\sudp-port\s(?P<udp_port>\d+))?
                 (\s(?P<version>v1|v3|v2c))?
                 (\s(?P<version_option>encrypted))?
-                (\saccess\sipv6\s(?P<acl_v6>\S+))?
-                (\saccess\s(?P<acl_v4>\S+|\d+))?
+                (\saccess(\sipv6\s(?P<acl_v6>\S+))?(\s(?P<acl_v4>\S+|\d+))?)?
                 (\svrf\s(?P<vrf>\S+))?
                 """, re.VERBOSE,
             ),

--- a/plugins/module_utils/network/ios/rm_templates/snmp_server.py
+++ b/plugins/module_utils/network/ios/rm_templates/snmp_server.py
@@ -283,7 +283,8 @@ class Snmp_serverTemplate(NetworkTemplate):
                 (\sread\s(?P<read>\S+))?
                 (\swrite\s(?P<write>\S+))?
                 (\snotify\s(?P<notify>\S+))?
-                (\saccess(\sipv6\s(?P<acl_v6>\S+))?(\s(?P<acl_v4>\S+|\d+))?)?
+                (\saccess(\sipv6\s(?P<acl_v6>\S+))?
+                (\s(?P<acl_v4>\S+|\d+))?)?
                 """, re.VERBOSE,
             ),
             "setval": "snmp-server group "
@@ -398,7 +399,8 @@ class Snmp_serverTemplate(NetworkTemplate):
                 (\sudp-port\s(?P<udp_port>\d+))?
                 (\s(?P<version>v1|v3|v2c))?
                 (\s(?P<version_option>encrypted))?
-                (\saccess(\sipv6\s(?P<acl_v6>\S+))?(\s(?P<acl_v4>\S+|\d+))?)?
+                (\saccess(\sipv6\s(?P<acl_v6>\S+))?
+                (\s(?P<acl_v4>\S+|\d+))?)?
                 (\svrf\s(?P<vrf>\S+))?
                 """, re.VERBOSE,
             ),

--- a/plugins/module_utils/network/ios/rm_templates/snmp_server.py
+++ b/plugins/module_utils/network/ios/rm_templates/snmp_server.py
@@ -283,8 +283,7 @@ class Snmp_serverTemplate(NetworkTemplate):
                 (\sread\s(?P<read>\S+))?
                 (\swrite\s(?P<write>\S+))?
                 (\snotify\s(?P<notify>\S+))?
-                (\saccess(\sipv6\s(?P<acl_v6>\S+))?
-                (\s(?P<acl_v4>\S+|\d+))?)?
+                (\saccess(\sipv6\s(?P<acl_v6>\S+))?(\s(?P<acl_v4>\S+|\d+))?)?
                 """, re.VERBOSE,
             ),
             "setval": "snmp-server group "
@@ -399,8 +398,7 @@ class Snmp_serverTemplate(NetworkTemplate):
                 (\sudp-port\s(?P<udp_port>\d+))?
                 (\s(?P<version>v1|v3|v2c))?
                 (\s(?P<version_option>encrypted))?
-                (\saccess(\sipv6\s(?P<acl_v6>\S+))?
-                (\s(?P<acl_v4>\S+|\d+))?)?
+                (\saccess(\sipv6\s(?P<acl_v6>\S+))?(\s(?P<acl_v4>\S+|\d+))?)?
                 (\svrf\s(?P<vrf>\S+))?
                 """, re.VERBOSE,
             ),

--- a/tests/unit/modules/network/ios/test_ios_snmp_server.py
+++ b/tests/unit/modules/network/ios/test_ios_snmp_server.py
@@ -54,11 +54,13 @@ class TestIosSnmpServerModule(TestIosModule):
             snmp-server engineID remote 172.16.0.2 udp-port 23 AB0C5342FAAB
             snmp-server engineID remote 172.16.0.1 udp-port 22 AB0C5342FAAA
             snmp-server user newuser newfamily v1 access 24
-            snmp-server user paul familypaul v3 access ipv6 ipv6acl
+            snmp-server user paul familypaul v3 access ipv6 ipv6acl ipv4acl
             snmp-server user replaceUser replaceUser v3
             snmp-server group group0 v3 auth
-            snmp-server group group1 v1 notify me access 2
+            snmp-server group group1 v1 notify me access ipv6 ipv6acl 2
             snmp-server group group2 v3 priv
+            snmp-server group group3 v1 access ipv6 ipv6acl
+            snmp-server group group4 v1 access 2
             snmp-server group replaceUser v3 noauth
             snmp-server community commu1 view view1 RO ipv6 te
             snmp-server community commu2 RO 1322
@@ -172,9 +174,11 @@ class TestIosSnmpServerModule(TestIosModule):
                 "file_transfer": {"access_group": "testAcl", "protocol": ["ftp", "rcp"]},
                 "groups": [
                     {"group": "group0", "version": "v3", "version_option": "auth"},
-                    {"acl_v4": "2", "group": "group1", "notify": "me", "version": "v1"},
+                    {"acl_v4": "2", "acl_v6": "ipv6acl", "group": "group1", "notify": "me", "version": "v1"},
                     {"group": "group2", "version": "v3", "version_option": "priv"},
                     {"group": "replaceUser", "version": "v3", "version_option": "noauth"},
+                    {"acl_v6": "ipv6acl", "group": "group3", "version": "v1"},
+                    {"acl_v4": "2", "group": "group4", "version": "v1"},
                 ],
                 "hosts": [
                     {
@@ -349,6 +353,7 @@ class TestIosSnmpServerModule(TestIosModule):
                 "users": [
                     {"acl_v4": "24", "group": "newfamily", "username": "newuser", "version": "v1"},
                     {
+                        "acl_v4": "ipv4acl",
                         "acl_v6": "ipv6acl",
                         "group": "familypaul",
                         "username": "paul",
@@ -435,9 +440,11 @@ class TestIosSnmpServerModule(TestIosModule):
                 "file_transfer": {"access_group": "testAcl", "protocol": ["ftp", "rcp"]},
                 "groups": [
                     {"group": "group0", "version": "v3", "version_option": "auth"},
-                    {"acl_v4": "2", "group": "group1", "notify": "me", "version": "v1"},
+                    {"acl_v4": "2", "acl_v6": "ipv6acl", "group": "group1", "notify": "me", "version": "v1"},
                     {"group": "group2", "version": "v3", "version_option": "priv"},
                     {"group": "replaceUser", "version": "v3", "version_option": "noauth"},
+                    {"acl_v6": "ipv6acl", "group": "group3", "version": "v1"},
+                    {"acl_v4": "2", "group": "group4", "version": "v1"},
                 ],
                 "hosts": [
                     {
@@ -692,8 +699,10 @@ class TestIosSnmpServerModule(TestIosModule):
             "snmp-server host 172.16.2.99 check slb",
             "snmp-server host 172.16.2.99 checktrap isis",
             "snmp-server group group0 v3 auth",
-            "snmp-server group group1 v1 notify me access 2",
+            "snmp-server group group1 v1 notify me access ipv6 ipv6acl 2",
             "snmp-server group group2 v3 priv",
+            "snmp-server group group3 v1 access ipv6 ipv6acl",
+            "snmp-server group group4 v1 access 2",
             "snmp-server group replaceUser v3 noauth",
             "snmp-server engineID remote 172.16.0.1 udp-port 22 vrf mgmt AB0C5342FAAA",
             "snmp-server community commu1 view view1 ro ipv6 te",
@@ -723,8 +732,10 @@ class TestIosSnmpServerModule(TestIosModule):
             snmp-server user replaceUser replaceUser v3
             snmp-server user flow mfamily v3 access 27
             snmp-server group group0 v3 auth
-            snmp-server group group1 v1 notify me access 2
+            snmp-server group group1 v1 notify me access ipv6 ipv6acl 2
             snmp-server group group2 v3 priv
+            snmp-server group group3 v1 access ipv6 ipv6acl
+            snmp-server group group4 v1 access 2
             snmp-server group replaceUser v3 noauth
             snmp-server community commu1 view view1 RO ipv6 te
             snmp-server community commu2 RO 1322
@@ -985,8 +996,10 @@ class TestIosSnmpServerModule(TestIosModule):
             "no snmp-server host 172.16.2.99 check slb",
             "no snmp-server host 172.16.2.99 checktrap isis",
             "no snmp-server group group0 v3 auth",
-            "no snmp-server group group1 v1 notify me access 2",
+            "no snmp-server group group1 v1 notify me access ipv6 ipv6acl 2",
             "no snmp-server group group2 v3 priv",
+            "no snmp-server group group3 v1 access ipv6 ipv6acl",
+            "no snmp-server group group4 v1 access 2",
             "no snmp-server group replaceUser v3 noauth",
             "no snmp-server engineID local AB0C5342FA0A",
             "no snmp-server engineID remote 172.16.0.1 udp-port 22 AB0C5342FAAA",
@@ -1103,7 +1116,7 @@ class TestIosSnmpServerModule(TestIosModule):
                 "file_transfer": {"access_group": "testAcl", "protocol": ["ftp", "rcp"]},
                 "groups": [
                     {"group": "group0", "version": "v3", "version_option": "auth"},
-                    {"acl_v4": "2", "group": "group1", "notify": "me", "version": "v1"},
+                    {"acl_v4": "2", "acl_v6": "ipv6acl", "group": "group1", "notify": "me", "version": "v1"},
                     {"group": "group2", "version": "v3", "version_option": "priv"},
                     {"group": "replaceUser", "version": "v3", "version_option": "noauth"},
                 ],
@@ -1318,7 +1331,7 @@ class TestIosSnmpServerModule(TestIosModule):
             "snmp-server host 172.16.2.1 version 2c trapsac tty",
             "snmp-server host 172.16.2.99 checktrap isis",
             "snmp-server group group0 v3 auth",
-            "snmp-server group group1 v1 notify me access 2",
+            "snmp-server group group1 v1 notify me access ipv6 ipv6acl 2",
             "snmp-server engineID local AB0C5342FA0A",
             "snmp-server engineID remote 172.16.0.1 udp-port 22 AB0C5342FAAA",
             "snmp-server community commu1 view view1 ro ipv6 te",

--- a/tests/unit/modules/network/ios/test_ios_snmp_server.py
+++ b/tests/unit/modules/network/ios/test_ios_snmp_server.py
@@ -174,7 +174,13 @@ class TestIosSnmpServerModule(TestIosModule):
                 "file_transfer": {"access_group": "testAcl", "protocol": ["ftp", "rcp"]},
                 "groups": [
                     {"group": "group0", "version": "v3", "version_option": "auth"},
-                    {"acl_v4": "2", "acl_v6": "ipv6acl", "group": "group1", "notify": "me", "version": "v1"},
+                    {
+                        "acl_v4": "2",
+                        "acl_v6": "ipv6acl",
+                        "group": "group1",
+                        "notify": "me",
+                        "version": "v1",
+                    },
                     {"group": "group2", "version": "v3", "version_option": "priv"},
                     {"group": "replaceUser", "version": "v3", "version_option": "noauth"},
                     {"acl_v6": "ipv6acl", "group": "group3", "version": "v1"},
@@ -440,7 +446,13 @@ class TestIosSnmpServerModule(TestIosModule):
                 "file_transfer": {"access_group": "testAcl", "protocol": ["ftp", "rcp"]},
                 "groups": [
                     {"group": "group0", "version": "v3", "version_option": "auth"},
-                    {"acl_v4": "2", "acl_v6": "ipv6acl", "group": "group1", "notify": "me", "version": "v1"},
+                    {
+                        "acl_v4": "2",
+                        "acl_v6": "ipv6acl",
+                        "group": "group1",
+                        "notify": "me",
+                        "version": "v1",
+                    },
                     {"group": "group2", "version": "v3", "version_option": "priv"},
                     {"group": "replaceUser", "version": "v3", "version_option": "noauth"},
                     {"acl_v6": "ipv6acl", "group": "group3", "version": "v1"},
@@ -1116,7 +1128,13 @@ class TestIosSnmpServerModule(TestIosModule):
                 "file_transfer": {"access_group": "testAcl", "protocol": ["ftp", "rcp"]},
                 "groups": [
                     {"group": "group0", "version": "v3", "version_option": "auth"},
-                    {"acl_v4": "2", "acl_v6": "ipv6acl", "group": "group1", "notify": "me", "version": "v1"},
+                    {
+                        "acl_v4": "2",
+                        "acl_v6": "ipv6acl",
+                        "group": "group1",
+                        "notify": "me",
+                        "version": "v1",
+                    },
                     {"group": "group2", "version": "v3", "version_option": "priv"},
                     {"group": "replaceUser", "version": "v3", "version_option": "noauth"},
                 ],


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #993 

The `group` and `user` IPv6 `access` entries are incorrectly generated and/or parsed, like:
```
snmp-server group read-only-group v3 priv read read-all-view access snmp-ipv4-acl access ipv6 snmp-ipv6-acl
```
->
```
snmp-server group read-only-group v3 priv read read-all-view access ipv6 snmp-ipv6-acl snmp-ipv4-acl
```

I added test cases for `group` and `user` commands.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios_snmp_server
