### PR TITLE
Fix some idempotency issues in static_routes and bgp_global

### DIFF
--- a/changelogs/fragments/pr-1095-fragment.yaml
+++ b/changelogs/fragments/pr-1095-fragment.yaml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - static_routes - add TenGigabitEthernet as valid interface
+  - bgp_global - fix ebgp_multihop recognnition and hop_count settings

--- a/plugins/module_utils/network/ios/rm_templates/bgp_global.py
+++ b/plugins/module_utils/network/ios/rm_templates/bgp_global.py
@@ -1462,13 +1462,13 @@ class Bgp_globalTemplate(NetworkTemplate):
             "getval": re.compile(
                 r"""
                 \sneighbor\s(?P<neighbor_address>\S+)
-                \s(?P<enable>ebgp_multihop)
+                \s(?P<enable>ebgp-multihop)
                 (\s(?P<hop_count>\d+))?
                 $""",
                 re.VERBOSE,
             ),
             "setval": "neighbor {{ neighbor_address }} ebgp-multihop"
-            "{{ (' ' + hop_count|string) if hop_count is defined else '' }}",
+            "{{ (' ' + ebgp_multihop.hop_count|string) if ebgp_multihop.hop_count is defined else '' }}",
             "result": {
                 "neighbors": {
                     "{{ neighbor_address }}": {

--- a/plugins/module_utils/network/ios/rm_templates/static_routes.py
+++ b/plugins/module_utils/network/ios/rm_templates/static_routes.py
@@ -37,7 +37,7 @@ class Static_routesTemplate(NetworkTemplate):
                 (\svrf\s(?P<vrf>\S+))?
                 (\s(?P<dest>\S+))
                 (\s(?P<netmask>\S+))
-                (\s(?P<interface>(ACR|ATM-ACR|Analysis-Module|AppNav-Compress|AppNav-UnCompress|Async|Auto-Template|BD-VIF|BDI|BVI|Bluetooth|CDMA-Ix|CEM-ACR|CEM-PG|CTunnel|Container|Dialer|EsconPhy|Ethernet-Internal|Fcpa|Filter|Filtergroup|GigabitEthernet|IMA-ACR|LongReachEthernet|Loopback|Lspvif|MFR|Multilink|NVI|Null|PROTECTION_GROUP|Port-channel|Portgroup|Pos-channel|SBC|SDH_ACR|SERIAL-ACR|SONET_ACR|SSLVPN-VIF|SYSCLOCK|Serial-PG|Service-Engine|TLS-VIF|Tunnel|VPN|Vif|Vir-cem-ACR|Virtual-PPP|Virtual-TokenRing)\S+))?
+                (\s(?P<interface>(ACR|ATM-ACR|Analysis-Module|AppNav-Compress|AppNav-UnCompress|Async|Auto-Template|BD-VIF|BDI|BVI|Bluetooth|CDMA-Ix|CEM-ACR|CEM-PG|CTunnel|Container|Dialer|EsconPhy|Ethernet-Internal|Fcpa|Filter|Filtergroup|GigabitEthernet|TenGigabitEthernet|IMA-ACR|LongReachEthernet|Loopback|Lspvif|MFR|Multilink|NVI|Null|PROTECTION_GROUP|Port-channel|Portgroup|Pos-channel|SBC|SDH_ACR|SERIAL-ACR|SONET_ACR|SSLVPN-VIF|SYSCLOCK|Serial-PG|Service-Engine|TLS-VIF|Tunnel|VPN|Vif|Vir-cem-ACR|Virtual-PPP|Virtual-TokenRing)\S+))?
                 (\s(?P<forward_router_address>(?!multicast|dhcp|global|tag|track|permanent|name)\S+))?
                 (\s(?P<distance_metric>\d+))?
                 (\stag\s(?P<tag>\d+))?

--- a/tests/unit/modules/network/ios/test_ios_bgp_global.py
+++ b/tests/unit/modules/network/ios/test_ios_bgp_global.py
@@ -314,6 +314,34 @@ class TestIosBgpGlobalModule(TestIosModule):
         )
         self.execute_module(changed=False, commands=[])
 
+    def test_ios_bgp_global_ebgp_multihop(self):
+        self.execute_show_command.return_value = dedent(
+            """\
+            router bgp 65000
+             neighbor 192.0.2.1 remote-as 100
+             neighbor 192.0.2.1 ebgp-multihop 255
+            """,
+        )
+        set_module_args(
+            {   
+                "config": {
+                    "as_number": "65000",
+                    "neighbors": [
+                        {
+                            "neighbor_address": "192.0.2.1",
+                            "remote_as": "100",
+                            "ebgp_multihop": {
+                                "enable": True,
+                                "hop_count": 255
+                            },
+                        },
+                    ],
+                },
+                "state": "merged",
+            },
+        )
+        self.execute_module(changed=False, commands=[])
+
     def test_ios_bgp_global_merged_fail_msg(self):
         self.execute_show_command.return_value = dedent(
             """\

--- a/tests/unit/modules/network/ios/test_ios_bgp_global.py
+++ b/tests/unit/modules/network/ios/test_ios_bgp_global.py
@@ -323,7 +323,7 @@ class TestIosBgpGlobalModule(TestIosModule):
             """,
         )
         set_module_args(
-            {   
+            {
                 "config": {
                     "as_number": "65000",
                     "neighbors": [
@@ -332,7 +332,7 @@ class TestIosBgpGlobalModule(TestIosModule):
                             "remote_as": "100",
                             "ebgp_multihop": {
                                 "enable": True,
-                                "hop_count": 255
+                                "hop_count": 255,
                             },
                         },
                     ],


### PR DESCRIPTION
##### SUMMARY
Found some minor issues on static_routes not idempotent when TenGigabitEthernet Interfaces in use and
within the same troubleshooting fixing also ebgp-multihop recognition

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
static_routes
bgp_global

##### ADDITIONAL INFORMATION
Add TenGigabitEthernet to interface regex to also recognize these type of interfaces in static routes.
Typo fixed and variable usage in bgp_global for ebgp-multihop
