### PR TITLE
Fix module failure when ARP ACLs are present on cat9k device 

### DIFF
--- a/plugins/module_utils/network/ios/facts/acls/acls.py
+++ b/plugins/module_utils/network/ios/facts/acls/acls.py
@@ -42,7 +42,7 @@ class AclsFacts(object):
     def get_acl_data(self, connection):
         # Removed the show access-list
         # Removed the show running-config | include ip(v6)* access-list|remark
-        return connection.get("show running-config | section access-list")
+        return connection.get("show running-config | section 'ip[v6]* access-list'")
 
     def get_acl_names(self, connection):
         # this information is required to scoop out the access lists which has no aces

--- a/tests/unit/modules/network/ios/test_ios_acls.py
+++ b/tests/unit/modules/network/ios/test_ios_acls.py
@@ -2303,3 +2303,59 @@ class TestIosAclsModule(TestIosModule):
             "no ip access-list extended test_acl",
         ]
         self.assertEqual(sorted(result["commands"]), sorted(commands))
+
+    def test_ios_acls_with_arp_acl(self):
+        self.execute_show_command.return_value = dedent(
+            """\
+            ip access-list standard 10
+            10 permit 192.168.1.0 0.0.0.255
+            arp access-list arp-test
+            permit ip any mac any
+            ip access-list extended ext_acl
+            10 permit ip 192.0.2.0 0.0.0.255 192.0.3.0 0.0.0.255
+            """
+        )
+        self.execute_show_command_name.return_value = dedent(
+            """\
+            Standard IP access list 10
+            Extended IP access list ext_acl
+            """
+        )
+
+        set_module_args(
+            dict(
+                config=[
+                    dict(
+                        afi="ipv4",
+                        acls=[
+                            dict(
+                                name="test_ext_acl",
+                                acl_type="extended",
+                                aces=[
+                                    dict(
+                                        grant="permit",
+                                        protocol="ip",
+                                        source=dict(
+                                            address="192.0.2.0",
+                                            wildcard_bits="0.0.0.255"
+                                        ),
+                                        destination=dict(
+                                            address="192.0.3.0",
+                                            wildcard_bits="0.0.0.255"
+                                        )
+                                    )
+                                ]
+                            )
+                        ]
+                    )
+                ],
+                state="merged"
+            )
+        )
+
+        result = self.execute_module(changed=True)
+        commands = [
+            "ip access-list extended test_ext_acl",
+            "permit ip 192.0.2.0 0.0.0.255 192.0.3.0 0.0.0.255"
+        ]
+        self.assertEqual(sorted(result["commands"]), sorted(commands))


### PR DESCRIPTION
SUMMARY
This PR fixes an issue with the ios_acls module where it fails when ARP ACLs are present on the device. The module was incorrectly parsing ARP ACL entries, causing errors when configuring extended ACLs with protocol options.

Changed the command from:
`show running-config | section access-list`
to:
`show running-config | section ip access-list`

```
    def get_acl_data(self, connection):
        # Removed the show access-list
        # Removed the show running-config | include ip(v6)* access-list|remark
        return connection.get("show running-config | section 'ip[v6]* access-list'")
```

This ensures the module only processes IP ACLs and ignores ARP ACLs.

Fixes: https://github.com/ansible-collections/cisco.ios/issues/1111

ISSUE TYPE
Bugfix Pull Request

COMPONENT NAME
cisco.ios.ios_acls

ADDITIONAL INFORMATION
Original error:

`fatal: [device]: FAILED! => {"changed": false, "msg": "Unsupported attribute for standard ACL - protocol."}`

Configuration that triggered the issue:
# On device:
```
ip access-list standard 10
 10 permit 192.168.1.0 0.0.0.255
arp access-list arp-test
 permit ip any mac any
```

Unit tests added to verify the fix. Integration tests present already cover this scenario.