### PR TITLE
Fix upstream CI

### DIFF
--- a/changelogs/fragments/fix_ci_upstream.yaml
+++ b/changelogs/fragments/fix_ci_upstream.yaml
@@ -1,0 +1,8 @@
+---
+bugfixes:
+  - ios_route_maps - Fixes an issue where 'no description value' is an invalid command on the latest devices.
+trivial:
+  - ios_lldp_interfaces - Fix upstream CI failure due to difference in interface values.
+  - ios_interfaces - Fix upstream CI failure due to difference in interface values.
+  - ios_user - Fixes ios_user purging the ssh user running the test.
+  - ios_ospf_interfaces - Fix upstream CI failure due to difference in interface values.

--- a/plugins/module_utils/network/ios/rm_templates/route_maps.py
+++ b/plugins/module_utils/network/ios/rm_templates/route_maps.py
@@ -711,6 +711,7 @@ class Route_mapsTemplate(NetworkTemplate):
                 re.VERBOSE,
             ),
             "setval": "description {{ description }}",
+            "remval": "description",
             "result": {
                 "{{ route_map }}": {
                     "{{ action|d() + '_' + sequence|d() }}": {

--- a/tests/integration/targets/ios_interfaces/tests/cli/_populate_config.yaml
+++ b/tests/integration/targets/ios_interfaces/tests/cli/_populate_config.yaml
@@ -1,8 +1,25 @@
 ---
-- name: Populate configuration
-  vars:
+- name: Configure interface settings GigabitEthernet1
+  cisco.ios.ios_config:
     lines:
-      "interface GigabitEthernet 1\ndescription Management interface do not change\ninterface GigabitEthernet 2\ndescription this is interface1\nmtu 1500\nspeed 1000\nno shutdown\ninterface GigabitEthernet 3\ndescription this is interface\
-      \ for testing\nmtu 1500\nspeed 1000\nshutdown\n"
-  ansible.netcommon.cli_config:
-    config: "{{ lines }}"
+      - description Management interface do not change
+    parents: interface GigabitEthernet1
+
+- name: Configure interface settings GigabitEthernet2
+  cisco.ios.ios_config:
+    lines:
+      - description this is interface1
+      - no negotiation auto
+      - mtu 1500
+      - speed 1000
+      - no shutdown
+    parents: interface GigabitEthernet2
+
+- name: Configure interface settings GigabitEthernet2
+  cisco.ios.ios_config:
+    lines:
+      - description this is interface for testing
+      - no negotiation auto
+      - speed 1000
+      - shutdown
+    parents: interface GigabitEthernet3

--- a/tests/integration/targets/ios_l3_interfaces/tests/cli/deleted.yaml
+++ b/tests/integration/targets/ios_l3_interfaces/tests/cli/deleted.yaml
@@ -23,12 +23,24 @@
     - name: L3_interface deleted - assert that before dicts are correctly generated
       ansible.builtin.assert:
         that:
-          - "{{ deleted['before'] | symmetric_difference(result['before']) | length == 0 }}"
+          - >
+            {{
+              result['before']
+              | selectattr('name', 'in', 'GigabitEthernet1,GigabitEthernet2,GigabitEthernet3,GigabitEthernet4')
+              | symmetric_difference(deleted['before'])
+              | length == 0
+            }}
 
     - name: L3_interface deleted - assert that after dict is correctly generated
       ansible.builtin.assert:
         that:
-          - "{{ deleted['after'] | symmetric_difference(result['after']) | length == 0 }}"
+          - >
+            {{
+              result['after']
+              | selectattr('name', 'in', 'GigabitEthernet1,GigabitEthernet2,GigabitEthernet3,GigabitEthernet4')
+              | symmetric_difference(deleted['after'])
+              | length == 0
+            }}
 
     - name: L3_interface deleted - delete attributes of all configured interfaces (idempotent)
       register: result

--- a/tests/integration/targets/ios_l3_interfaces/tests/cli/gathered.yaml
+++ b/tests/integration/targets/ios_l3_interfaces/tests/cli/gathered.yaml
@@ -14,7 +14,13 @@
     - name: L3_interface gathered - assert
       ansible.builtin.assert:
         that:
-          - gathered['config'] | symmetric_difference(result.gathered) == []
+          - >
+            {{
+              result.gathered
+              | selectattr('name', 'in', 'GigabitEthernet1,GigabitEthernet2,GigabitEthernet3,GigabitEthernet4')
+              | symmetric_difference(gathered['config'])
+              | length == 0
+            }}
           - result['changed'] == false
   always:
     - ansible.builtin.include_tasks: _remove_config.yaml

--- a/tests/integration/targets/ios_l3_interfaces/tests/cli/merged.yaml
+++ b/tests/integration/targets/ios_l3_interfaces/tests/cli/merged.yaml
@@ -46,12 +46,24 @@
     - name: L3_interface merged - assert that before dicts are correctly generated
       ansible.builtin.assert:
         that:
-          - "{{ merged['before'] | symmetric_difference(result['before']) | length == 0 }}"
+          - >
+            {{
+              result['before']
+              | selectattr('name', 'in', 'GigabitEthernet1,GigabitEthernet2,GigabitEthernet3,GigabitEthernet4')
+              | symmetric_difference(merged['before'])
+              | length == 0
+            }}
 
     - name: L3_interface merged - assert that after dict is correctly generated
       ansible.builtin.assert:
         that:
-          - "{{ merged['after'] | symmetric_difference(result['after']) | length == 0 }}"
+          - >
+            {{
+              result['after']
+              | rejectattr('name', 'in', 'Loopback888')
+              | symmetric_difference(merged['after'])
+              | length == 0
+            }}
 
     - name: L3_interface merged - merge provided configuration with device configuration (idempotent)
       register: result

--- a/tests/integration/targets/ios_l3_interfaces/tests/cli/overridden.yaml
+++ b/tests/integration/targets/ios_l3_interfaces/tests/cli/overridden.yaml
@@ -32,12 +32,24 @@
     - name: L3_interface overridden - assert that before dicts are correctly generated
       ansible.builtin.assert:
         that:
-          - "{{ overridden['before'] | symmetric_difference(result['before']) | length == 0 }}"
+          - >
+            {{
+              result['before']
+              | rejectattr('name', 'in', 'Loopback888,Loopback999')
+              | symmetric_difference(overridden['before'])
+              | length == 0
+            }}
 
     - name: L3_interface overridden - assert that after dict is correctly generated
       ansible.builtin.assert:
         that:
-          - "{{ overridden['after'] | symmetric_difference(result['after']) | length == 0 }}"
+          - >
+            {{
+              result['after']
+              | rejectattr('name', 'in', 'Loopback888,Loopback999')
+              | symmetric_difference(overridden['after'])
+              | length == 0
+            }}
 
     - name: L3_interface overridden - override device configuration of all interfaces with provided configuration (idempotent)
       register: result

--- a/tests/integration/targets/ios_l3_interfaces/tests/cli/replaced.yaml
+++ b/tests/integration/targets/ios_l3_interfaces/tests/cli/replaced.yaml
@@ -33,12 +33,24 @@
     - name: L3_interface replaced - assert that before dicts are correctly generated
       ansible.builtin.assert:
         that:
-          - "{{ replaced['before'] | symmetric_difference(result['before']) | length == 0 }}"
+          - >
+            {{
+              result['before']
+              | rejectattr('name', 'in', 'Loopback888,Loopback999')
+              | symmetric_difference(replaced['before'])
+              | length == 0
+            }}
 
     - name: L3_interface replaced - assert that after dict is correctly generated
       ansible.builtin.assert:
         that:
-          - "{{ replaced['after'] | symmetric_difference(result['after']) | length == 0 }}"
+          - >
+            {{
+              result['after']
+              | rejectattr('name', 'in', 'Loopback888,Loopback999')
+              | symmetric_difference(replaced['after'])
+              | length == 0
+            }}
 
     - name: L3_interface replaced - replaces device configuration of listed interfaces with provided configuration (idempotent)
       register: result

--- a/tests/integration/targets/ios_l3_interfaces/vars/main.yaml
+++ b/tests/integration/targets/ios_l3_interfaces/vars/main.yaml
@@ -1,8 +1,8 @@
 ---
 merged:
   before:
-    - name: Loopback888
-    - name: Loopback999
+    # - name: Loopback888
+    # - name: Loopback999
     - ipv4:
         - dhcp:
             enable: true
@@ -28,7 +28,7 @@ merged:
     - interface Vlan101
     - no autostate
   after:
-    - name: Loopback888
+    # - name: Loopback888
     - ipv4:
         - address: 192.0.2.1/24
       name: Loopback999
@@ -65,8 +65,8 @@ merged:
 
 replaced:
   before:
-    - name: Loopback888
-    - name: Loopback999
+    # - name: Loopback888
+    # - name: Loopback999
     - ipv4:
         - dhcp:
             enable: true
@@ -97,8 +97,8 @@ replaced:
     - ip address 198.51.100.2 255.255.255.0
     - ip address 198.51.100.1 255.255.255.0 secondary
   after:
-    - name: Loopback888
-    - name: Loopback999
+    # - name: Loopback888
+    # - name: Loopback999
     - ipv4:
         - dhcp:
             enable: true
@@ -117,8 +117,8 @@ replaced:
 
 overridden:
   before:
-    - name: Loopback888
-    - name: Loopback999
+    # - name: Loopback888
+    # - name: Loopback999
     - ipv4:
         - dhcp:
             enable: true
@@ -147,8 +147,8 @@ overridden:
     - ip address 198.51.100.2 255.255.255.0 secondary
     - ip address 198.51.100.1 255.255.255.0
   after:
-    - name: Loopback888
-    - name: Loopback999
+    # - name: Loopback888
+    # - name: Loopback999
     - ipv4:
         - dhcp:
             enable: true
@@ -180,8 +180,8 @@ deleted:
             enable: true
       name: GigabitEthernet3
     - name: GigabitEthernet4
-    - name: Loopback888
-    - name: Loopback999
+    # - name: Loopback888
+    # - name: Loopback999
   commands:
     - interface GigabitEthernet2
     - no ip address 203.0.113.27 255.255.255.0
@@ -191,8 +191,8 @@ deleted:
     - no ipv6 address 2001:db8:0:3::/64
     - no ipv6 address autoconfig
   after:
-    - name: Loopback888
-    - name: Loopback999
+    # - name: Loopback888
+    # - name: Loopback999
     - ipv4:
         - dhcp:
             enable: true
@@ -203,8 +203,8 @@ deleted:
 
 gathered:
   config:
-    - name: Loopback888
-    - name: Loopback999
+    # - name: Loopback888
+    # - name: Loopback999
     - ipv4:
         - dhcp:
             enable: true

--- a/tests/integration/targets/ios_lldp_interfaces/tests/cli/_populate_config.yaml
+++ b/tests/integration/targets/ios_lldp_interfaces/tests/cli/_populate_config.yaml
@@ -6,3 +6,10 @@
       lldp receive\nlldp transmit\n"
   ansible.netcommon.cli_config:
     config: "{{ lines }}"
+
+- name: Negate GigabitEthernet 4 lldp receive and transmit if merged
+  vars:
+    lines: "interface GigabitEthernet 4\nno lldp receive\nno lldp transmit\n"
+  ansible.netcommon.cli_config:
+    config: "{{ lines }}"
+  when: isMerged is defined and isMerged

--- a/tests/integration/targets/ios_lldp_interfaces/tests/cli/deleted.yaml
+++ b/tests/integration/targets/ios_lldp_interfaces/tests/cli/deleted.yaml
@@ -7,6 +7,8 @@
 - ansible.builtin.include_tasks: _remove_config.yaml
 
 - ansible.builtin.include_tasks: _populate_config.yaml
+  vars:
+    isMerged: true
 
 - block:
     - name: Delete lldp attributes for respective configured interfaces

--- a/tests/integration/targets/ios_ospf_interfaces/tests/cli/gathered.yaml
+++ b/tests/integration/targets/ios_ospf_interfaces/tests/cli/gathered.yaml
@@ -17,7 +17,13 @@
       ansible.builtin.assert:
         that:
           - result.changed == false
-          - "{{ gathered['config'] | symmetric_difference(result['gathered']) |length == 0 }}"
+          - >
+            {{
+              result['gathered']
+              | selectattr('name', 'in', 'GigabitEthernet1,GigabitEthernet2,GigabitEthernet3,GigabitEthernet4')
+              | symmetric_difference(gathered['config'])
+              | length == 0
+            }}
 
   always:
     - ansible.builtin.include_tasks: _remove_config.yaml

--- a/tests/integration/targets/ios_ospf_interfaces/tests/cli/merged.yaml
+++ b/tests/integration/targets/ios_ospf_interfaces/tests/cli/merged.yaml
@@ -51,12 +51,24 @@
     - name: Assert that before dicts are correctly generated
       ansible.builtin.assert:
         that:
-          - "{{ merged['before'] | symmetric_difference(result['before']) | length == 0 }}"
+          - >
+            {{
+              result['before']
+              | selectattr('name', 'in', 'GigabitEthernet1,GigabitEthernet2,GigabitEthernet3,GigabitEthernet4')
+              | symmetric_difference(merged['before'])
+              | length == 0
+            }}
 
     - name: Assert that after dict is correctly generated
       ansible.builtin.assert:
         that:
-          - "{{ merged['after'] | symmetric_difference(result['after']) | length == 0 }}"
+          - >
+            {{
+              result['after']
+              | selectattr('name', 'in', 'GigabitEthernet1,GigabitEthernet2,GigabitEthernet3,GigabitEthernet4')
+              | symmetric_difference(merged['after'])
+              | length == 0
+            }}
 
     - name: Merge provided configuration with device configuration (idempotent)
       register: result

--- a/tests/integration/targets/ios_ospf_interfaces/tests/cli/overridden.yaml
+++ b/tests/integration/targets/ios_ospf_interfaces/tests/cli/overridden.yaml
@@ -40,12 +40,24 @@
     - name: Assert that before dicts are correctly generated
       ansible.builtin.assert:
         that:
-          - "{{ merged['after'] | symmetric_difference(result['before']) | length == 0 }}"
+          - >
+            {{
+              result['before']
+              | selectattr('name', 'in', 'GigabitEthernet1,GigabitEthernet2,GigabitEthernet3,GigabitEthernet4')
+              | symmetric_difference(merged['after'])
+              | length == 0
+            }}
 
     - name: Assert that after dict is correctly generated
       ansible.builtin.assert:
         that:
-          - "{{ overridden['after'] | symmetric_difference(result['after']) | length == 0 }}"
+          - >
+            {{
+              result['after']
+              | selectattr('name', 'in', 'GigabitEthernet1,GigabitEthernet2,GigabitEthernet3,GigabitEthernet4')
+              | symmetric_difference(overridden['after'])
+              | length == 0
+            }}
 
     - name: Override provided OSPF interfaces configuration (idempotent)
       register: result

--- a/tests/integration/targets/ios_ospf_interfaces/tests/cli/replaced.yaml
+++ b/tests/integration/targets/ios_ospf_interfaces/tests/cli/replaced.yaml
@@ -27,12 +27,24 @@
     - name: Assert that before dicts are correctly generated
       ansible.builtin.assert:
         that:
-          - "{{ replaced['before'] | symmetric_difference(result['before']) | length == 0 }}"
+          - >
+            {{
+              result['before']
+              | selectattr('name', 'in', 'GigabitEthernet1,GigabitEthernet2,GigabitEthernet3,GigabitEthernet4')
+              | symmetric_difference(replaced['before'])
+              | length == 0
+            }}
 
     - name: Assert that after dict is correctly generated
       ansible.builtin.assert:
         that:
-          - "{{ replaced['after'] | symmetric_difference(result['after']) | length == 0 }}"
+          - >
+            {{
+              result['after']
+              | selectattr('name', 'in', 'GigabitEthernet1,GigabitEthernet2,GigabitEthernet3,GigabitEthernet4')
+              | symmetric_difference(replaced['after'])
+              | length == 0
+            }}
 
     - name: Replaced provided OSPF interfaces configuration (idempotent)
       register: result

--- a/tests/integration/targets/ios_ospf_interfaces/vars/main.yaml
+++ b/tests/integration/targets/ios_ospf_interfaces/vars/main.yaml
@@ -1,8 +1,8 @@
 ---
 merged:
   before:
-    - name: Loopback888
-    - name: Loopback999
+    # - name: Loopback888
+    # - name: Loopback999
     - name: GigabitEthernet1
     - name: GigabitEthernet2
     - name: GigabitEthernet3
@@ -25,8 +25,8 @@ merged:
     - ipv6 ospf priority 55
     - ipv6 ospf transmit-delay 45
   after:
-    - name: Loopback888
-    - name: Loopback999
+    # - name: Loopback888
+    # - name: Loopback999
     - name: GigabitEthernet1
     - address_family:
         - adjacency: true
@@ -61,8 +61,8 @@ merged:
 
 replaced:
   before:
-    - name: Loopback888
-    - name: Loopback999
+    # - name: Loopback888
+    # - name: Loopback999
     - name: GigabitEthernet1
     - address_family:
         - adjacency: true
@@ -100,8 +100,8 @@ replaced:
     - ipv6 ospf priority 20
     - ipv6 ospf transmit-delay 30
   after:
-    - name: Loopback888
-    - name: Loopback999
+    # - name: Loopback888
+    # - name: Loopback999
     - name: GigabitEthernet1
     - address_family:
         - adjacency: true
@@ -163,8 +163,8 @@ overridden:
     - ip ospf priority 40
     - ip ospf ttl-security hops 50
   after:
-    - name: Loopback888
-    - name: Loopback999
+    # - name: Loopback888
+    # - name: Loopback999
     - name: GigabitEthernet1
     - address_family:
         - adjacency: true
@@ -209,8 +209,8 @@ deleted:
 
 gathered:
   config:
-    - name: Loopback888
-    - name: Loopback999
+    # - name: Loopback888
+    # - name: Loopback999
     - name: GigabitEthernet1
     - address_family:
         - adjacency: true

--- a/tests/integration/targets/ios_route_maps/vars/main.yaml
+++ b/tests/integration/targets/ios_route_maps/vars/main.yaml
@@ -166,7 +166,7 @@ overridden:
     - set aigp-metric 100
     - set as-path prepend last-as 2
     - route-map test_1 deny 10
-    - no description this is test route
+    - no description
     - description this is override route
     - match ip flowspec dest-pfx test_acl_1 test_acl_2
     - no match ip next-hop prefix-list test_1_new test_2_new
@@ -305,7 +305,7 @@ replaced:
     - set aigp-metric 100
     - set as-path prepend 65111 65111
     - route-map test_1 deny 10
-    - no description this is test route
+    - no description
     - description this is replaced route
     - match ip flowspec dest-pfx test_acl_1 test_acl_2
     - no match ip next-hop prefix-list test_1_new test_2_new

--- a/tests/integration/targets/ios_user/tests/cli/basic.yaml
+++ b/tests/integration/targets/ios_user/tests/cli/basic.yaml
@@ -178,7 +178,7 @@
   register: result_purge
   cisco.ios.ios_user:
     aggregate:
-      - name: cisco
+      - name: "{{ ansible_user }}"
     purge: true
 
 - ansible.builtin.assert:

--- a/tests/unit/modules/network/ios/test_ios_route_maps.py
+++ b/tests/unit/modules/network/ios/test_ios_route_maps.py
@@ -328,7 +328,7 @@ class TestIosRouteMapsModule(TestIosModule):
         )
         commands = [
             "route-map test_1 deny 10",
-            "no description this is test",
+            "no description",
             "continue 20",
             "description this is replace test",
             "match community new_replace exact-match",
@@ -541,7 +541,7 @@ class TestIosRouteMapsModule(TestIosModule):
         )
         commands = [
             "route-map test_1 deny 10",
-            "no description this is test",
+            "no description",
             "continue 20",
             "description this is override test",
             "match community new_override exact-match",


### PR DESCRIPTION
##### SUMMARY

bugfixes:
  - ios_route_maps - Fixes an issue where 'no description value' is an invalid command on the latest devices.

trivial:
  - ios_lldp_interfaces - Fix upstream CI failure due to difference in interface values.
  - ios_interfaces - Fix upstream CI failure due to difference in interface values.
  - ios_user - Fixes ios_user purging the ssh user running the test.
  - ios_ospf_interfaces - Fix upstream CI failure due to difference in interface values.



##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test fixes

