### PR TITLE
Fixes ipv6 remark parsing in older device

### DIFF
--- a/plugins/module_utils/network/ios/facts/acls/acls.py
+++ b/plugins/module_utils/network/ios/facts/acls/acls.py
@@ -235,7 +235,7 @@ class AclsFacts(object):
 
             for each in temp_v6:
                 if each.get("aces"):
-                    # each["aces"] = collect_remarks(each.get("aces"))
+                    each["aces"] = collect_remarks(each.get("aces"))
                     process_protocol_options(each)
 
         objs = []

--- a/tests/unit/modules/network/ios/test_ios_acls.py
+++ b/tests/unit/modules/network/ios/test_ios_acls.py
@@ -2303,3 +2303,56 @@ class TestIosAclsModule(TestIosModule):
             "no ip access-list extended test_acl",
         ]
         self.assertEqual(sorted(result["commands"]), sorted(commands))
+
+
+    def test_ios_merged_general(self):
+        self.execute_show_command.return_value = dedent(
+            """\
+            ipv6 access-list extended std_acl_name_test_1
+                10 remark std_acl_name_test_1
+                20 permit 220 any any
+            """,
+        )
+        self.execute_show_command_name.return_value = dedent("")
+        set_module_args(
+            dict(
+                config=[
+                    {
+                        "afi": "ipv6",
+                        "acls": [
+                            {
+                                "name": "std_acl_name_test_1",
+                                "acl_type": "extended",
+                                "aces": [
+                                    {
+                                        "remarks": [
+                                            "Test_ipv4_ipv6_acl"
+                                        ]
+                                    },
+                                    {
+                                        "destination": {
+                                            "any": True
+                                        },
+                                        "grant": "permit",
+                                        "protocol": 220,
+                                        "sequence": 40,
+                                        "source": {
+                                            "any": True
+                                        }
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                state="merged",
+            ),
+        )
+
+        result = self.execute_module(changed=True)
+        commands = [
+                "ipv6 access-list std_acl_name_test_1",
+                "permit 220 any any sequence 40",
+                "remark Test_ipv4_ipv6_acl"     
+            ]
+        self.assertEqual(result["commands"], commands)


### PR DESCRIPTION
##### SUMMARY
Fixes ipv6 remark parsing/processing in older device

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
- ios_acls.py

##### ADDITIONAL INFORMATION

The cisco.ios.ios_acls module errors out when adding a remark to an IPv6 ACL ACE. This happens because the module does not properly process IPv6 ACL remarks, leading to unsupported parameters (is_remark_for, order, the_remark). The issue occurs specifically when an IPv6 ACL with a remark exists on the device.

Example:

Initial config in device causing error:
```
 ipv6 access-list extended std_acl_name_test_1
     10 remark std_acl_name_test_1
     20 permit 220 any any
```
run play:
```yaml
- name: Ios acls test
  hosts: all
  gather_facts: False
  tasks:
    - name: Add ACL
      cisco.ios.ios_acls:
        config:
          - afi: ipv6
            acls:
              - name: new_test
                acl_type: extended
                aces:
                  - remarks:
                      - "Test_ipv4_ipv6_acl"
                  - destination:
                      any: true
                    grant: permit
                    protocol: 220
                    sequence: 40
                    source:
                      any: true
        state: merged
```

error:
```yaml
ASK [Add ACL] ************************************************************************************************** fatal: [3850-01]: 
FAILED! => {   
 "changed": false,  
 "msg": "Unsupported parameters for (basic.py) module: config.acls.aces.is_remark_for, config.acls.aces.order, config.acls.aces.the_remark. Supported parameters include: destination, dscp, enable_fragments, evaluate, grant, log, log_input, option, precedence, protocol, protocol_options, remarks, sequence, source, time_range, tos, ttl." 
}
```

Fix:
There was a line commented that was supposed to process the ipv6 remartks which is now uncommented