### PR TITLE
l3_interfaces - Fix gathering wrong facts for source interface in ipv4.

### DIFF
--- a/changelogs/fragments/l3_sinterface_parser.yml
+++ b/changelogs/fragments/l3_sinterface_parser.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - ios_l3_interfaces - Fix gathering wrong facts for source interface in ipv4.

--- a/plugins/module_utils/network/ios/rm_templates/l3_interfaces.py
+++ b/plugins/module_utils/network/ios/rm_templates/l3_interfaces.py
@@ -166,7 +166,7 @@ class L3_interfacesTemplate(NetworkTemplate):
             "name": "ipv4.source_interface",
             "getval": re.compile(
                 r"""\s+ip\sunnumbered
-                    (\s(?P<name>\S+))
+                    (\s(?P<src_name>\S+))
                     (\s(?P<poll>poll))?
                     (\s(?P<point_to_point>point-to-point))?
                     $""",
@@ -180,7 +180,7 @@ class L3_interfacesTemplate(NetworkTemplate):
                     "ipv4": [
                         {
                             "source_interface": {
-                                "name": "{{ True if name is defined }}",
+                                "name": "{{ src_name }}",
                                 "poll": "{{ True if poll is defined }}",
                                 "point_to_point": "{{ True if point_to_point is defined }}",
                             },

--- a/tests/unit/modules/network/ios/test_ios_l3_interfaces.py
+++ b/tests/unit/modules/network/ios/test_ios_l3_interfaces.py
@@ -407,7 +407,6 @@ class TestIosL3InterfacesModule(TestIosModule):
             "ipv6 enable",
             "no autostate",
         ]
-
         result = self.execute_module(changed=True)
         self.assertEqual(sorted(result["commands"]), sorted(commands))
 
@@ -524,3 +523,31 @@ class TestIosL3InterfacesModule(TestIosModule):
         ]
         result = self.execute_module(changed=True)
         self.assertEqual(sorted(result["commands"]), sorted(commands))
+
+    def test_ios_l3_interfaces_gathered(self):
+        self.execute_show_command.return_value = dedent(
+            """\
+            interface GigabitEthernet0/1
+             no autostate
+            interface Vlan901
+             ip unnumbered Loopback2
+            """,
+        )
+        set_module_args(
+            dict(
+                state="gathered",
+            ),
+        )
+        result = self.execute_module(changed=False)
+        gathered = [
+            {
+                'name': 'GigabitEthernet0/1', 
+                'autostate': False
+            }, 
+            {
+                'name': 'Vlan901', 
+                'ipv4': [{'source_interface': {'name': 'Loopback2'}}], 
+                'autostate': True
+            }
+        ]
+        self.assertEqual(result["gathered"], gathered)

--- a/tests/unit/modules/network/ios/test_ios_l3_interfaces.py
+++ b/tests/unit/modules/network/ios/test_ios_l3_interfaces.py
@@ -541,13 +541,13 @@ class TestIosL3InterfacesModule(TestIosModule):
         result = self.execute_module(changed=False)
         gathered = [
             {
-                'name': 'GigabitEthernet0/1', 
-                'autostate': False
-            }, 
+                "name": "GigabitEthernet0/1",
+                "autostate": False,
+            },
             {
-                'name': 'Vlan901', 
-                'ipv4': [{'source_interface': {'name': 'Loopback2'}}], 
-                'autostate': True
-            }
+                "name": "Vlan901",
+                "ipv4": [{"source_interface": {"name": "Loopback2"}}],
+                "autostate": True,
+            },
         ]
         self.assertEqual(result["gathered"], gathered)


### PR DESCRIPTION
##### SUMMARY
This fixes issue where the module is gathering wrong facts for source_interface in ipv4 in l3_interfaces.

It was gathering a `bool` value instead of the name of the interface which should be `str` based on the argspec.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- tests/unit/modules/network/ios/test_ios_l3_interfaces.py
- plugins/module_utils/network/ios/rm_templates/l3_interfaces.py


