### PR TITLE
Add support for FiftyGigabitEthernet

### DIFF
--- a/changelogs/fragments/fix_interface_fifty_interface.yml
+++ b/changelogs/fragments/fix_interface_fifty_interface.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - ios_interfaces - Fixes rendering of FiftyGigabitEthernet as it was wrongly rendering FiftyGigabitEthernet as FiveGigabitEthernet.

--- a/plugins/module_utils/network/ios/ios.py
+++ b/plugins/module_utils/network/ios/ios.py
@@ -141,8 +141,10 @@ def normalize_interface(name):
         if_type = "FastEthernet"
     elif name.lower().startswith("fo"):
         if_type = "FortyGigabitEthernet"
-    elif name.lower().startswith("fi"):
+    elif name.lower().startswith("fiv"):
         if_type = "FiveGigabitEthernet"
+    elif name.lower().startswith("fif"):
+        if_type = "FiftyGigabitEthernet"
     elif name.lower().startswith("et"):
         if_type = "Ethernet"
     elif name.lower().startswith("vl"):

--- a/plugins/module_utils/network/ios/utils/utils.py
+++ b/plugins/module_utils/network/ios/utils/utils.py
@@ -286,8 +286,10 @@ def normalize_interface(name):
         if_type = "FastEthernet"
     elif name.lower().startswith("fo"):
         if_type = "FortyGigabitEthernet"
-    elif name.lower().startswith("fi"):
+    elif name.lower().startswith("fiv"):
         if_type = "FiveGigabitEthernet"
+    elif name.lower().startswith("fif"):
+        if_type = "FiftyGigabitEthernet"
     elif name.lower().startswith("long"):
         if_type = "LongReachEthernet"
     elif name.lower().startswith("et"):

--- a/tests/unit/modules/network/ios/test_ios_interfaces.py
+++ b/tests/unit/modules/network/ios/test_ios_interfaces.py
@@ -679,6 +679,10 @@ class TestIosInterfacesModule(TestIosModule):
                         "description": "Ansible UT FiveGigabitEthernet",
                     },
                     {
+                        "name": "fiftyGigabitEthernet",
+                        "description": "Ansible UT for fiftyGigabitEthernet",
+                    },
+                    {
                         "name": "ethernet1",
                         "description": "Ansible UT Ethernet",
                     },
@@ -749,6 +753,9 @@ class TestIosInterfacesModule(TestIosModule):
             "no shutdown",
             "interface FiveGigabitEthernet",
             "description Ansible UT FiveGigabitEthernet",
+            "no shutdown",
+            "interface FiftyGigabitEthernet",
+            "description Ansible UT for fiftyGigabitEthernet",
             "no shutdown",
             "interface Ethernet1",
             "description Ansible UT Ethernet",


### PR DESCRIPTION
##### SUMMARY
Add support for `FiftyGigabitEthernet` as it was always being replaced by `FiveGigabitEthernet`
<!--- Describe the change below, including rationale and design decisions -->
```yaml
    - name: test
      check_mode: true
      cisco.ios.ios_interfaces:
        config:
          - name: FiftyGigE1/0/1
            description: add support for FiftyGigabitEthernet
```
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
```
ios_interface
utils.py
l2_interface
l3_interface
lacp_interfaces
lldp_interfaces
```
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
  commands:
  - interface FiftyGigabitEthernet1/0/1
  - description NOENB-C9300-MGT04.dnbnor.no via TenGigabitEthernet1/1/2
  - no shutdown
```
