### PR TITLE
[bgp_address_family] Quick fix bgp_address_family, configuration of `neighbor {{ip}} as-override split-horizon` 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,4 @@ venv.bak/
 .DS_Store
 
 changelogs/.plugin-cache.yaml
+.ansible/.lock

--- a/changelogs/fragments/bgp_add_fam_qfix.yaml
+++ b/changelogs/fragments/bgp_add_fam_qfix.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "ios_bgp_address_family - fix configuration of neighbor's as-override split-horizon."

--- a/plugins/module_utils/network/ios/rm_templates/bgp_address_family.py
+++ b/plugins/module_utils/network/ios/rm_templates/bgp_address_family.py
@@ -1048,15 +1048,27 @@ class Bgp_address_familyTemplate(NetworkTemplate):
             "name": "as_override",
             "getval": re.compile(
                 r"""
-                \s\sneighbor\s(?P<neighbor_address>\S+)\sas-override
+                \s\sneighbor\s(?P<neighbor_address>\S+)
+                (\s(?P<set>as-override))
+                (\s(?P<split_horizon>split-horizon))?
                 $""",
                 re.VERBOSE,
             ),
             "setval": "neighbor {{ neighbor_address }}"
-            "{{ (' as-override') if as_override|d(False) else '' }}",
+            "{{ (' as-override') if as_override|d(False) else '' }}"
+            "{{ (' split-horizon') if as_override.split_horizon|d(False) else '' }}",
             "result": {
                 "address_family": {
-                    UNIQUE_AFI: {"neighbors": {UNIQUE_NEIB_ADD: {"as_override": True}}},
+                    UNIQUE_AFI: {
+                        "neighbors": {
+                            UNIQUE_NEIB_ADD: {
+                                "as_override": {
+                                    "set": "{{ not not set }}",
+                                    "split_horizon": "{{ not not split_horizon }}",
+                                },
+                            },
+                        },
+                    },
                 },
             },
         },

--- a/tests/unit/modules/network/ios/test_ios_bgp_address_family.py
+++ b/tests/unit/modules/network/ios/test_ios_bgp_address_family.py
@@ -240,6 +240,7 @@ class TestIosBgpAddressFamilyModule(TestIosModule):
               neighbor 198.51.100.1 next-hop-self all
               neighbor 198.51.100.1 aigp send cost-community 100 poi igp-cost transitive
               neighbor 198.51.100.1 route-server-client
+              neighbor 198.51.100.1 as-override split-horizon
               neighbor 198.51.100.1 prefix-list AS65100-PREFIX-OUT out
               neighbor 198.51.100.1 slow-peer detection threshold 150
               neighbor 198.51.100.1 route-map test-out out
@@ -662,6 +663,7 @@ class TestIosBgpAddressFamilyModule(TestIosModule):
               neighbor 198.51.100.1 local-as 20
               neighbor 198.51.100.1 activate
               neighbor 198.51.100.1 next-hop-self all
+              neighbor 198.51.100.1 as-override split-horizon
               neighbor 198.51.100.1 aigp send cost-community 100 poi igp-cost transitive
               neighbor 198.51.100.1 route-server-client
               neighbor 198.51.100.1 prefix-list AS65100-PREFIX-OUT out
@@ -728,6 +730,7 @@ class TestIosBgpAddressFamilyModule(TestIosModule):
                                 dict(
                                     activate=True,
                                     address="198.51.100.1",
+                                    as_override=dict(set=True, split_horizon=True),
                                     aigp=dict(
                                         send=dict(
                                             cost_community=dict(
@@ -963,6 +966,7 @@ class TestIosBgpAddressFamilyModule(TestIosModule):
                                 dict(
                                     activate=True,
                                     address="198.51.100.1",
+                                    as_override=dict(set=True, split_horizon=True),
                                     aigp=dict(
                                         send=dict(
                                             cost_community=dict(
@@ -1035,6 +1039,7 @@ class TestIosBgpAddressFamilyModule(TestIosModule):
             "neighbor 198.51.100.1 activate",
             "neighbor 198.51.100.1 aigp send cost-community 100 poi igp-cost transitive",
             "neighbor 198.51.100.1 route-map test-route out",
+            "neighbor 198.51.100.1 as-override split-horizon",
             "neighbor 198.51.100.1 route-server-client",
             "neighbor 198.51.100.1 slow-peer detection threshold 150",
             "network 198.51.110.10 mask 255.255.255.255 backdoor",


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fix the configuration of  `neighbor {{ip}} as-override split-horizon` 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios_bgp_address_family

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
