### PR TITLE
Update IOS Facts documentation to say mebibytes (MiB) instead of megabits (Mb)

### DIFF
--- a/changelogs/fragments/1097-ios-facts-MiB.yml
+++ b/changelogs/fragments/1097-ios-facts-MiB.yml
@@ -1,0 +1,3 @@
+---
+doc_changes:
+  - ios_facts - update documentation for ansible_net_memtotal_mb, ansible_net_memfree_mb return values as mebibytes (MiB), not megabits (Mb)

--- a/docs/cisco.ios.ios_facts_module.rst
+++ b/docs/cisco.ios.ios_facts_module.rst
@@ -371,7 +371,7 @@ Common return values are documented `here <https://docs.ansible.com/ansible/late
                 </td>
                 <td>when hardware is configured</td>
                 <td>
-                            <div>The available free memory on the remote device in Mb</div>
+                            <div>The available free memory on the remote device in MiB</div>
                     <br/>
                 </td>
             </tr>
@@ -386,7 +386,7 @@ Common return values are documented `here <https://docs.ansible.com/ansible/late
                 </td>
                 <td>when hardware is configured</td>
                 <td>
-                            <div>The total memory on the remote device in Mb</div>
+                            <div>The total memory on the remote device in MiB</div>
                     <br/>
                 </td>
             </tr>

--- a/docs/cisco.ios.ios_facts_module.rst
+++ b/docs/cisco.ios.ios_facts_module.rst
@@ -371,7 +371,7 @@ Common return values are documented `here <https://docs.ansible.com/ansible/late
                 </td>
                 <td>when hardware is configured</td>
                 <td>
-                            <div>The available free memory on the remote device in MiB</div>
+                            <div>The available free memory on the remote device in Mb</div>
                     <br/>
                 </td>
             </tr>
@@ -386,7 +386,7 @@ Common return values are documented `here <https://docs.ansible.com/ansible/late
                 </td>
                 <td>when hardware is configured</td>
                 <td>
-                            <div>The total memory on the remote device in MiB</div>
+                            <div>The total memory on the remote device in Mb</div>
                     <br/>
                 </td>
             </tr>

--- a/plugins/modules/ios_facts.py
+++ b/plugins/modules/ios_facts.py
@@ -177,11 +177,11 @@ ansible_net_filesystems_info:
   returned: when hardware is configured
   type: dict
 ansible_net_memfree_mb:
-  description: The available free memory on the remote device in Mb
+  description: The available free memory on the remote device in MiB
   returned: when hardware is configured
   type: int
 ansible_net_memtotal_mb:
-  description: The total memory on the remote device in Mb
+  description: The total memory on the remote device in MiB
   returned: when hardware is configured
   type: int
 ansible_net_cpu_utilization:


### PR DESCRIPTION
##### SUMMARY
Updated the documentation for the ansible_net_memtotal_mb and ansible_net_memfree_mb return values to have the acronym for mebibytes (MiB) instead of megabits (Mb). In the source code it seems to be converting the values reported by the Cisco device from bits to mebibytes.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
ios_facts

##### ADDITIONAL INFORMATION
The source code for finding the unit conversion can be found here:
https://github.com/ansible-collections/cisco.ios/blob/main/plugins/module_utils/network/ios/facts/legacy/base.py#L151

```
