### PR TITLE
Fix snmp host syntax

### DIFF
--- a/changelogs/fragments/snmp_server_host.yml
+++ b/changelogs/fragments/snmp_server_host.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - snmp_server - Fix wrong syntax of snmp-server host command generation.

--- a/plugins/module_utils/network/ios/rm_templates/snmp_server.py
+++ b/plugins/module_utils/network/ios/rm_templates/snmp_server.py
@@ -63,12 +63,12 @@ def cmd_option_hosts(config_data):  # contain sub list attr
             cmd += " {host}".format(host=config_data.get("host"))
         if config_data.get("informs"):
             cmd += " informs"
+        if config_data.get("vrf"):
+            cmd += " vrf {vrf}".format(vrf=config_data.get("vrf"))
         if config_data.get("version"):
             cmd += " version {version}".format(version=config_data.get("version"))
         if config_data.get("version_option"):
             cmd += " {version}".format(version=config_data.get("version_option"))
-        if config_data.get("vrf"):
-            cmd += " vrf {vrf}".format(vrf=config_data.get("vrf"))
         if config_data.get("community_string"):
             cmd += " {community_string}".format(
                 community_string=config_data.get("community_string"),

--- a/tests/unit/modules/network/ios/test_ios_snmp_server.py
+++ b/tests/unit/modules/network/ios/test_ios_snmp_server.py
@@ -1928,7 +1928,7 @@ class TestIosSnmpServerModule(TestIosModule):
             "snmp-server enable traps ospf state-change",
             "snmp-server enable traps ethernet cfm cc mep-up mep-down cross-connect loop config",
             "snmp-server enable traps ethernet cfm crosscheck mep-missing mep-unknown service-up",
-            "snmp-server host 172.16.1.1 version 3 auth vrf mgmt group0 tty",
+            "snmp-server host 172.16.1.1 vrf mgmt version 3 auth group0 tty",
             "snmp-server host 172.16.2.1 version 3 priv newtera rsrb",
             "snmp-server host 172.16.2.1 version 3 noauth replaceUser slb",
             "snmp-server host 172.16.2.1 version 2c trapsac tty",


### PR DESCRIPTION
##### SUMMARY
Fixes issue - #1071 

cisco.ios.ios_snmp_server module is NOT applying commands correctly, so causing errors.

The correct way this command should be applied is:
`snmp-server host 10.1.1.1 vrf Mgmt-intf version 3 priv test_user`

But in the run the playbook it tries to run the command like this instead:
`snmp-server host 10.1.1.1 version 3 priv vrf Mgmt-intf test_user`


Fixed based on - cisco [docs](https://www.cisco.com/c/en/us/td/docs/ios-xml/ios/snmp/command/nm-snmp-cr-book/nm-snmp-cr-s5.html#wp3482803949)

Syntax:

```
snmp-server host {hostname | ip-address} [vrf vrf-name | informs | traps | version {1 | 2c | 3 [auth | noauth | priv]}] community-string [udp-port port [notification-type] | notification-type] 
```

##### ISSUE TYPE
- Bugfix Pull Request

