### PR TITLE
Fixes population of wrong data forward_router_address attribute

### DIFF
--- a/changelogs/fragments/ios_static_routes.yaml
+++ b/changelogs/fragments/ios_static_routes.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - ios_static_routes - Fixes an issue where metric_distance is being populated in the forward_router_address attribute.

--- a/changelogs/fragments/ios_static_routes.yaml
+++ b/changelogs/fragments/ios_static_routes.yaml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - ios_static_routes - Fixes an issue where metric_distance is being populated in the forward_router_address attribute.
+  - ios_static_routes - Fix processing of metric_distance as it was wrongly populated under the forward_router_address attribute.

--- a/plugins/module_utils/network/ios/rm_templates/static_routes.py
+++ b/plugins/module_utils/network/ios/rm_templates/static_routes.py
@@ -38,7 +38,8 @@ class Static_routesTemplate(NetworkTemplate):
                 (\s(?P<dest>\S+))
                 (\s(?P<netmask>\S+))
                 (\s(?P<interface>(ACR|ATM-ACR|Analysis-Module|AppNav-Compress|AppNav-UnCompress|Async|Auto-Template|BD-VIF|BDI|BVI|Bluetooth|CDMA-Ix|CEM-ACR|CEM-PG|CTunnel|Container|Dialer|EsconPhy|Ethernet-Internal|Fcpa|Filter|Filtergroup|GigabitEthernet|TenGigabitEthernet|IMA-ACR|LongReachEthernet|Loopback|Lspvif|MFR|Multilink|NVI|Null|PROTECTION_GROUP|Port-channel|Portgroup|Pos-channel|SBC|SDH_ACR|SERIAL-ACR|SONET_ACR|SSLVPN-VIF|SYSCLOCK|Serial-PG|Service-Engine|TLS-VIF|Tunnel|VPN|Vif|Vir-cem-ACR|Virtual-PPP|Virtual-TokenRing)\S+))?
-                (\s(?P<forward_router_address>(?!multicast|dhcp|global|tag|track|permanent|name)(?!(?<!\d\.)\b\d+\b(?!\.\d))(\d{1,3}(\.\d{1,3}){3}|\S+)))? # Had to add ip validation due to it picking up numbers as forward_router_address and negate just numbers
+                # Had to add ip validation due to it picking up numbers as forward_router_address and negate just numbers
+                (\s(?P<forward_router_address>(?!multicast|dhcp|global|tag|track|permanent|name)(?!(?<!\d\.)\b\d+\b(?!\.\d))(\d{1,3}(\.\d{1,3}){3}|\S+)))?
                 (\s(?P<distance_metric>\d+))?
                 (\stag\s(?P<tag>\d+))?
                 (\s(?P<permanent>permanent))?

--- a/plugins/module_utils/network/ios/rm_templates/static_routes.py
+++ b/plugins/module_utils/network/ios/rm_templates/static_routes.py
@@ -38,7 +38,6 @@ class Static_routesTemplate(NetworkTemplate):
                 (\s(?P<dest>\S+))
                 (\s(?P<netmask>\S+))
                 (\s(?P<interface>(ACR|ATM-ACR|Analysis-Module|AppNav-Compress|AppNav-UnCompress|Async|Auto-Template|BD-VIF|BDI|BVI|Bluetooth|CDMA-Ix|CEM-ACR|CEM-PG|CTunnel|Container|Dialer|EsconPhy|Ethernet-Internal|Fcpa|Filter|Filtergroup|GigabitEthernet|TenGigabitEthernet|IMA-ACR|LongReachEthernet|Loopback|Lspvif|MFR|Multilink|NVI|Null|PROTECTION_GROUP|Port-channel|Portgroup|Pos-channel|SBC|SDH_ACR|SERIAL-ACR|SONET_ACR|SSLVPN-VIF|SYSCLOCK|Serial-PG|Service-Engine|TLS-VIF|Tunnel|VPN|Vif|Vir-cem-ACR|Virtual-PPP|Virtual-TokenRing)\S+))?
-                # Had to add ip validation due to it picking up numbers as forward_router_address and negate just numbers
                 (\s(?P<forward_router_address>(?!multicast|dhcp|global|tag|track|permanent|name)(?!(?<!\d\.)\b\d+\b(?!\.\d))(\d{1,3}(\.\d{1,3}){3}|\S+)))?
                 (\s(?P<distance_metric>\d+))?
                 (\stag\s(?P<tag>\d+))?

--- a/plugins/module_utils/network/ios/rm_templates/static_routes.py
+++ b/plugins/module_utils/network/ios/rm_templates/static_routes.py
@@ -38,7 +38,7 @@ class Static_routesTemplate(NetworkTemplate):
                 (\s(?P<dest>\S+))
                 (\s(?P<netmask>\S+))
                 (\s(?P<interface>(ACR|ATM-ACR|Analysis-Module|AppNav-Compress|AppNav-UnCompress|Async|Auto-Template|BD-VIF|BDI|BVI|Bluetooth|CDMA-Ix|CEM-ACR|CEM-PG|CTunnel|Container|Dialer|EsconPhy|Ethernet-Internal|Fcpa|Filter|Filtergroup|GigabitEthernet|TenGigabitEthernet|IMA-ACR|LongReachEthernet|Loopback|Lspvif|MFR|Multilink|NVI|Null|PROTECTION_GROUP|Port-channel|Portgroup|Pos-channel|SBC|SDH_ACR|SERIAL-ACR|SONET_ACR|SSLVPN-VIF|SYSCLOCK|Serial-PG|Service-Engine|TLS-VIF|Tunnel|VPN|Vif|Vir-cem-ACR|Virtual-PPP|Virtual-TokenRing)\S+))?
-                (\s(?P<forward_router_address>(?!multicast|dhcp|global|tag|track|permanent|name)\S+))?
+                (\s(?P<forward_router_address>(?!multicast|dhcp|global|tag|track|permanent|name)(?!(?<!\d\.)\b\d+\b(?!\.\d))(\d{1,3}(\.\d{1,3}){3}|\S+)))? # Had to add ip validation due to it picking up numbers as forward_router_address and negate just numbers
                 (\s(?P<distance_metric>\d+))?
                 (\stag\s(?P<tag>\d+))?
                 (\s(?P<permanent>permanent))?

--- a/tests/integration/targets/ios_static_routes/tests/cli/_parsed.cfg
+++ b/tests/integration/targets/ios_static_routes/tests/cli/_parsed.cfg
@@ -1,0 +1,2 @@
+ip route 198.51.100.0 255.255.255.0 198.51.101.1 175 tag 70 name replaced_route multicast
+ip route 192.168.1.0 255.255.255.0 GigabitEthernet0/1.22 10.0.0.1 tag 30

--- a/tests/integration/targets/ios_static_routes/tests/cli/parsed.yaml
+++ b/tests/integration/targets/ios_static_routes/tests/cli/parsed.yaml
@@ -1,0 +1,14 @@
+---
+- ansible.builtin.debug:
+    msg: START ios_static_routes parsed integration test
+
+- name: Ios_static_routes parsed - play
+  register: result
+  cisco.ios.ios_static_routes:
+    running_config: "{{ lookup('file', '_parsed.cfg') }}"
+    state: parsed
+
+- ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - parsed_data == result['parsed']

--- a/tests/integration/targets/ios_static_routes/vars/main.yaml
+++ b/tests/integration/targets/ios_static_routes/vars/main.yaml
@@ -81,6 +81,22 @@ gathered:
                   name: route_2
                 - forward_router_address: 198.51.101.3
                   name: route_3
+parsed_data:
+  - address_families:
+      - afi: ipv4
+        routes:
+          - dest: 198.51.100.0/24
+            next_hops:
+              - distance_metric: 175
+                forward_router_address: 198.51.101.1
+                multicast: true
+                name: replaced_route
+                tag: 70
+          - dest: 192.168.1.0/24
+            next_hops:
+              - forward_router_address: 10.0.0.1
+                interface: GigabitEthernet0/1.22
+                tag: 30
 rtt:
   override_commands:
     - ip route vrf ansible_temp_vrf 192.0.2.0 255.255.255.0 192.0.2.12 tag 10 name new_rtt_vrf track 150

--- a/tests/unit/modules/network/ios/test_ios_static_routes.py
+++ b/tests/unit/modules/network/ios/test_ios_static_routes.py
@@ -2258,3 +2258,48 @@ class TestIosStaticRoutesModule(TestIosModule):
         ]
         result = self.execute_module(changed=False)
         self.assertEqual(sorted(result["gathered"]), sorted(gathered))
+
+    def test_ios_static_route_overridden_2(self):
+        self.execute_show_command.return_value = dedent(
+            """\
+            ip route 198.51.100.0 255.255.255.0 198.51.101.1 175 tag 70 name replaced_route multicast
+            ip route 192.168.1.0 255.255.255.0 GigabitEthernet0/1.22 10.0.0.1 tag 30
+            """,
+        )
+        set_module_args(dict(config=[
+                    {
+                        "address_families": [
+                            {
+                                "afi": "ipv4",
+                                "routes": [
+                                    {
+                                        "next_hops": [
+                                            {
+                                                "forward_router_address": "198.51.101.20",
+                                                "distance_metric": 175,
+                                                "tag": 70,
+                                                "name": "replaced_route",
+                                                "track": 150,
+                                            },
+                                            {
+                                                "forward_router_address": "198.51.101.3",
+                                                "name": "merged_route_3",
+                                            },
+                                        ],
+                                        "dest": "198.51.100.0/24",
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+            ],
+            state="overridden"
+        ))
+        commands = [
+            'ip route 198.51.100.0 255.255.255.0 198.51.101.20 175 tag 70 name replaced_route track 150', 
+            'ip route 198.51.100.0 255.255.255.0 198.51.101.3 name merged_route_3', 
+            'no ip route 198.51.100.0 255.255.255.0 198.51.101.1 175 tag 70 name replaced_route multicast', 
+            'no ip route 192.168.1.0 255.255.255.0 GigabitEthernet0/1.22 10.0.0.1 tag 30'
+        ]
+        result = self.execute_module(changed=True)
+        self.assertEqual(sorted(result["commands"]), sorted(commands))

--- a/tests/unit/modules/network/ios/test_ios_static_routes.py
+++ b/tests/unit/modules/network/ios/test_ios_static_routes.py
@@ -2224,37 +2224,37 @@ class TestIosStaticRoutesModule(TestIosModule):
         )
         set_module_args(dict(state="gathered"))
         gathered = [
-            {'address_families': 
-                [
+            {
+                "address_families": [
                     {
-                        'afi': 'ipv4', 
-                        'routes': [
+                        "afi": "ipv4",
+                        "routes": [
                             {
-                                'next_hops': [
+                                "next_hops": [
                                     {
-                                        'forward_router_address': '198.51.101.1', 
-                                        'distance_metric': 175, 
-                                        'tag': 70, 
-                                        'name': 'replaced_route', 
-                                        'multicast': True
-                                    }
-                                ], 
-                                'dest': '198.51.100.0/24'
-                            }, 
+                                        "forward_router_address": "198.51.101.1",
+                                        "distance_metric": 175,
+                                        "tag": 70,
+                                        "name": "replaced_route",
+                                        "multicast": True,
+                                    },
+                                ],
+                                "dest": "198.51.100.0/24",
+                            },
                             {
-                                'next_hops': [
+                                "next_hops": [
                                     {
-                                        'interface': 'GigabitEthernet0/1.22', 
-                                        'forward_router_address': '10.0.0.1', 
-                                        'tag': 30
-                                    }
-                                ], 
-                                'dest': '192.168.1.0/24'
-                            }
-                        ]
-                    }
-                ]
-            }
+                                        "interface": "GigabitEthernet0/1.22",
+                                        "forward_router_address": "10.0.0.1",
+                                        "tag": 30,
+                                    },
+                                ],
+                                "dest": "192.168.1.0/24",
+                            },
+                        ],
+                    },
+                ],
+            },
         ]
         result = self.execute_module(changed=False)
         self.assertEqual(sorted(result["gathered"]), sorted(gathered))

--- a/tests/unit/modules/network/ios/test_ios_static_routes.py
+++ b/tests/unit/modules/network/ios/test_ios_static_routes.py
@@ -2266,7 +2266,9 @@ class TestIosStaticRoutesModule(TestIosModule):
             ip route 192.168.1.0 255.255.255.0 GigabitEthernet0/1.22 10.0.0.1 tag 30
             """,
         )
-        set_module_args(dict(config=[
+        set_module_args(
+            dict(
+                config=[
                     {
                         "address_families": [
                             {
@@ -2292,14 +2294,15 @@ class TestIosStaticRoutesModule(TestIosModule):
                             },
                         ],
                     },
-            ],
-            state="overridden"
-        ))
+                ],
+                state="overridden",
+            ),
+        )
         commands = [
-            'ip route 198.51.100.0 255.255.255.0 198.51.101.20 175 tag 70 name replaced_route track 150', 
-            'ip route 198.51.100.0 255.255.255.0 198.51.101.3 name merged_route_3', 
-            'no ip route 198.51.100.0 255.255.255.0 198.51.101.1 175 tag 70 name replaced_route multicast', 
-            'no ip route 192.168.1.0 255.255.255.0 GigabitEthernet0/1.22 10.0.0.1 tag 30'
+            "ip route 198.51.100.0 255.255.255.0 198.51.101.20 175 tag 70 name replaced_route track 150",
+            "ip route 198.51.100.0 255.255.255.0 198.51.101.3 name merged_route_3",
+            "no ip route 198.51.100.0 255.255.255.0 198.51.101.1 175 tag 70 name replaced_route multicast",
+            "no ip route 192.168.1.0 255.255.255.0 GigabitEthernet0/1.22 10.0.0.1 tag 30",
         ]
         result = self.execute_module(changed=True)
         self.assertEqual(sorted(result["commands"]), sorted(commands))

--- a/tests/unit/modules/network/ios/test_ios_static_routes.py
+++ b/tests/unit/modules/network/ios/test_ios_static_routes.py
@@ -2214,3 +2214,47 @@ class TestIosStaticRoutesModule(TestIosModule):
         self.maxDiff = None
         print(result["gathered"])
         self.assertEqual(sorted(result["gathered"]), sorted(gathered))
+
+    def test_ios_static_route_gathered_2(self):
+        self.execute_show_command.return_value = dedent(
+            """\
+            ip route 198.51.100.0 255.255.255.0 198.51.101.1 175 tag 70 name replaced_route multicast
+            ip route 192.168.1.0 255.255.255.0 GigabitEthernet0/1.22 10.0.0.1 tag 30
+            """,
+        )
+        set_module_args(dict(state="gathered"))
+        gathered = [
+            {'address_families': 
+                [
+                    {
+                        'afi': 'ipv4', 
+                        'routes': [
+                            {
+                                'next_hops': [
+                                    {
+                                        'forward_router_address': '198.51.101.1', 
+                                        'distance_metric': 175, 
+                                        'tag': 70, 
+                                        'name': 'replaced_route', 
+                                        'multicast': True
+                                    }
+                                ], 
+                                'dest': '198.51.100.0/24'
+                            }, 
+                            {
+                                'next_hops': [
+                                    {
+                                        'interface': 'GigabitEthernet0/1.22', 
+                                        'forward_router_address': '10.0.0.1', 
+                                        'tag': 30
+                                    }
+                                ], 
+                                'dest': '192.168.1.0/24'
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+        result = self.execute_module(changed=False)
+        self.assertEqual(sorted(result["gathered"]), sorted(gathered))


### PR DESCRIPTION
##### SUMMARY
Fixes issue where data of `metric_distance` is being populated in `forward_router_address` when gathering facts.

Happens because the regex used for `forward_router_address` picks up the `metric_distance` value when the interface is present instead of `forward_router_address`

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ios_static_routes
