### PR TITLE
Update test-requirements.txt

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,7 +4,6 @@ flake8
 yamllint
 
 # Unit test runner
-pytest-ansible ; python_version >= '3.9'
-git+https://github.com/ansible-community/pytest-ansible-units.git ; python_version < '3.9'
+pytest-ansible ; python_version
 pytest-xdist
 pytest-cov


### PR DESCRIPTION
We no longer run Python <3.9 tests in CI.