### PR TITLE
FIX: Include netmask into static_routes parser as part of result key

### DIFF
--- a/changelogs/fragments/static_routes_facts_fix.yml
+++ b/changelogs/fragments/static_routes_facts_fix.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - ios_static_routes - Fix gathering facts by properly distinguising routes.

--- a/plugins/module_utils/network/ios/rm_templates/static_routes.py
+++ b/plugins/module_utils/network/ios/rm_templates/static_routes.py
@@ -64,7 +64,7 @@ class Static_routesTemplate(NetworkTemplate):
             "{{ (' dhcp' ) if ipv4.dhcp|d(False) else '' }}"
             "{{ (' global' ) if ipv4.global|d(False) else '' }}",
             "result": {
-                "{{ dest }}_{{ vrf|d() }}_{{ topology|d() }}_ipv4": [
+                "{{ dest }}_{{ netmask }}_{{ vrf|d() }}_{{ topology|d() }}_ipv4": [
                     {
                         "_vrf": "{{ vrf }}",
                         "_topology": "{{ topology }}",

--- a/tests/unit/modules/network/ios/test_ios_static_routes.py
+++ b/tests/unit/modules/network/ios/test_ios_static_routes.py
@@ -2157,7 +2157,7 @@ class TestIosStaticRoutesModule(TestIosModule):
                                 "next_hops": [
                                     {
                                         "interface": "Null0",
-                                        "permanent": True
+                                        "permanent": True,
                                     },
                                 ],
                             },
@@ -2167,12 +2167,12 @@ class TestIosStaticRoutesModule(TestIosModule):
                                     {
                                         "forward_router_address": "10.0.0.1",
                                         "interface": "GigabitEthernet0/1.22",
-                                        "tag": 30
+                                        "tag": 30,
                                     },
                                     {
-                                        "forward_router_address": "10.0.0.2"
-                                    }
-                                ]
+                                        "forward_router_address": "10.0.0.2",
+                                    },
+                                ],
                             },
                             {
                                 "dest": "192.168.1.0/29",
@@ -2180,10 +2180,10 @@ class TestIosStaticRoutesModule(TestIosModule):
                                     {
                                         "forward_router_address": "10.0.0.3",
                                         "interface": "GigabitEthernet0/1.23",
-                                        "tag": 30
-                                    }
-                                ]
-                            }
+                                        "tag": 30,
+                                    },
+                                ],
+                            },
                         ],
                     },
                     {
@@ -2193,20 +2193,20 @@ class TestIosStaticRoutesModule(TestIosModule):
                                 "dest": "2001:DB8:0:3::/128",
                                 "next_hops": [
                                     {
-                                        "forward_router_address": "2001:DB8:0:3::33"
-                                    }
-                                ]
+                                        "forward_router_address": "2001:DB8:0:3::33",
+                                    },
+                                ],
                             },
                             {
                                 "dest": "2001:DB8:0:3::/64",
                                 "next_hops": [
                                     {
-                                        "forward_router_address": "2001:DB8:0:3::3"
-                                    }
-                                ]
+                                        "forward_router_address": "2001:DB8:0:3::3",
+                                    },
+                                ],
                             },
-                        ]
-                    }
+                        ],
+                    },
                 ],
             },
         ]

--- a/tests/unit/modules/network/ios/test_ios_static_routes.py
+++ b/tests/unit/modules/network/ios/test_ios_static_routes.py
@@ -2138,6 +2138,11 @@ class TestIosStaticRoutesModule(TestIosModule):
         self.execute_show_command.return_value = dedent(
             """\
             ip route 10.0.0.0 255.0.0.0 Null0 permanent
+            ip route 192.168.1.0 255.255.255.0 GigabitEthernet0/1.22 10.0.0.1 tag 30
+            ip route 192.168.1.0 255.255.255.0 10.0.0.2
+            ip route 192.168.1.0 255.255.255.248 GigabitEthernet0/1.23 10.0.0.3 tag 30
+            ipv6 route 2001:DB8:0:3::/128 2001:DB8:0:3::33
+            ipv6 route 2001:DB8:0:3::/64 2001:DB8:0:3::3
             """,
         )
         set_module_args(dict(state="gathered"))
@@ -2150,11 +2155,58 @@ class TestIosStaticRoutesModule(TestIosModule):
                             {
                                 "dest": "10.0.0.0/8",
                                 "next_hops": [
-                                    {"interface": "Null0", "permanent": True},
+                                    {
+                                        "interface": "Null0",
+                                        "permanent": True
+                                    },
                                 ],
                             },
+                            {
+                                "dest": "192.168.1.0/24",
+                                "next_hops": [
+                                    {
+                                        "forward_router_address": "10.0.0.1",
+                                        "interface": "GigabitEthernet0/1.22",
+                                        "tag": 30
+                                    },
+                                    {
+                                        "forward_router_address": "10.0.0.2"
+                                    }
+                                ]
+                            },
+                            {
+                                "dest": "192.168.1.0/29",
+                                "next_hops": [
+                                    {
+                                        "forward_router_address": "10.0.0.3",
+                                        "interface": "GigabitEthernet0/1.23",
+                                        "tag": 30
+                                    }
+                                ]
+                            }
                         ],
                     },
+                    {
+                        "afi": "ipv6",
+                        "routes": [
+                            {
+                                "dest": "2001:DB8:0:3::/128",
+                                "next_hops": [
+                                    {
+                                        "forward_router_address": "2001:DB8:0:3::33"
+                                    }
+                                ]
+                            },
+                            {
+                                "dest": "2001:DB8:0:3::/64",
+                                "next_hops": [
+                                    {
+                                        "forward_router_address": "2001:DB8:0:3::3"
+                                    }
+                                ]
+                            },
+                        ]
+                    }
                 ],
             },
         ]
@@ -2162,4 +2214,3 @@ class TestIosStaticRoutesModule(TestIosModule):
         self.maxDiff = None
         print(result["gathered"])
         self.assertEqual(sorted(result["gathered"]), sorted(gathered))
-        # self.assertEqual(result["gathered"], gathered)


### PR DESCRIPTION
Netmask is part of route destination and should be included as 'primary' key for distinguishing routes. For ipv6 it is already part of dest parameter.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes https://github.com/ansible-collections/cisco.ios/issues/1037
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios_static_routes

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
DEVICE BEFORE STATE:
#sh run | sec ip route
ip route 153.5.255.0 255.255.255.248 178.172.80.30
ip route 192.168.30.0 255.255.255.0 GigabitEthernet0/1.23 10.0.0.33 tag 30
ip route 192.168.30.0 255.255.255.0 10.0.0.3
ip route 192.168.30.0 255.255.255.248 GigabitEthernet0/1.23 10.0.0.33 tag 30

PLAYBOOK:
    - name: Replace provided configuration with device configuration
      ios_static_routes:
        config:
          - address_families:
              - afi: ipv4
                routes:
                  - dest: 153.5.255.0/29
                    next_hops:
                      - forward_router_address: 178.172.80.30
                  - dest: 192.168.30.0/24
                    next_hops:
                      - forward_router_address: 10.0.0.30
                        interface: GigabitEthernet0/1.23
                        tag: 30
        state: replaced

OUTPUT:
TASK [Replace provided configuration with device configuration] ***************************************************************************************************************************************************
changed: [rmeereen.cpe.arnes.si] => changed=true 
  after:
  - address_families:
    - afi: ipv4
      routes:
      - dest: 153.5.255.0/29
        next_hops:
        - forward_router_address: 178.172.80.30
      - dest: 192.168.30.0/24
        next_hops:
        - forward_router_address: 10.0.0.30
          interface: GigabitEthernet0/1.23
          tag: 30
  before:
  - address_families:
    - afi: ipv4
      routes:
      - dest: 153.5.255.0/29
        next_hops:
        - forward_router_address: 178.172.80.30
      - dest: 192.168.30.0/24
        next_hops:
        - forward_router_address: 10.0.0.33
          interface: GigabitEthernet0/1.23
          tag: 30
        - forward_router_address: 10.0.0.3
      - dest: 192.168.30.0/29
        next_hops:
        - forward_router_address: 10.0.0.33
          interface: GigabitEthernet0/1.23
          tag: 30
  commands:
  - ip route 192.168.30.0 255.255.255.0 GigabitEthernet0/1.23 10.0.0.30 tag 30
  - no ip route 192.168.30.0 255.255.255.0 GigabitEthernet0/1.23 10.0.0.33 tag 30
  - no ip route 192.168.30.0 255.255.255.0 10.0.0.3
  - no ip route 192.168.30.0 255.255.255.248 GigabitEthernet0/1.23 10.0.0.33 tag 30

DEVICE AFTER STATE:
#sh run | sec ip route
ip route 153.5.255.0 255.255.255.248 178.172.80.30
ip route 192.168.30.0 255.255.255.0 GigabitEthernet0/1.23 10.0.0.30 tag 30
```
