### PR TITLE
Fix wrong parsing of commands and wrong command generation

### DIFF
--- a/changelogs/fragments/fix_acls.yml
+++ b/changelogs/fragments/fix_acls.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "ios_acls - Fix issue where commands were not being parsed correctly and incorrect commands were being generated."

--- a/plugins/module_utils/network/ios/rm_templates/acls.py
+++ b/plugins/module_utils/network/ios/rm_templates/acls.py
@@ -33,15 +33,21 @@ def remarks_with_sequence(remarks_data):
 
 def _tmplt_access_list_entries(aces):
     def source_destination_common_config(config_data, command, attr):
+        if config_data[attr].get("any") and attr == "destination":
+            command += " any"
+            source_host = config_data.get("source").get("host") or config_data.get("source").get("address")
+            source_object = config_data.get("source").get("object_group")
+            source_any = config_data.get("source").get("any")
+            if not source_host and not source_any and not source_object:
+                command += " any"
+
         if config_data[attr].get("address"):
             command += " {address}".format(**config_data[attr])
             if config_data[attr].get("wildcard_bits"):
                 command += " {wildcard_bits}".format(**config_data[attr])
-        elif config_data[attr].get("any"):
-            command += " any".format(**config_data[attr])
         elif config_data[attr].get("host"):
             command += " host {host}".format(**config_data[attr])
-        elif config_data[attr].get("object_group"):
+        if config_data[attr].get("object_group"):
             command += " object-group {object_group}".format(**config_data[attr])
         if config_data[attr].get("port_protocol"):
             if config_data[attr].get("port_protocol").get("range"):
@@ -55,6 +61,9 @@ def _tmplt_access_list_entries(aces):
                     port_proto_type,
                     config_data[attr]["port_protocol"][port_proto_type],
                 )
+
+        if config_data[attr].get("any") and attr == "source":
+            command += " any"
         return command
 
     command = ""
@@ -272,6 +281,44 @@ class AclsTemplate(NetworkTemplate):
                                     "any": "{{ not not any }}",
                                 },
                                 "log": {"set": "{{ not not log }}"},
+                            },
+                        ],
+                    },
+                },
+            },
+        },
+        {   
+            "name": "aces_source_dest_any",
+            "getval": re.compile(
+                r"""
+                ^\s*((?P<sequence>\d+))?
+                (\s(?P<grant>deny|permit))
+                ((\s*object-group\s(?P<source_obj_grp>\S+))|
+                (\s*host\s(?P<source_host>\S+))|
+                (\s*(?P<ipv6_source_address>\S+/\d+))|
+                (\s*(?P<source_address>(\d{1,3}.\d{1,3}.\d{1,3}.\d{1,3})\s\S+)))?
+                (\s*(?P<source_any>any))
+                (\s*(?P<dest_any>any))
+                $""",
+                re.VERBOSE,
+            ),
+            "compval": "aces",
+            "result": {
+                "acls": {
+                    "{{ acl_name|d() }}": {
+                        "name": "{{ acl_name }}",
+                        "aces": [
+                            {
+                                "sequence": "{{ sequence }}",
+                                "grant": "{{ grant }}",
+                                "source": {
+                                    "address": "{{ source_address }}",
+                                    "ipv6_address": "{{ ipv6_source_address }}",
+                                    "any": "{{ not not source_any }}",
+                                    "host": "{{ source_host }}",
+                                    "object_group": "{{ source_obj_grp }}",
+                                },
+                                "destination": {"any": "{{ not not dest_any }}"},
                             },
                         ],
                     },

--- a/plugins/module_utils/network/ios/rm_templates/acls.py
+++ b/plugins/module_utils/network/ios/rm_templates/acls.py
@@ -36,7 +36,7 @@ def _tmplt_access_list_entries(aces):
         if config_data[attr].get("any") and attr == "destination":
             command += " any"
             source_host = config_data.get("source").get("host") or config_data.get("source").get(
-                "address"
+                "address",
             )
             source_object = config_data.get("source").get("object_group")
             source_any = config_data.get("source").get("any")

--- a/plugins/module_utils/network/ios/rm_templates/acls.py
+++ b/plugins/module_utils/network/ios/rm_templates/acls.py
@@ -35,7 +35,9 @@ def _tmplt_access_list_entries(aces):
     def source_destination_common_config(config_data, command, attr):
         if config_data[attr].get("any") and attr == "destination":
             command += " any"
-            source_host = config_data.get("source").get("host") or config_data.get("source").get("address")
+            source_host = config_data.get("source").get("host") or config_data.get("source").get(
+                "address"
+            )
             source_object = config_data.get("source").get("object_group")
             source_any = config_data.get("source").get("any")
             if not source_host and not source_any and not source_object:
@@ -287,7 +289,7 @@ class AclsTemplate(NetworkTemplate):
                 },
             },
         },
-        {   
+        {
             "name": "aces_source_dest_any",
             "getval": re.compile(
                 r"""

--- a/plugins/module_utils/network/ios/rm_templates/acls.py
+++ b/plugins/module_utils/network/ios/rm_templates/acls.py
@@ -34,7 +34,7 @@ def remarks_with_sequence(remarks_data):
 def _tmplt_access_list_entries(aces):
     def source_destination_common_config(config_data, command, attr):
         source_host = config_data.get("source").get("host") or config_data.get("source").get(
-                "address",
+            "address",
         )
         source_port_protocol = config_data.get("source").get("port_protocol")
         any_source_used = False
@@ -42,7 +42,12 @@ def _tmplt_access_list_entries(aces):
             command += " any"
             source_object = config_data.get("source").get("object_group")
             source_any = config_data.get("source").get("any")
-            if not source_host and not source_any and not source_object and not source_port_protocol:
+            if (
+                not source_host
+                and not source_any
+                and not source_object
+                and not source_port_protocol
+            ):
                 command += " any"
 
         if config_data[attr].get("address"):
@@ -55,10 +60,10 @@ def _tmplt_access_list_entries(aces):
             command += " object-group {object_group}".format(**config_data[attr])
         if config_data[attr].get("port_protocol"):
             if (
-                    source_port_protocol and 
-                    not source_host and 
-                    config_data.get("source").get("any") and
-                    attr == "source"
+                source_port_protocol
+                and not source_host
+                and config_data.get("source").get("any")
+                and attr == "source"
             ):
                 command += " any"
                 any_source_used = True

--- a/tests/integration/targets/ios_l3_interfaces/tests/cli/_remove_config.yaml
+++ b/tests/integration/targets/ios_l3_interfaces/tests/cli/_remove_config.yaml
@@ -17,3 +17,16 @@
       - name: Vlan901
       - name: Vlan902
     state: purged
+
+- name: Delete attributes of all configured interfaces
+  register: result
+  cisco.ios.ios_interfaces:
+    config:
+      - name: Port-channel10
+      - name: Port-channel11
+      - name: Port-channel22
+      - name: Port-channel40
+      - name: Loopback1
+    state: purged
+  retries: 2
+  delay: 10

--- a/tests/integration/targets/ios_vrf_interfaces/tests/common/_remove_config.yaml
+++ b/tests/integration/targets/ios_vrf_interfaces/tests/common/_remove_config.yaml
@@ -43,3 +43,16 @@
 - name: Wait for VRF
   ansible.builtin.wait_for:
     timeout: 2
+
+- name: Delete attributes of all configured interfaces
+  register: result
+  cisco.ios.ios_interfaces:
+    config:
+      - name: Port-channel10
+      - name: Port-channel11
+      - name: Port-channel22
+      - name: Port-channel40
+      - name: Loopback1
+    state: purged
+  retries: 2
+  delay: 10

--- a/tests/unit/modules/network/ios/test_ios_acls.py
+++ b/tests/unit/modules/network/ios/test_ios_acls.py
@@ -38,7 +38,6 @@ class TestIosAclsModule(TestIosModule):
             "AclsFacts.get_acl_names",
         )
         self.execute_show_command_name = self.mock_execute_show_command_name_specific.start()
-        self.maxDiff = None
 
     def tearDown(self):
         super(TestIosAclsModule, self).tearDown()
@@ -1359,7 +1358,6 @@ class TestIosAclsModule(TestIosModule):
             ),
         )
         result = self.execute_module(changed=True, sort=True)
-        print(result)
         cmds = [
             "ip access-list extended 110",
             "no 10 permit tcp 198.51.100.0 0.0.0.255 any eq 22 log testLog",

--- a/tests/unit/modules/network/ios/test_ios_acls.py
+++ b/tests/unit/modules/network/ios/test_ios_acls.py
@@ -1885,12 +1885,12 @@ class TestIosAclsModule(TestIosModule):
                                 "grant": "deny",
                                 "source": {
                                     "any": True,
-                                    "object_group": "deny-mgmt-ports"
+                                    "object_group": "deny-mgmt-ports",
                                 },
                                 "destination": {
-                                    "any": True
+                                    "any": True,
                                 },
-                            }
+                            },
                         ],
                     },
                 ],
@@ -2373,8 +2373,9 @@ class TestIosAclsModule(TestIosModule):
     def test_ios_parsed_complex_2(self):
         self.execute_show_command_name.return_value = dedent("")
         set_module_args(
-            dict(running_config=dedent(
-                """\
+            dict(
+                running_config=dedent(
+                    """\
                 ip access-list extended CP_Quarantine-v4-in
                     10 permit udp any object-group FAA-Networks eq bootps
                     20 permit object-group BT-ports any object-group AIT-BT-Servers
@@ -2390,151 +2391,150 @@ class TestIosAclsModule(TestIosModule):
                 """,
                 ),
                 state="parsed",
-            )
+            ),
         )
         result = self.execute_module(changed=False)
         parsed_list = [
             {
-            "acls": [
-                {
-                "aces": [
+                "acls": [
                     {
-                    "source": {
-                        "any": True
-                    }, 
-                    "destination": {
-                        "object_group": "FAA-Networks", 
-                        "port_protocol": {
-                        "eq": "bootps"
-                        }
-                    }, 
-                    "protocol": "udp", 
-                    "grant": "permit", 
-                    "sequence": 10
-                    }, 
-                    {
-                    "source": {
-                        "object_group": "BT-ports"
-                    }, 
-                    "destination": {
-                        "any": True, 
-                        "object_group": "AIT-BT-Servers"
-                    }, 
-                    "grant": "permit", 
-                    "sequence": 20
-                    }, 
-                    {
-                    "source": {
-                        "any": True
-                    }, 
-                    "destination": {
-                        "object_group": "CP-Appliances", 
-                        "port_protocol": {
-                        "eq": "443"
-                        }
-                    }, 
-                    "protocol": "tcp", 
-                    "grant": "permit", 
-                    "sequence": 30
-                    }, 
-                    {
-                        "source": {
-                            "any": True,
-                            "object_group": "deny-mgmt-ports"
-                        }, 
-                        "destination": {
-                            "any": True
-                        }, 
-                        "grant": "deny", 
-                        "sequence": 40
-                    }, 
-                    {
-                    "source": {
-                        "object_group": "icmp"
-                    }, 
-                    "destination": {
-                        "any": True, 
-                        "object_group": "IB-Servers"
-                    }, 
-                    "grant": "permit", 
-                    "sequence": 50
-                    }, 
-                    {
-                    "source": {
-                        "object_group": "generic-any-port"
-                    }, 
-                    "destination": {
-                        "any": True, 
-                        "object_group": "IB-Servers"
-                    }, 
-                    "grant": "permit", 
-                    "sequence": 60
-                    }, 
-                    {
-                    "source": {
-                        "object_group": "generic-any-port"
-                    }, 
-                    "destination": {
-                        "any": True, 
-                        "object_group": "AD-Servers"
-                    }, 
-                    "grant": "permit", 
-                    "sequence": 70
-                    }, 
-                    {
-                    "source": {
-                        "object_group": "generic-any-port"
-                    }, 
-                    "destination": {
-                        "any": True, 
-                        "object_group": "CP-Appliances"
-                    }, 
-                    "grant": "permit", 
-                    "sequence": 80
-                    }, 
-                    {
-                    "source": {
-                        "object_group": "generic-any-port"
-                    }, 
-                    "destination": {
-                        "any": True, 
-                        "object_group": "Tanium-Servers"
-                    }, 
-                    "grant": "permit", 
-                    "sequence": 90
-                    }, 
-                    {
-                    "source": {
-                        "object_group": "generic-any-port"
-                    }, 
-                    "destination": {
-                        "any": True, 
-                        "object_group": "SOC-Tenable-Servers"
-                    }, 
-                    "grant": "permit", 
-                    "sequence": 100
-                    }, 
-                    {
-                        "source": {
-                            "any": True
-                        }, 
-                        "destination": {
-                            "any": True
-                        }, 
-                        "protocol": "ip", 
-                        "grant": "deny", 
-                        "sequence": 5000
-                    }
-                ], 
-                "acl_type": "extended", 
-                "name": "CP_Quarantine-v4-in"
-                }
-            ], 
-            "afi": "ipv4"
-            }
+                        "aces": [
+                            {
+                                "source": {
+                                    "any": True,
+                                },
+                                "destination": {
+                                    "object_group": "FAA-Networks",
+                                    "port_protocol": {
+                                        "eq": "bootps",
+                                    },
+                                },
+                                "protocol": "udp",
+                                "grant": "permit",
+                                "sequence": 10,
+                            },
+                            {
+                                "source": {
+                                    "object_group": "BT-ports",
+                                },
+                                "destination": {
+                                    "any": True,
+                                    "object_group": "AIT-BT-Servers",
+                                },
+                                "grant": "permit",
+                                "sequence": 20,
+                            },
+                            {
+                                "source": {
+                                    "any": True,
+                                },
+                                "destination": {
+                                    "object_group": "CP-Appliances",
+                                    "port_protocol": {
+                                        "eq": "443",
+                                    },
+                                },
+                                "protocol": "tcp",
+                                "grant": "permit",
+                                "sequence": 30,
+                            },
+                            {
+                                "source": {
+                                    "any": True,
+                                    "object_group": "deny-mgmt-ports",
+                                },
+                                "destination": {
+                                    "any": True,
+                                },
+                                "grant": "deny",
+                                "sequence": 40,
+                            },
+                            {
+                                "source": {
+                                    "object_group": "icmp",
+                                },
+                                "destination": {
+                                    "any": True,
+                                    "object_group": "IB-Servers",
+                                },
+                                "grant": "permit",
+                                "sequence": 50,
+                            },
+                            {
+                                "source": {
+                                    "object_group": "generic-any-port",
+                                },
+                                "destination": {
+                                    "any": True,
+                                    "object_group": "IB-Servers",
+                                },
+                                "grant": "permit",
+                                "sequence": 60,
+                            },
+                            {
+                                "source": {
+                                    "object_group": "generic-any-port",
+                                },
+                                "destination": {
+                                    "any": True,
+                                    "object_group": "AD-Servers",
+                                },
+                                "grant": "permit",
+                                "sequence": 70,
+                            },
+                            {
+                                "source": {
+                                    "object_group": "generic-any-port",
+                                },
+                                "destination": {
+                                    "any": True,
+                                    "object_group": "CP-Appliances",
+                                },
+                                "grant": "permit",
+                                "sequence": 80,
+                            },
+                            {
+                                "source": {
+                                    "object_group": "generic-any-port",
+                                },
+                                "destination": {
+                                    "any": True,
+                                    "object_group": "Tanium-Servers",
+                                },
+                                "grant": "permit",
+                                "sequence": 90,
+                            },
+                            {
+                                "source": {
+                                    "object_group": "generic-any-port",
+                                },
+                                "destination": {
+                                    "any": True,
+                                    "object_group": "SOC-Tenable-Servers",
+                                },
+                                "grant": "permit",
+                                "sequence": 100,
+                            },
+                            {
+                                "source": {
+                                    "any": True,
+                                },
+                                "destination": {
+                                    "any": True,
+                                },
+                                "protocol": "ip",
+                                "grant": "deny",
+                                "sequence": 5000,
+                            },
+                        ],
+                        "acl_type": "extended",
+                        "name": "CP_Quarantine-v4-in",
+                    },
+                ],
+                "afi": "ipv4",
+            },
         ]
         self.assertEqual(parsed_list, result["parsed"])
-
 
     def test_ios_merged_general_2(self):
         self.execute_show_command.return_value = dedent(
@@ -2573,24 +2573,24 @@ class TestIosAclsModule(TestIosModule):
                                     },
                                     {
                                         "source": {
-                                            "any": True
-                                        }, 
+                                            "any": True,
+                                        },
                                         "destination": {
-                                            "any": True
-                                        }, 
-                                        "protocol": "ip", 
+                                            "any": True,
+                                        },
+                                        "protocol": "ip",
                                         "grant": "deny",
-                                    }, 
+                                    },
                                     {
                                         "source": {
                                             "any": True,
-                                            "object_group": "deny-mgmt-ports"
-                                        }, 
+                                            "object_group": "deny-mgmt-ports",
+                                        },
                                         "destination": {
-                                            "any": True
-                                        }, 
+                                            "any": True,
+                                        },
                                         "grant": "deny",
-                                    }
+                                    },
                                 ],
                             },
                         ],
@@ -2606,6 +2606,6 @@ class TestIosAclsModule(TestIosModule):
             "permit 220 any any sequence 40",
             "remark Test_ipv4_ipv6_acl",
             "deny object-group deny-mgmt-ports any any",
-            "deny ip any any"
+            "deny ip any any",
         ]
         self.assertEqual(sorted(result["commands"]), sorted(commands))

--- a/tests/unit/modules/network/ios/test_ios_acls.py
+++ b/tests/unit/modules/network/ios/test_ios_acls.py
@@ -38,6 +38,7 @@ class TestIosAclsModule(TestIosModule):
             "AclsFacts.get_acl_names",
         )
         self.execute_show_command_name = self.mock_execute_show_command_name_specific.start()
+        self.maxDiff = None
 
     def tearDown(self):
         super(TestIosAclsModule, self).tearDown()
@@ -1358,6 +1359,7 @@ class TestIosAclsModule(TestIosModule):
             ),
         )
         result = self.execute_module(changed=True, sort=True)
+        print(result)
         cmds = [
             "ip access-list extended 110",
             "no 10 permit tcp 198.51.100.0 0.0.0.255 any eq 22 log testLog",
@@ -1686,6 +1688,7 @@ class TestIosAclsModule(TestIosModule):
                         20 permit tcp host 10.1.1.1 host 10.5.5.5 eq www
                         30 permit icmp any any
                         40 permit udp host 10.6.6.6 10.10.10.0 0.0.0.255 eq domain
+                        50 deny object-group deny-mgmt-ports any any
                     """,
                 ),
                 state="parsed",
@@ -1877,6 +1880,17 @@ class TestIosAclsModule(TestIosModule):
                                     "wildcard_bits": "0.0.0.255",
                                 },
                             },
+                            {
+                                "sequence": 50,
+                                "grant": "deny",
+                                "source": {
+                                    "any": True,
+                                    "object_group": "deny-mgmt-ports"
+                                },
+                                "destination": {
+                                    "any": True
+                                },
+                            }
                         ],
                     },
                 ],

--- a/tests/unit/modules/network/ios/test_ios_acls.py
+++ b/tests/unit/modules/network/ios/test_ios_acls.py
@@ -2369,3 +2369,243 @@ class TestIosAclsModule(TestIosModule):
             "remark Test_ipv4_ipv6_acl",
         ]
         self.assertEqual(sorted(result["commands"]), sorted(commands))
+
+    def test_ios_parsed_complex_2(self):
+        self.execute_show_command_name.return_value = dedent("")
+        set_module_args(
+            dict(running_config=dedent(
+                """\
+                ip access-list extended CP_Quarantine-v4-in
+                    10 permit udp any object-group FAA-Networks eq bootps
+                    20 permit object-group BT-ports any object-group AIT-BT-Servers
+                    30 permit tcp any object-group CP-Appliances eq 443
+                    40 deny object-group deny-mgmt-ports any any
+                    50 permit object-group icmp any object-group IB-Servers
+                    60 permit object-group generic-any-port any object-group IB-Servers
+                    70 permit object-group generic-any-port any object-group AD-Servers
+                    80 permit object-group generic-any-port any object-group CP-Appliances
+                    90 permit object-group generic-any-port any object-group Tanium-Servers
+                    100 permit object-group generic-any-port any object-group SOC-Tenable-Servers
+                    5000 deny ip any any
+                """,
+                ),
+                state="parsed",
+            )
+        )
+        result = self.execute_module(changed=False)
+        parsed_list = [
+            {
+            "acls": [
+                {
+                "aces": [
+                    {
+                    "source": {
+                        "any": True
+                    }, 
+                    "destination": {
+                        "object_group": "FAA-Networks", 
+                        "port_protocol": {
+                        "eq": "bootps"
+                        }
+                    }, 
+                    "protocol": "udp", 
+                    "grant": "permit", 
+                    "sequence": 10
+                    }, 
+                    {
+                    "source": {
+                        "object_group": "BT-ports"
+                    }, 
+                    "destination": {
+                        "any": True, 
+                        "object_group": "AIT-BT-Servers"
+                    }, 
+                    "grant": "permit", 
+                    "sequence": 20
+                    }, 
+                    {
+                    "source": {
+                        "any": True
+                    }, 
+                    "destination": {
+                        "object_group": "CP-Appliances", 
+                        "port_protocol": {
+                        "eq": "443"
+                        }
+                    }, 
+                    "protocol": "tcp", 
+                    "grant": "permit", 
+                    "sequence": 30
+                    }, 
+                    {
+                        "source": {
+                            "any": True,
+                            "object_group": "deny-mgmt-ports"
+                        }, 
+                        "destination": {
+                            "any": True
+                        }, 
+                        "grant": "deny", 
+                        "sequence": 40
+                    }, 
+                    {
+                    "source": {
+                        "object_group": "icmp"
+                    }, 
+                    "destination": {
+                        "any": True, 
+                        "object_group": "IB-Servers"
+                    }, 
+                    "grant": "permit", 
+                    "sequence": 50
+                    }, 
+                    {
+                    "source": {
+                        "object_group": "generic-any-port"
+                    }, 
+                    "destination": {
+                        "any": True, 
+                        "object_group": "IB-Servers"
+                    }, 
+                    "grant": "permit", 
+                    "sequence": 60
+                    }, 
+                    {
+                    "source": {
+                        "object_group": "generic-any-port"
+                    }, 
+                    "destination": {
+                        "any": True, 
+                        "object_group": "AD-Servers"
+                    }, 
+                    "grant": "permit", 
+                    "sequence": 70
+                    }, 
+                    {
+                    "source": {
+                        "object_group": "generic-any-port"
+                    }, 
+                    "destination": {
+                        "any": True, 
+                        "object_group": "CP-Appliances"
+                    }, 
+                    "grant": "permit", 
+                    "sequence": 80
+                    }, 
+                    {
+                    "source": {
+                        "object_group": "generic-any-port"
+                    }, 
+                    "destination": {
+                        "any": True, 
+                        "object_group": "Tanium-Servers"
+                    }, 
+                    "grant": "permit", 
+                    "sequence": 90
+                    }, 
+                    {
+                    "source": {
+                        "object_group": "generic-any-port"
+                    }, 
+                    "destination": {
+                        "any": True, 
+                        "object_group": "SOC-Tenable-Servers"
+                    }, 
+                    "grant": "permit", 
+                    "sequence": 100
+                    }, 
+                    {
+                        "source": {
+                            "any": True
+                        }, 
+                        "destination": {
+                            "any": True
+                        }, 
+                        "protocol": "ip", 
+                        "grant": "deny", 
+                        "sequence": 5000
+                    }
+                ], 
+                "acl_type": "extended", 
+                "name": "CP_Quarantine-v4-in"
+                }
+            ], 
+            "afi": "ipv4"
+            }
+        ]
+        self.assertEqual(parsed_list, result["parsed"])
+
+
+    def test_ios_merged_general_2(self):
+        self.execute_show_command.return_value = dedent(
+            """\
+            ipv6 access-list extended std_acl_name_test_1
+                10 remark std_acl_name_test_1
+                20 permit 220 any any
+            """,
+        )
+        self.execute_show_command_name.return_value = dedent("")
+        set_module_args(
+            dict(
+                config=[
+                    {
+                        "afi": "ipv6",
+                        "acls": [
+                            {
+                                "name": "std_acl_name_test_1",
+                                "acl_type": "extended",
+                                "aces": [
+                                    {
+                                        "remarks": [
+                                            "Test_ipv4_ipv6_acl",
+                                        ],
+                                    },
+                                    {
+                                        "destination": {
+                                            "any": True,
+                                        },
+                                        "grant": "permit",
+                                        "protocol": 220,
+                                        "sequence": 40,
+                                        "source": {
+                                            "any": True,
+                                        },
+                                    },
+                                    {
+                                        "source": {
+                                            "any": True
+                                        }, 
+                                        "destination": {
+                                            "any": True
+                                        }, 
+                                        "protocol": "ip", 
+                                        "grant": "deny",
+                                    }, 
+                                    {
+                                        "source": {
+                                            "any": True,
+                                            "object_group": "deny-mgmt-ports"
+                                        }, 
+                                        "destination": {
+                                            "any": True
+                                        }, 
+                                        "grant": "deny",
+                                    }
+                                ],
+                            },
+                        ],
+                    },
+                ],
+                state="merged",
+            ),
+        )
+
+        result = self.execute_module(changed=True)
+        commands = [
+            "ipv6 access-list std_acl_name_test_1",
+            "permit 220 any any sequence 40",
+            "remark Test_ipv4_ipv6_acl",
+            "deny object-group deny-mgmt-ports any any",
+            "deny ip any any"
+        ]
+        self.assertEqual(sorted(result["commands"]), sorted(commands))


### PR DESCRIPTION
### Summary

Fix issues with the `cisco.ios.ios_acls` Ansible module when applying an acl. The module incorrectly parses certain ACL configuration attributes. The module also incorrectly generates certain commands, this PR aims to fix the above

### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- `ios_acls`

### ADDITIONAL INFORMATION

#### Issue 1 - Incorrect parsing:
```yaml
running_config: |-
  !
  ip access-list extended CP_Quarantine-v4-in
   10 permit udp any object-group FAA-Networks eq bootps
   20 permit object-group BT-ports any object-group AIT-BT-Servers
   30 permit tcp any object-group CP-Appliances eq 443
   40 deny   object-group deny-mgmt-ports any any
   50 permit object-group icmp any object-group IB-Servers
   60 permit object-group generic-any-port any object-group IB-Servers
   70 permit object-group generic-any-port any object-group AD-Servers
   80 permit object-group generic-any-port any object-group CP-Appliances
   90 permit object-group generic-any-port any object-group Tanium-Servers
   100 permit object-group generic-any-port any object-group SOC-Tenable-Servers
   5000 deny   ip any any
  !
state: parsed
```

In the above it incorrectly parses any command with double `any`


#### Issue 2 - Incorrect command generation:

Incorrectly generated such commands
```sh
permit object-group generic-any-port any object-group AD-Servers
permit object-group generic-any-port any object-group CP-Appliances
permit object-group generic-any-port any object-group Tanium-Servers
deny  ip any any
```

Incorrectly generates anything to do with both source and destination object group, and also incorrect generation when having multiple `any`

This PR includes tests. And also has been tested against a cisco device

