### PR TITLE
Support `ansible_net_model` for Rockwell / Allen-Bradley Cisco Switches

### DIFF
--- a/plugins/cliconf/ios.py
+++ b/plugins/cliconf/ios.py
@@ -433,6 +433,7 @@ class Cliconf(CliconfBase):
                 device_info["network_os_version"] = match.group(1).strip(",")
 
             model_search_strs = [
+                r"^[Aa]llen[ -][Bb]radley (.+) \(revision",
                 r"^[Cc]isco (.+) \(revision",
                 r"^[Cc]isco (\S+).+bytes of .*memory",
             ]


### PR DESCRIPTION
##### SUMMARY

* Rockwell through Allen-Bradley sell switches that run Cisco IOS like the Stratix 5800 series. This adds support for their model numbers to be detected.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME

ios_facts

##### ADDITIONAL INFORMATION

> `show version` from a Stratix 5800

```
...
Allen-Bradley 1783-MMS10AR (ARM) processor (revision V03)
...
```

> `show version` from a Cisco IE3400

```
cisco IE-3400-8T2S (ARM) processor (revision V06)
```