### PR TITLE
[ios_l3_interfaces] Remove strict ipv6 validation

### DIFF
--- a/changelogs/fragments/ios_l3_ipv6.yml
+++ b/changelogs/fragments/ios_l3_ipv6.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - ios_l3_interfaces - remove validation from ipv6 address parameter.

--- a/plugins/module_utils/network/ios/config/l3_interfaces/l3_interfaces.py
+++ b/plugins/module_utils/network/ios/config/l3_interfaces/l3_interfaces.py
@@ -23,13 +23,14 @@ from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.u
     dict_merge,
 )
 
-from ansible_collections.cisco.ios.plugins.module_utils.network.ios.facts.facts import Facts
+from ansible_collections.cisco.ios.plugins.module_utils.network.ios.facts.facts import (
+    Facts,
+)
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.rm_templates.l3_interfaces import (
     L3_interfacesTemplate,
 )
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.utils.utils import (
     normalize_interface,
-    validate_ipv6,
     validate_n_expand_ipv4,
 )
 
@@ -153,7 +154,11 @@ class L3_interfaces(ResourceModule):
                     # hacl is set as primary, if wacls has no other primary entry we must keep
                     # this entry as primary (so we'll compare entry to hacl and not
                     # generate commands)
-                    if list(filter(lambda w: w.get("secondary", False) is False, wacls.values())):
+                    if list(
+                        filter(
+                            lambda w: w.get("secondary", False) is False, wacls.values()
+                        )
+                    ):
                         # another primary is in wacls
                         hacl = {}
                 self.validate_ips(afi, want=entry, have=hacl)
@@ -177,20 +182,22 @@ class L3_interfaces(ResourceModule):
 
     def validate_ips(self, afi, want=None, have=None):
         if afi == "ipv4" and want:
-            v4_addr = validate_n_expand_ipv4(self._module, want) if want.get("address") else {}
+            v4_addr = (
+                validate_n_expand_ipv4(self._module, want)
+                if want.get("address")
+                else {}
+            )
             if v4_addr:
                 want["address"] = v4_addr
-        elif afi == "ipv6" and want:
-            if want.get("address"):
-                validate_ipv6(want["address"], self._module)
 
         if afi == "ipv4" and have:
-            v4_addr_h = validate_n_expand_ipv4(self._module, have) if have.get("address") else {}
+            v4_addr_h = (
+                validate_n_expand_ipv4(self._module, have)
+                if have.get("address")
+                else {}
+            )
             if v4_addr_h:
                 have["address"] = v4_addr_h
-        elif afi == "ipv6" and have:
-            if have.get("address"):
-                validate_ipv6(have["address"], self._module)
 
     def list_to_dict(self, param):
         if param:

--- a/plugins/module_utils/network/ios/config/l3_interfaces/l3_interfaces.py
+++ b/plugins/module_utils/network/ios/config/l3_interfaces/l3_interfaces.py
@@ -23,9 +23,7 @@ from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.u
     dict_merge,
 )
 
-from ansible_collections.cisco.ios.plugins.module_utils.network.ios.facts.facts import (
-    Facts,
-)
+from ansible_collections.cisco.ios.plugins.module_utils.network.ios.facts.facts import Facts
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.rm_templates.l3_interfaces import (
     L3_interfacesTemplate,
 )
@@ -156,8 +154,9 @@ class L3_interfaces(ResourceModule):
                     # generate commands)
                     if list(
                         filter(
-                            lambda w: w.get("secondary", False) is False, wacls.values()
-                        )
+                            lambda w: w.get("secondary", False) is False,
+                            wacls.values(),
+                        ),
                     ):
                         # another primary is in wacls
                         hacl = {}
@@ -182,20 +181,12 @@ class L3_interfaces(ResourceModule):
 
     def validate_ips(self, afi, want=None, have=None):
         if afi == "ipv4" and want:
-            v4_addr = (
-                validate_n_expand_ipv4(self._module, want)
-                if want.get("address")
-                else {}
-            )
+            v4_addr = validate_n_expand_ipv4(self._module, want) if want.get("address") else {}
             if v4_addr:
                 want["address"] = v4_addr
 
         if afi == "ipv4" and have:
-            v4_addr_h = (
-                validate_n_expand_ipv4(self._module, have)
-                if have.get("address")
-                else {}
-            )
+            v4_addr_h = validate_n_expand_ipv4(self._module, have) if have.get("address") else {}
             if v4_addr_h:
                 have["address"] = v4_addr_h
 

--- a/plugins/module_utils/network/ios/utils/utils.py
+++ b/plugins/module_utils/network/ios/utils/utils.py
@@ -85,7 +85,10 @@ def new_dict_to_set(input_dict, temp_list, test_set, count=0):
                 if v is not None:
                     test_dict.update({k: v})
                 try:
-                    if tuple(iteritems(test_dict)) not in test_set and count == input_dict_len:
+                    if (
+                        tuple(iteritems(test_dict)) not in test_set
+                        and count == input_dict_len
+                    ):
                         test_set.add(tuple(iteritems(test_dict)))
                         count = 0
                 except TypeError:
@@ -219,29 +222,17 @@ def validate_ipv4(value, module):
         address = value.split("/")
         if len(address) != 2:
             module.fail_json(
-                msg="address format is <ipv4 address>/<mask>, got invalid format {0}".format(value),
+                msg="address format is <ipv4 address>/<mask>, got invalid format {0}".format(
+                    value
+                ),
             )
 
         if not is_masklen(address[1]):
             module.fail_json(
-                msg="invalid value for mask: {0}, mask should be in range 0-32".format(address[1]),
+                msg="invalid value for mask: {0}, mask should be in range 0-32".format(
+                    address[1]
+                ),
             )
-
-
-def validate_ipv6(value, module):
-    if value:
-        address = value.split("/")
-        if len(address) != 2:
-            module.fail_json(
-                msg="address format is <ipv6 address>/<mask>, got invalid format {0}".format(value),
-            )
-        else:
-            if not 0 <= int(address[1]) <= 128:
-                module.fail_json(
-                    msg="invalid value for mask: {0}, mask should be in range 0-128".format(
-                        address[1],
-                    ),
-                )
 
 
 def validate_n_expand_ipv4(module, want):

--- a/plugins/module_utils/network/ios/utils/utils.py
+++ b/plugins/module_utils/network/ios/utils/utils.py
@@ -85,10 +85,7 @@ def new_dict_to_set(input_dict, temp_list, test_set, count=0):
                 if v is not None:
                     test_dict.update({k: v})
                 try:
-                    if (
-                        tuple(iteritems(test_dict)) not in test_set
-                        and count == input_dict_len
-                    ):
+                    if tuple(iteritems(test_dict)) not in test_set and count == input_dict_len:
                         test_set.add(tuple(iteritems(test_dict)))
                         count = 0
                 except TypeError:
@@ -223,14 +220,14 @@ def validate_ipv4(value, module):
         if len(address) != 2:
             module.fail_json(
                 msg="address format is <ipv4 address>/<mask>, got invalid format {0}".format(
-                    value
+                    value,
                 ),
             )
 
         if not is_masklen(address[1]):
             module.fail_json(
                 msg="invalid value for mask: {0}, mask should be in range 0-32".format(
-                    address[1]
+                    address[1],
                 ),
             )
 

--- a/tests/unit/modules/network/ios/test_ios_l3_interfaces.py
+++ b/tests/unit/modules/network/ios/test_ios_l3_interfaces.py
@@ -27,9 +27,7 @@ class TestIosL3InterfacesModule(TestIosModule):
             "ansible_collections.ansible.netcommon.plugins.module_utils.network.common.rm_base.resource_module_base."
             "get_resource_connection",
         )
-        self.get_resource_connection_facts = (
-            self.mock_get_resource_connection_facts.start()
-        )
+        self.get_resource_connection_facts = self.mock_get_resource_connection_facts.start()
 
         self.mock_execute_show_command = patch(
             "ansible_collections.cisco.ios.plugins.module_utils.network.ios.facts.l3_interfaces.l3_interfaces."
@@ -74,7 +72,7 @@ class TestIosL3InterfacesModule(TestIosModule):
                             dict(
                                 address="fe80:0:3a2:84::3",
                                 link_local=True,
-                            )
+                            ),
                         ],
                     ),
                 ],
@@ -113,7 +111,8 @@ class TestIosL3InterfacesModule(TestIosModule):
                         ipv4=[dict(address="192.168.0.1/24", secondary=True)],
                     ),
                     dict(
-                        name="GigabitEthernet0/2", ipv4=[dict(address="192.168.0.2/24")]
+                        name="GigabitEthernet0/2",
+                        ipv4=[dict(address="192.168.0.2/24")],
                     ),
                     dict(name="Serial1/0", ipv4=[dict(address="192.168.0.3/24")]),
                 ],
@@ -233,7 +232,7 @@ class TestIosL3InterfacesModule(TestIosModule):
         )
         result = self.execute_module(changed=False)
         parsed_list = [
-            {"name": "GigabitEthernet0/3.100", "ipv4": [{"address": "192.168.0.3/24"}]}
+            {"name": "GigabitEthernet0/3.100", "ipv4": [{"address": "192.168.0.3/24"}]},
         ]
         self.assertEqual(parsed_list, result["parsed"])
 
@@ -319,9 +318,10 @@ class TestIosL3InterfacesModule(TestIosModule):
                         ipv4=[
                             dict(
                                 dhcp=dict(
-                                    client_id="GigabitEthernet0/2", hostname="test.com"
-                                )
-                            )
+                                    client_id="GigabitEthernet0/2",
+                                    hostname="test.com",
+                                ),
+                            ),
                         ],
                     ),
                     dict(name="GigabitEthernet0/2", ipv4=[dict(pool="PoolName1")]),
@@ -444,9 +444,10 @@ class TestIosL3InterfacesModule(TestIosModule):
                         ipv4=[
                             dict(
                                 dhcp=dict(
-                                    client_id="GigabitEthernet0/2", hostname="test.com"
-                                )
-                            )
+                                    client_id="GigabitEthernet0/2",
+                                    hostname="test.com",
+                                ),
+                            ),
                         ],
                     ),
                     dict(

--- a/tests/unit/modules/network/ios/test_ios_l3_interfaces.py
+++ b/tests/unit/modules/network/ios/test_ios_l3_interfaces.py
@@ -27,7 +27,9 @@ class TestIosL3InterfacesModule(TestIosModule):
             "ansible_collections.ansible.netcommon.plugins.module_utils.network.common.rm_base.resource_module_base."
             "get_resource_connection",
         )
-        self.get_resource_connection_facts = self.mock_get_resource_connection_facts.start()
+        self.get_resource_connection_facts = (
+            self.mock_get_resource_connection_facts.start()
+        )
 
         self.mock_execute_show_command = patch(
             "ansible_collections.cisco.ios.plugins.module_utils.network.ios.facts.l3_interfaces.l3_interfaces."
@@ -46,6 +48,9 @@ class TestIosL3InterfacesModule(TestIosModule):
             interface GigabitEthernet0/3.100
              encapsulation dot1Q 20
              ip address 192.168.0.3 255.255.255.0
+            interface VirtualPortGroup0
+             ip address 192.168.0.4 255.255.255.0
+             ipv6 address fe80:0:3a2:84::3 link-local
             interface Serial3/0
              ipv6 address fd5d:12c9:2201:1::1/64
             interface Serial7/0
@@ -58,7 +63,20 @@ class TestIosL3InterfacesModule(TestIosModule):
                         name="GigabitEthernet0/3.100",
                         ipv4=[dict(address="192.168.0.3/24", secondary=True)],
                     ),
-                    dict(name="Serial3/0", ipv6=[dict(address="FD5D:12C9:2201:1::1/64", cga=True)]),
+                    dict(
+                        name="Serial3/0",
+                        ipv6=[dict(address="FD5D:12C9:2201:1::1/64", cga=True)],
+                    ),
+                    dict(
+                        name="VirtualPortGroup0",
+                        ipv4=[dict(address="192.168.0.4/24", secondary=True)],
+                        ipv6=[
+                            dict(
+                                address="fe80:0:3a2:84::3",
+                                link_local=True,
+                            )
+                        ],
+                    ),
                 ],
                 state="merged",
             ),
@@ -94,7 +112,9 @@ class TestIosL3InterfacesModule(TestIosModule):
                         name="GigabitEthernet0/1",
                         ipv4=[dict(address="192.168.0.1/24", secondary=True)],
                     ),
-                    dict(name="GigabitEthernet0/2", ipv4=[dict(address="192.168.0.2/24")]),
+                    dict(
+                        name="GigabitEthernet0/2", ipv4=[dict(address="192.168.0.2/24")]
+                    ),
                     dict(name="Serial1/0", ipv4=[dict(address="192.168.0.3/24")]),
                 ],
                 state="overridden",
@@ -171,13 +191,19 @@ class TestIosL3InterfacesModule(TestIosModule):
         set_module_args(
             dict(
                 config=[
-                    dict(name="GigabitEthernet0/3", ipv6=[dict(address="FD5D:12C9:2202:1::1/64")]),
+                    dict(
+                        name="GigabitEthernet0/3",
+                        ipv6=[dict(address="FD5D:12C9:2202:1::1/64")],
+                    ),
                     dict(
                         name="GigabitEthernet0/2",
                         ipv4=[dict(address="192.168.0.2/24", secondary=False)],
                     ),
                     dict(name="Serial1/0", ipv4=[dict(address="192.168.0.5/24")]),
-                    dict(name="GigabitEthernet0/3.100", ipv4=[dict(address="192.168.0.4/24")]),
+                    dict(
+                        name="GigabitEthernet0/3.100",
+                        ipv4=[dict(address="192.168.0.4/24")],
+                    ),
                 ],
                 state="replaced",
             ),
@@ -206,7 +232,9 @@ class TestIosL3InterfacesModule(TestIosModule):
             ),
         )
         result = self.execute_module(changed=False)
-        parsed_list = [{"name": "GigabitEthernet0/3.100", "ipv4": [{"address": "192.168.0.3/24"}]}]
+        parsed_list = [
+            {"name": "GigabitEthernet0/3.100", "ipv4": [{"address": "192.168.0.3/24"}]}
+        ]
         self.assertEqual(parsed_list, result["parsed"])
 
     def test_ios_l3_interfaces_rendered(self):
@@ -288,7 +316,13 @@ class TestIosL3InterfacesModule(TestIosModule):
                 config=[
                     dict(
                         name="GigabitEthernet0/1",
-                        ipv4=[dict(dhcp=dict(client_id="GigabitEthernet0/2", hostname="test.com"))],
+                        ipv4=[
+                            dict(
+                                dhcp=dict(
+                                    client_id="GigabitEthernet0/2", hostname="test.com"
+                                )
+                            )
+                        ],
                     ),
                     dict(name="GigabitEthernet0/2", ipv4=[dict(pool="PoolName1")]),
                     dict(name="Serial1/0", ipv6=[dict(autoconfig=dict(default=True))]),
@@ -298,8 +332,14 @@ class TestIosL3InterfacesModule(TestIosModule):
                         ipv6=[dict(address="FD5D:12C9:2201:1::1/64", anycast=True)],
                     ),
                     dict(name="Vlan51", ipv4=[dict(address="192.168.0.4/31")]),
-                    dict(name="Serial4/0", ipv6=[dict(address="FD5D:12C9:2201:2::1/64", cga=True)]),
-                    dict(name="Serial5/0", ipv6=[dict(address="FD5D:12C9:2201:3::1/64", eui=True)]),
+                    dict(
+                        name="Serial4/0",
+                        ipv6=[dict(address="FD5D:12C9:2201:2::1/64", cga=True)],
+                    ),
+                    dict(
+                        name="Serial5/0",
+                        ipv6=[dict(address="FD5D:12C9:2201:3::1/64", eui=True)],
+                    ),
                     dict(
                         name="Serial6/0",
                         ipv6=[dict(address="FD5D:12C9:2201:4::1/64", link_local=True)],
@@ -401,16 +441,31 @@ class TestIosL3InterfacesModule(TestIosModule):
                 config=[
                     dict(
                         name="GigabitEthernet0/1",
-                        ipv4=[dict(dhcp=dict(client_id="GigabitEthernet0/2", hostname="test.com"))],
+                        ipv4=[
+                            dict(
+                                dhcp=dict(
+                                    client_id="GigabitEthernet0/2", hostname="test.com"
+                                )
+                            )
+                        ],
                     ),
-                    dict(name="GigabitEthernet0/3.100", ipv4=[dict(address="192.168.0.3/24")]),
+                    dict(
+                        name="GigabitEthernet0/3.100",
+                        ipv4=[dict(address="192.168.0.3/24")],
+                    ),
                     dict(name="Serial2/0", ipv6=[dict(dhcp=dict(rapid_commit=True))]),
                     dict(
                         name="Serial3/0",
                         ipv6=[dict(address="FD5D:12C9:2201:1::1/64", anycast=True)],
                     ),
-                    dict(name="Serial4/0", ipv6=[dict(address="FD5D:12C9:2201:2::1/64", cga=True)]),
-                    dict(name="Serial5/0", ipv6=[dict(address="FD5D:12C9:2201:3::1/64", eui=True)]),
+                    dict(
+                        name="Serial4/0",
+                        ipv6=[dict(address="FD5D:12C9:2201:2::1/64", cga=True)],
+                    ),
+                    dict(
+                        name="Serial5/0",
+                        ipv6=[dict(address="FD5D:12C9:2201:3::1/64", eui=True)],
+                    ),
                     dict(
                         name="Serial6/0",
                         ipv6=[dict(address="FD5D:12C9:2201:4::1/64", link_local=True)],
@@ -453,7 +508,10 @@ class TestIosL3InterfacesModule(TestIosModule):
         set_module_args(
             dict(
                 config=[
-                    dict(name="GigabitEthernet0/3.100", ipv4=[dict(address="192.168.1.3/24")]),
+                    dict(
+                        name="GigabitEthernet0/3.100",
+                        ipv4=[dict(address="192.168.1.3/24")],
+                    ),
                 ],
                 state="replaced",
             ),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Remove strict ipv6 validation

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
l3_interfaces

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
playbook
```paste below
    - name: SET VIRTUAL PORT GROUP
      cisco.ios.ios_l3_interfaces:
        config:
          - name: VirtualPortGroup0
            ipv4:
              - address: "10.0.2.x/24"
            ipv6:
              - address: "fe80:0:cxc:84::4"
                link_local: true
        state: merged
```
output
```paste below
    [
        "interface VirtualPortGroup0",
        "ip address 10.0.2.x 255.255.255.0",
        "ipv6 address fe80:0:cxc:84::4 link-local"
    ],
    "invocation": {
        "module_args": {
            "config": [
```
