### PR TITLE
Fix snmp-server host commad parsing

### DIFF
--- a/changelogs/fragments/snmp_parse_fix.yml
+++ b/changelogs/fragments/snmp_parse_fix.yml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - snmp_server - Fix wrong parsing of snmp-server host command.
+  - snmp_server - Fix configuration command for snmp-server host.

--- a/changelogs/fragments/snmp_parse_fix.yml
+++ b/changelogs/fragments/snmp_parse_fix.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - snmp_server - Fix wrong parsing of snmp-server host command.

--- a/plugins/module_utils/network/ios/rm_templates/snmp_server.py
+++ b/plugins/module_utils/network/ios/rm_templates/snmp_server.py
@@ -322,9 +322,9 @@ class Snmp_serverTemplate(NetworkTemplate):
                 ^snmp-server\shost
                 (\s(?P<host>\S+))?
                 (\s(?P<informs>informs))?
+                (\svrf\s(?P<vrf>\S+))?
                 (\sversion\s(?P<version>1|3|2c))?
                 (\s(?P<version_option>auth|noauth|priv))?
-                (\svrf\s(?P<vrf>\S+))?
                 (\s(?P<community_string>\S+))?
                 (\s+(?P<traps>.+$))?
                 """, re.VERBOSE,

--- a/tests/unit/modules/network/ios/test_ios_snmp_server.py
+++ b/tests/unit/modules/network/ios/test_ios_snmp_server.py
@@ -1761,7 +1761,7 @@ class TestIosSnmpServerModule(TestIosModule):
                     "version_option": "priv",
                     "community_string": "newtera1",
                     "traps": ["rsrb", "pim"],
-                }
+                },
             ],
             "users": [
                 {

--- a/tests/unit/modules/network/ios/test_ios_snmp_server.py
+++ b/tests/unit/modules/network/ios/test_ios_snmp_server.py
@@ -1684,6 +1684,7 @@ class TestIosSnmpServerModule(TestIosModule):
             snmp-server host 172.16.2.99 checktrap  isis hsrp
             snmp-server host 172.16.2.1 version 3 priv newtera  rsrb pim rsvp slb pki
             snmp-server host 172.16.2.1 version 3 noauth replace-User!  slb pki
+            snmp-server host 172.16.2.1 vrf vrf1 version 3 priv newtera1  rsrb pim
             """,
         )
         self.execute_show_command_user.return_value = dedent(
@@ -1753,6 +1754,14 @@ class TestIosSnmpServerModule(TestIosModule):
                     "community_string": "checktrap",
                     "traps": ["isis", "hsrp"],
                 },
+                {
+                    "host": "172.16.2.99",
+                    "vrf": "vrf1",
+                    "version": "3",
+                    "version_option": "priv",
+                    "community_string": "newtera1",
+                    "traps": ["rsrb", "pim"],
+                }
             ],
             "users": [
                 {

--- a/tests/unit/modules/network/ios/test_ios_snmp_server.py
+++ b/tests/unit/modules/network/ios/test_ios_snmp_server.py
@@ -1681,8 +1681,8 @@ class TestIosSnmpServerModule(TestIosModule):
     def test_ios_snmp_server_gathered(self):
         self.execute_show_command.return_value = dedent(
             """\
-            snmp-server host 172.16.2.99 checktrap  isis hsrp
-            snmp-server host 172.16.2.1 version 3 priv newtera  rsrb pim rsvp slb pki
+            snmp-server host 172.16.2.99 checktrap isis hsrp
+            snmp-server host 172.16.2.1 version 3 priv newtera rsrb pim rsvp slb pki
             snmp-server host 172.16.2.1 version 3 noauth replace-User! slb pki
             snmp-server host 172.16.2.1 vrf vrf1 version 3 priv newtera1 rsrb pim
             """,

--- a/tests/unit/modules/network/ios/test_ios_snmp_server.py
+++ b/tests/unit/modules/network/ios/test_ios_snmp_server.py
@@ -1683,8 +1683,8 @@ class TestIosSnmpServerModule(TestIosModule):
             """\
             snmp-server host 172.16.2.99 checktrap  isis hsrp
             snmp-server host 172.16.2.1 version 3 priv newtera  rsrb pim rsvp slb pki
-            snmp-server host 172.16.2.1 version 3 noauth replace-User!  slb pki
-            snmp-server host 172.16.2.1 vrf vrf1 version 3 priv newtera1  rsrb pim
+            snmp-server host 172.16.2.1 version 3 noauth replace-User! slb pki
+            snmp-server host 172.16.2.1 vrf vrf1 version 3 priv newtera1 rsrb pim
             """,
         )
         self.execute_show_command_user.return_value = dedent(


### PR DESCRIPTION
##### SUMMARY
Fixes parsing of snmp server host config

#1073 - Changes the command of snmp host due to with parsing failed, fixed that in this pr

##### ISSUE TYPE
- Bugfix Pull Request
