### PR TITLE
Add missing interface names in static_routes parser

### DIFF
--- a/changelogs/fragments/static_routes_missing_interface_names.yml
+++ b/changelogs/fragments/static_routes_missing_interface_names.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - ios_static_routes - Add missing interface names in parser

--- a/plugins/module_utils/network/ios/rm_templates/static_routes.py
+++ b/plugins/module_utils/network/ios/rm_templates/static_routes.py
@@ -37,7 +37,7 @@ class Static_routesTemplate(NetworkTemplate):
                 (\svrf\s(?P<vrf>\S+))?
                 (\s(?P<dest>\S+))
                 (\s(?P<netmask>\S+))
-                (\s(?P<interface>(ACR|ATM-ACR|Analysis-Module|AppNav-Compress|AppNav-UnCompress|Async|Auto-Template|BD-VIF|BDI|BVI|Bluetooth|CDMA-Ix|CEM-ACR|CEM-PG|CTunnel|Container|Dialer|EsconPhy|Ethernet-Internal|Fcpa|Filter|Filtergroup|GigabitEthernet|IMA-ACR|LongReachEthernet|Loopback|Lspvif|MFR|Multilink|NVI|Null|PROTECTION_GROUP|Port-channel|Portgroup|Pos-channel|SBC|SDH_ACR|SERIAL-ACR|SONET_ACR|SSLVPN-VIF|SYSCLOCK|Serial-PG|Service-Engine|TLS-VIF|Tunnel|VPN|Vif|Vir-cem-ACR|Virtual-PPP|Virtual-TokenRing)\S+))?
+                (\s(?P<interface>(ACR|ATM-ACR|Analysis-Module|AppNav-Compress|AppNav-UnCompress|Async|Auto-Template|BD-VIF|BDI|BVI|Bluetooth|CDMA-Ix|CEM-ACR|CEM-PG|CTunnel|Container|Dialer|EsconPhy|Ethernet-Internal|FastEthernet|Fcpa|Filter|Filtergroup|FiveGigabitEthernet|FortyGigabitEthernet|GigabitEthernet|HundredGigE|IMA-ACR|LongReachEthernet|Loopback|Lspvif|MFR|Multilink|NVI|Null|PROTECTION_GROUP|Port-channel|Portgroup|Pos-channel|SBC|SDH_ACR|SERIAL-ACR|SONET_ACR|SSLVPN-VIF|SYSCLOCK|Serial|Serial-PG|Service-Engine|TenGigabitEthernet|TLS-VIF|Tunnel|TwentyFiveGigE|TwoGigabitEthernet|VPN|Vif|Vir-cem-ACR|Virtual-PPP|Virtual-TokenRing|Vlan)\S+))?
                 (\s(?P<forward_router_address>(?!multicast|dhcp|global|tag|track|permanent|name)\S+))?
                 (\s(?P<distance_metric>\d+))?
                 (\stag\s(?P<tag>\d+))?
@@ -93,7 +93,7 @@ class Static_routesTemplate(NetworkTemplate):
                 (\stopology\s(?P<topology>\S+))?
                 (\svrf\s(?P<vrf>\S+))?
                 (\s(?P<dest>\S+))
-                (\s(?P<interface>(ACR|ATM-ACR|Analysis-Module|AppNav-Compress|AppNav-UnCompress|Async|Auto-Template|BD-VIF|BDI|BVI|Bluetooth|CDMA-Ix|CEM-ACR|CEM-PG|CTunnel|Container|Dialer|EsconPhy|Ethernet-Internal|Fcpa|Filter|Filtergroup|GigabitEthernet|IMA-ACR|LongReachEthernet|Loopback|Lspvif|MFR|Multilink|NVI|Null|PROTECTION_GROUP|Port-channel|Portgroup|Pos-channel|SBC|SDH_ACR|SERIAL-ACR|SONET_ACR|SSLVPN-VIF|SYSCLOCK|Serial-PG|Service-Engine|TLS-VIF|Tunnel|VPN|Vif|Vir-cem-ACR|Virtual-PPP|Virtual-TokenRing)\S+))?
+                (\s(?P<interface>(ACR|ATM-ACR|Analysis-Module|AppNav-Compress|AppNav-UnCompress|Async|Auto-Template|BD-VIF|BDI|BVI|Bluetooth|CDMA-Ix|CEM-ACR|CEM-PG|CTunnel|Container|Dialer|EsconPhy|Ethernet-Internal|FastEthernet|Fcpa|Filter|Filtergroup|FiveGigabitEthernet|FortyGigabitEthernet|GigabitEthernet|HundredGigE|IMA-ACR|LongReachEthernet|Loopback|Lspvif|MFR|Multilink|NVI|Null|PROTECTION_GROUP|Port-channel|Portgroup|Pos-channel|SBC|SDH_ACR|SERIAL-ACR|SONET_ACR|SSLVPN-VIF|SYSCLOCK|Serial|Serial-PG|Service-Engine|TenGigabitEthernet|TLS-VIF|Tunnel|TwentyFiveGigE|TwoGigabitEthernet|VPN|Vif|Vir-cem-ACR|Virtual-PPP|Virtual-TokenRing|Vlan)\S+))?
                 (\s(?P<forward_router_address>(?!multicast|unicast|tag|track|permanent|name)\S+))?
                 (\s(?P<distance_metric>\d+))?
                 (\s(?P<multicast>multicast))?

--- a/tests/unit/modules/network/ios/test_ios_static_routes.py
+++ b/tests/unit/modules/network/ios/test_ios_static_routes.py
@@ -2138,6 +2138,7 @@ class TestIosStaticRoutesModule(TestIosModule):
         self.execute_show_command.return_value = dedent(
             """\
             ip route 10.0.0.0 255.0.0.0 Null0 permanent
+            ip route 10.10.0.0 255.255.0.0 Vlan10 10.0.0.1
             ip route 192.168.1.0 255.255.255.0 GigabitEthernet0/1.22 10.0.0.1 tag 30
             ip route 192.168.1.0 255.255.255.0 10.0.0.2
             ip route 192.168.1.0 255.255.255.248 GigabitEthernet0/1.23 10.0.0.3 tag 30
@@ -2158,6 +2159,15 @@ class TestIosStaticRoutesModule(TestIosModule):
                                     {
                                         "interface": "Null0",
                                         "permanent": True,
+                                    },
+                                ],
+                            },
+                            {
+                                "dest": "10.10.0.0/16",
+                                "next_hops": [
+                                    {
+                                        "forward_router_address": "10.0.0.1",
+                                        "interface": "Vlan10",
                                     },
                                 ],
                             },


### PR DESCRIPTION
##### SUMMARY
There were some common interface names missing. Regex did not match these.

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
static_routes.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
