### PR TITLE
[ios_bgp_global/ address_family] fix parsing of password_options while gathering password configuratin

### DIFF
--- a/changelogs/fragments/bgp_global_render_pass.yml
+++ b/changelogs/fragments/bgp_global_render_pass.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - ios_bgp_global - fix parsing of password_options while gathering password configuration from appliance.
+  - ios_bgp_address_family - fix parsing of password_options while gathering password configuration from appliance.

--- a/plugins/module_utils/network/ios/rm_templates/bgp_address_family.py
+++ b/plugins/module_utils/network/ios/rm_templates/bgp_address_family.py
@@ -1586,8 +1586,8 @@ class Bgp_address_familyTemplate(NetworkTemplate):
             "getval": re.compile(
                 r"""
                 \s\sneighbor\s(?P<neighbor_address>\S+)\spassword
-                \s(?P<encryption>\d+)
-                (\s(?P<pass_key>.$))?
+                (\s(?P<encryption>\d+))
+                (\s(?P<pass_key>.+))?
                 $""",
                 re.VERBOSE,
             ),

--- a/plugins/module_utils/network/ios/rm_templates/bgp_global.py
+++ b/plugins/module_utils/network/ios/rm_templates/bgp_global.py
@@ -1642,7 +1642,7 @@ class Bgp_globalTemplate(NetworkTemplate):
                 r"""
                 \sneighbor\s(?P<neighbor_address>\S+)\spassword
                 \s(?P<encryption>\d+)
-                (\s(?P<pass_key>.$))?
+                (\s(?P<pass_key>.+))?
                 $""",
                 re.VERBOSE,
             ),

--- a/tests/unit/modules/network/ios/test_ios_bgp_global.py
+++ b/tests/unit/modules/network/ios/test_ios_bgp_global.py
@@ -628,6 +628,7 @@ class TestIosBgpGlobalModule(TestIosModule):
                      timers bgp 100 200 150
                      redistribute connected metric 10
                      neighbor 192.0.2.1 remote-as 100
+                     neighbor 192.0.2.1 password 7 DEQPITOP101395
                      neighbor 192.0.2.1 route-map test-route out
                      address-family ipv4
                       neighbor 192.0.2.28 activate
@@ -652,7 +653,13 @@ class TestIosBgpGlobalModule(TestIosModule):
                 {
                     "remote_as": "100",
                     "neighbor_address": "192.0.2.1",
-                    "route_maps": [{"name": "test-route", "out": True}],
+                    "route_maps": [
+                        {"name": "test-route", "out": True},
+                    ],
+                    "password_options": {
+                        "encryption": 7,
+                        "pass_key": "DEQPITOP101395",
+                    },
                 },
             ],
         }


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
  - ios_bgp_global - fix parsing of password_options while gathering password configuration from appliance.
  - ios_bgp_address_family - fix parsing of password_options while gathering password configuration from appliance.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- 
##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios_bgp_global
ios_bgp_address_family
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```bash
                    router bgp 65000
                     bgp nopeerup-delay post-boot 10
                     bgp bestpath compare-routerid
                     bgp advertise-best-external
                     timers bgp 100 200 150
                     redistribute connected metric 10
                     neighbor 192.0.2.1 remote-as 100
                     neighbor 192.0.2.1 password 7 DEQPITOP101395
                     neighbor 192.0.2.1 route-map test-route out
                     address-family ipv4
                      neighbor 192.0.2.28 activate
                      neighbor 172.31.35.140 activate
```
Parses - 
```json
{
            "as_number": "65000",
            "bgp": {
                "nopeerup_delay_options": {"post_boot": 10},
                "bestpath_options": {"compare_routerid": True},
                "default": {"ipv4_unicast": True, "route_target": {"filter": True}},
                "advertise_best_external": True,
            },
            "timers": {"keepalive": 100, "holdtime": 200, "min_holdtime": 150},
            "redistribute": [{"connected": {"set": True, "metric": 10}}],
            "neighbors": [
                {
                    "remote_as": "100",
                    "neighbor_address": "192.0.2.1",
                    "route_maps": [
                        {"name": "test-route", "out": True},
                    ],
                    "password_options": {
                        "encryption": 7,
                        "pass_key": "DEQPITOP101395",
                    },
                },
            ],
        }
```
