### PR TITLE
Fix typo in ios_service module

### DIFF
--- a/changelogs/fragments/1101-typo-ios_service.yml
+++ b/changelogs/fragments/1101-typo-ios_service.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - ios_service - Fix a typo causing log timestamps not being configurable

--- a/plugins/module_utils/network/ios/rm_templates/service.py
+++ b/plugins/module_utils/network/ios/rm_templates/service.py
@@ -29,7 +29,7 @@ def handleTimestamp(config_data):
 
     if config_data.get("datetime_options"):
         datetime_op = config_data.get("datetime_options")
-        command += " mesc" if datetime_op.get("msec") else ""
+        command += " msec" if datetime_op.get("msec") else ""
         command += " localtime" if datetime_op.get("localtime") else ""
         command += " show-timezone" if datetime_op.get("show_timezone") else ""
         command += " year" if datetime_op.get("year") else ""

--- a/tests/unit/modules/network/ios/test_ios_service.py
+++ b/tests/unit/modules/network/ios/test_ios_service.py
@@ -217,7 +217,7 @@ class TestIosServiceModule(TestIosModule):
             "service password-encryption",
             "service tcp-keepalives-in",
             "service tcp-keepalives-out",
-            "service timestamps log datetime mesc localtime show-timezone year",
+            "service timestamps log datetime msec localtime show-timezone year",
             "service timestamps debug datetime",
         ]
         playbook["state"] = "overridden"
@@ -276,8 +276,8 @@ class TestIosServiceModule(TestIosModule):
             "service password-encryption",
             "service tcp-keepalives-in",
             "service tcp-keepalives-out",
-            "service timestamps log datetime mesc localtime show-timezone year",
-            "service timestamps debug datetime mesc localtime",
+            "service timestamps log datetime msec localtime show-timezone year",
+            "service timestamps debug datetime msec localtime",
         ]
         playbook["state"] = "replaced"
         set_module_args(playbook)
@@ -500,7 +500,7 @@ class TestIosServiceModule(TestIosModule):
             "service tcp-keepalives-in",
             "service tcp-keepalives-out",
             "service timestamps debug uptime localtime",
-            "service timestamps log datetime mesc localtime show-timezone year",
+            "service timestamps log datetime msec localtime show-timezone year",
         ]
         result = self.execute_module(changed=False)
         self.maxDiff = None

--- a/tests/unit/modules/network/ios/test_ios_service.py
+++ b/tests/unit/modules/network/ios/test_ios_service.py
@@ -129,8 +129,8 @@ class TestIosServiceModule(TestIosModule):
         }
         merged = [
             "service password-encryption",
-            "service timestamps debug uptime mesc",
-            "service timestamps log datetime mesc localtime show-timezone year",
+            "service timestamps debug uptime msec",
+            "service timestamps log datetime msec localtime show-timezone year",
         ]
         playbook["state"] = "merged"
         set_module_args(playbook)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Fix typo in ios_service module

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios_service

##### ADDITIONAL INFORMATION

The actual command in Cisco IOS uses `msec` for *milliseconds*. I believe `mesc` is a typo.
