### PR TITLE
Integration test fix for ios_user and ios_facts

### DIFF
--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -1,3 +1,4 @@
+---
 ancestor: null
 releases:
   1.0.0:

--- a/changelogs/config.yaml
+++ b/changelogs/config.yaml
@@ -1,3 +1,4 @@
+---
 changelog_filename_template: ../CHANGELOG.rst
 changelog_filename_version_depth: 0
 changes_file: changelog.yaml

--- a/changelogs/fragments/ios_user_int_test.yml
+++ b/changelogs/fragments/ios_user_int_test.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - Fix ios_user module integration test failure - change the type 5 secret hash.

--- a/changelogs/fragments/ios_user_int_test.yml
+++ b/changelogs/fragments/ios_user_int_test.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Fix ios_user module integration test failure - change the type 5 secret hash.

--- a/tests/integration/targets/ios_facts/tests/cli/all_facts.yaml
+++ b/tests/integration/targets/ios_facts/tests/cli/all_facts.yaml
@@ -20,8 +20,10 @@
       - result.ansible_facts.ansible_net_memtotal_mb > 1
 
 - ansible.builtin.assert:
-    that: "{{ item.value.spacetotal_kb }} > {{ item.value.spacefree_kb }}"
+    that: "{{ my_var.value.spacetotal_kb }} > {{ my_var.value.spacefree_kb }}"
   loop: "{{ lookup('dict', result.ansible_facts.ansible_net_filesystems_info, wantlist=True) }}"
+  loop_control:
+    loop_var: my_var
 
 - ansible.builtin.set_fact:
     supported_network_resources:
@@ -34,6 +36,9 @@
       - lldp_global
       - lldp_interfaces
       - l3_interfaces
+      - evpn_global
+      - evpn_evi
+      - vxlan_vtep
       - logging_global
       - acl_interfaces
       - static_routes

--- a/tests/integration/targets/ios_user/tests/cli/basic.yaml
+++ b/tests/integration/targets/ios_user/tests/cli/basic.yaml
@@ -104,13 +104,13 @@
     name: ansibleuser6
     hashed_password:
       type: 5
-      value: $3$8JcDilcYgFZi.yz4ApaqkHG2.8/
+      value: $1$SpMm$eALjeyED.WSZs0naLNv22/
     state: present
 
 - ansible.builtin.assert:
     that:
       - result.changed == true
-      - "'username ansibleuser6 password' in result.commands[0]"
+      - "'username ansibleuser6 secret' in result.commands[0]"
 
 - name: Teardown
   become: true


### PR DESCRIPTION
##### SUMMARY
- Replaced the hash which was being used to test type 5 secret.
- Changed loop logic for a task to include loop_control to fix error - The loop variable
'item' is already in use.

##### ISSUE TYPE
- Test fix

