### PR TITLE
ios_vlans - add error regex for vlan name longer than 32 characters

### DIFF
--- a/changelogs/fragments/vlan_err_reg.yaml
+++ b/changelogs/fragments/vlan_err_reg.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - ios_vlans - Make the module fail when vlan name is longer than 32 characters with configuration as VTPv1 and VTPv2.

--- a/plugins/terminal/ios.py
+++ b/plugins/terminal/ios.py
@@ -27,14 +27,18 @@ import re
 from ansible.errors import AnsibleConnectionFailure
 from ansible.module_utils._text import to_bytes, to_text
 from ansible.utils.display import Display
-from ansible_collections.ansible.netcommon.plugins.plugin_utils.terminal_base import TerminalBase
+from ansible_collections.ansible.netcommon.plugins.plugin_utils.terminal_base import (
+    TerminalBase,
+)
 
 
 display = Display()
 
 
 class TerminalModule(TerminalBase):
-    terminal_stdout_re = [re.compile(rb"[\r\n]?[\w\+\-\.:\/\[\]]+(?:\([^\)]+\)){0,3}(?:[>#]) ?$")]
+    terminal_stdout_re = [
+        re.compile(rb"[\r\n]?[\w\+\-\.:\/\[\]]+(?:\([^\)]+\)){0,3}(?:[>#]) ?$")
+    ]
 
     privilege_level_re = re.compile(r"Current privilege level is (\d+)$")
 
@@ -55,10 +59,16 @@ class TerminalModule(TerminalBase):
         re.compile(rb"% ?(\S+) ?Informational: ?[\s]+", re.I),
         re.compile(rb"Command authorization failed"),
         re.compile(rb"Command Rejected: ?[\s]+", re.I),
-        re.compile(rb"% General session commands not allowed under the address family", re.I),
+        re.compile(
+            rb"% General session commands not allowed under the address family", re.I
+        ),
         re.compile(rb"% BGP: Error initializing topology", re.I),
         re.compile(rb"%SNMP agent not enabled", re.I),
         re.compile(rb"% Invalid", re.I),
+        re.compile(
+            rb"%You must disable VTPv1 and VTPv2 or switch to VTPv3 before configuring a VLAN name longer than 32 characters",
+            re.I,
+        ),
     ]
 
     terminal_config_prompt = re.compile(r"^.+\(config(-.*)?\)#$")
@@ -66,7 +76,9 @@ class TerminalModule(TerminalBase):
     def get_privilege_level(self):
         try:
             cmd = {"command": "show privilege"}
-            result = self._exec_cli_command(to_bytes(json.dumps(cmd), errors="surrogate_or_strict"))
+            result = self._exec_cli_command(
+                to_bytes(json.dumps(cmd), errors="surrogate_or_strict")
+            )
         except AnsibleConnectionFailure as e:
             raise AnsibleConnectionFailure(
                 "unable to fetch privilege, with error: %s" % (e.message),
@@ -74,7 +86,9 @@ class TerminalModule(TerminalBase):
 
         prompt = self.privilege_level_re.search(result)
         if not prompt:
-            raise AnsibleConnectionFailure("unable to check privilege level [%s]" % result)
+            raise AnsibleConnectionFailure(
+                "unable to check privilege level [%s]" % result
+            )
 
         return int(prompt.group(1))
 
@@ -86,7 +100,9 @@ class TerminalModule(TerminalBase):
             try:
                 self._exec_cli_command(b"screen-length 0")  # support to SD-WAN mode
                 _is_sdWan = True
-            except AnsibleConnectionFailure:  # fails as length required for handling prompt
+            except (
+                AnsibleConnectionFailure
+            ):  # fails as length required for handling prompt
                 raise AnsibleConnectionFailure("unable to set terminal parameters")
         try:
             if _is_sdWan:
@@ -110,11 +126,15 @@ class TerminalModule(TerminalBase):
         if passwd:
             # Note: python-3.5 cannot combine u"" and r"" together.  Thus make
             # an r string and use to_text to ensure it's text on both py2 and py3.
-            cmd["prompt"] = to_text(r"[\r\n]?(?:.*)?[Pp]assword: ?$", errors="surrogate_or_strict")
+            cmd["prompt"] = to_text(
+                r"[\r\n]?(?:.*)?[Pp]assword: ?$", errors="surrogate_or_strict"
+            )
             cmd["answer"] = passwd
             cmd["prompt_retry_check"] = True
         try:
-            self._exec_cli_command(to_bytes(json.dumps(cmd), errors="surrogate_or_strict"))
+            self._exec_cli_command(
+                to_bytes(json.dumps(cmd), errors="surrogate_or_strict")
+            )
             prompt = self._get_prompt()
             privilege_level = self.get_privilege_level()
         except AnsibleConnectionFailure as e:

--- a/plugins/terminal/ios.py
+++ b/plugins/terminal/ios.py
@@ -27,9 +27,7 @@ import re
 from ansible.errors import AnsibleConnectionFailure
 from ansible.module_utils._text import to_bytes, to_text
 from ansible.utils.display import Display
-from ansible_collections.ansible.netcommon.plugins.plugin_utils.terminal_base import (
-    TerminalBase,
-)
+from ansible_collections.ansible.netcommon.plugins.plugin_utils.terminal_base import TerminalBase
 
 
 display = Display()
@@ -37,7 +35,7 @@ display = Display()
 
 class TerminalModule(TerminalBase):
     terminal_stdout_re = [
-        re.compile(rb"[\r\n]?[\w\+\-\.:\/\[\]]+(?:\([^\)]+\)){0,3}(?:[>#]) ?$")
+        re.compile(rb"[\r\n]?[\w\+\-\.:\/\[\]]+(?:\([^\)]+\)){0,3}(?:[>#]) ?$"),
     ]
 
     privilege_level_re = re.compile(r"Current privilege level is (\d+)$")
@@ -60,7 +58,8 @@ class TerminalModule(TerminalBase):
         re.compile(rb"Command authorization failed"),
         re.compile(rb"Command Rejected: ?[\s]+", re.I),
         re.compile(
-            rb"% General session commands not allowed under the address family", re.I
+            rb"% General session commands not allowed under the address family",
+            re.I,
         ),
         re.compile(rb"% BGP: Error initializing topology", re.I),
         re.compile(rb"%SNMP agent not enabled", re.I),
@@ -77,7 +76,7 @@ class TerminalModule(TerminalBase):
         try:
             cmd = {"command": "show privilege"}
             result = self._exec_cli_command(
-                to_bytes(json.dumps(cmd), errors="surrogate_or_strict")
+                to_bytes(json.dumps(cmd), errors="surrogate_or_strict"),
             )
         except AnsibleConnectionFailure as e:
             raise AnsibleConnectionFailure(
@@ -87,7 +86,7 @@ class TerminalModule(TerminalBase):
         prompt = self.privilege_level_re.search(result)
         if not prompt:
             raise AnsibleConnectionFailure(
-                "unable to check privilege level [%s]" % result
+                "unable to check privilege level [%s]" % result,
             )
 
         return int(prompt.group(1))
@@ -100,9 +99,7 @@ class TerminalModule(TerminalBase):
             try:
                 self._exec_cli_command(b"screen-length 0")  # support to SD-WAN mode
                 _is_sdWan = True
-            except (
-                AnsibleConnectionFailure
-            ):  # fails as length required for handling prompt
+            except AnsibleConnectionFailure:  # fails as length required for handling prompt
                 raise AnsibleConnectionFailure("unable to set terminal parameters")
         try:
             if _is_sdWan:
@@ -127,13 +124,14 @@ class TerminalModule(TerminalBase):
             # Note: python-3.5 cannot combine u"" and r"" together.  Thus make
             # an r string and use to_text to ensure it's text on both py2 and py3.
             cmd["prompt"] = to_text(
-                r"[\r\n]?(?:.*)?[Pp]assword: ?$", errors="surrogate_or_strict"
+                r"[\r\n]?(?:.*)?[Pp]assword: ?$",
+                errors="surrogate_or_strict",
             )
             cmd["answer"] = passwd
             cmd["prompt_retry_check"] = True
         try:
             self._exec_cli_command(
-                to_bytes(json.dumps(cmd), errors="surrogate_or_strict")
+                to_bytes(json.dumps(cmd), errors="surrogate_or_strict"),
             )
             prompt = self._get_prompt()
             privilege_level = self.get_privilege_level()


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
ios_vlans - Make the module fail when vlan name is longer than 32 characters with configurations as VTPv1 and VTPv2.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios_vlans

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
