### PR TITLE
Fix state handling and AF parsing in ios_bgp_address_family

### DIFF
--- a/changelogs/fragments/bgp_address_family.yaml
+++ b/changelogs/fragments/bgp_address_family.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - ios_bgp_address_family - Refined state handling for `replaced` and `overridden` modes and enhanced address-family parsing to accurately differentiate between types such as unicast, multicast, and others.

--- a/tests/integration/targets/ios_bgp_address_family/tests/cli/_parsed.cfg
+++ b/tests/integration/targets/ios_bgp_address_family/tests/cli/_parsed.cfg
@@ -4,7 +4,7 @@ router bgp 65536
  neighbor 198.51.110.212 remote-as 65536
  neighbor 198.51.110.206 remote-as 65536
  !
- address-family ipv4
+ address-family ipv4 unicast
   network 192.0.2.0
   network 192.0.3.0
   network 192.0.4.0

--- a/tests/integration/targets/ios_bgp_address_family/tests/cli/_populate_config.yaml
+++ b/tests/integration/targets/ios_bgp_address_family/tests/cli/_populate_config.yaml
@@ -8,16 +8,29 @@
       - ip routing
       - ipv6 unicast-routing
 
+- name: Configure BGP neighbors using ios_config
+  cisco.ios.ios_config:
+    lines:
+      - router bgp 65000
+      - neighbor 10.1.1.1 remote-as 100
+      - neighbor 10.1.1.2 remote-as 200
+      - neighbor 10.1.1.3 remote-as 200
+
 - name: Populate BGP address family configuration
   cisco.ios.ios_bgp_address_family:
     config:
-      as_number: 65000
+      as_number: "65000"
       address_family:
         - afi: ipv4
           safi: multicast
-          # vrf: blue  # commented as c8000v throws topology error
+          neighbors:
+            - neighbor_address: "10.1.1.1"
+              activate: true
           aggregate_address:
             - address: 192.0.2.1
+              netmask: 255.255.255.255
+              as_confed_set: true
+            - address: 192.0.3.1
               netmask: 255.255.255.255
               as_confed_set: true
           bgp:
@@ -30,26 +43,21 @@
             slow_peer:
               - detection:
                   threshold: 150
-          neighbor:
-            - address: 198.51.100.1
-              aigp:
-                send:
-                  cost_community:
-                    id: 100
-                    poi:
-                      igp_cost: true
-                      transitive: true
-              slow_peer:
-                - detection:
-                    threshold: 150
-              remote_as: 10
-              route_maps:
-                - name: test-route
-                  out: true
           network:
             - address: 198.51.110.10
               mask: 255.255.255.255
               backdoor: true
+            - address: 198.51.111.11
+              mask: 255.255.255.255
+              route_map: test
+          default_metric: 12
+          distance:
+            external: 10
+            internal: 10
+            local: 100
+          table_map:
+            name: test_tableMap
+            filter: true
         - afi: ipv4
           safi: mdt
           bgp:
@@ -60,24 +68,6 @@
               suppress_route_val: 100
               max_suppress: 5
             soft_reconfig_backup: true
-        - afi: ipv4
-          safi: multicast
-          aggregate_address:
-            - address: 192.0.3.1
-              netmask: 255.255.255.255
-              as_confed_set: true
-          default_metric: 12
-          distance:
-            external: 10
-            internal: 10
-            local: 100
-          network:
-            - address: 198.51.111.11
-              mask: 255.255.255.255
-              route_map: test
-          table_map:
-            name: test_tableMap
-            filter: true
         - afi: ipv6
           redistribute:
             - ospf:

--- a/tests/integration/targets/ios_bgp_address_family/tests/cli/overridden.yaml
+++ b/tests/integration/targets/ios_bgp_address_family/tests/cli/overridden.yaml
@@ -50,6 +50,9 @@
                 slow_peer:
                   - detection:
                       threshold: 150
+              neighbors:
+                - neighbor_address: "10.1.1.2"
+                  activate: true
               network:
                 - address: 198.51.110.10
                   mask: 255.255.255.255
@@ -75,11 +78,6 @@
       ansible.builtin.assert:
         that:
           - "{{ overridden['commands'] | symmetric_difference(result['commands']) | length == 0 }}"
-
-    # - name: Assert that after dict is correctly generated
-    #   ansible.builtin.assert:
-    #     that:
-    #       - overridden['after'] == result['after']
 
     - name: Override provided BGP address family configuration (idempotent)
       register: result

--- a/tests/integration/targets/ios_bgp_address_family/tests/cli/replaced.yaml
+++ b/tests/integration/targets/ios_bgp_address_family/tests/cli/replaced.yaml
@@ -34,77 +34,32 @@
                     route_map: foo
             - afi: ipv4
               safi: multicast
-              # vrf: blue
-              aggregate_address:
+              aggregate_addresses:
                 - address: 192.0.2.1
                   netmask: 255.255.255.255
                   as_confed_set: true
               bgp:
                 aggregate_timer: 10
-                dampening:
-                  penalty_half_time: 1
-                  reuse_route_val: 1
-                  suppress_route_val: 1
-                  max_suppress: 1
-                slow_peer:
+                slow_peer: # slow_peer is deprecated, but let's assume module handles it
                   - detection:
                       threshold: 150
-              neighbor:
-                - address: 198.51.110.1
+              neighbors:
+                - neighbor_address: "10.1.1.3"
                   activate: true
-                  aigp:
-                    send:
-                      cost_community:
-                        id: 200
-                        poi:
-                          igp_cost: true
-                          transitive: true
-                  slow_peer:
-                    - detection:
-                        threshold: 150
-                  remote_as: 10
-                  route_maps:
-                    - name: test-replaced-route
-                      out: true
-              network:
+              networks:
                 - address: 198.51.110.10
                   mask: 255.255.255.255
                   backdoor: true
-            - afi: ipv4
-              safi: multicast
-              bgp:
-                aggregate_timer: 10
-                dampening:
-                  penalty_half_time: 10
-                  reuse_route_val: 10
-                  suppress_route_val: 10
-                  max_suppress: 10
-                slow_peer:
-                  - detection:
-                      threshold: 200
-              network:
                 - address: 192.0.2.1
                   mask: 255.255.255.255
                   route_map: test
         state: replaced
 
-    - name: debug merged commands
-      debug:
-        msg: "{{ replaced['after'] }}"
-
-    - name: debug result commands
-      debug:
-        msg: "{{ result['after'] }}"
-
     - name: Assert that correct set of commands were generated
       ansible.builtin.assert:
         that:
-          - "{{ replaced['commands'] | symmetric_difference(result['commands']) | length == 0 }}"
-
-    # - name: Assert that after dict is correctly generated
-    #   ansible.builtin.assert:
-    #     that:
-    #       - replaced['after'] == result['after']
+          - replaced['commands'] | symmetric_difference(result['commands']) | length == 0
+        msg: "FAILED: Commands do not match expected."
 
     - name: Replaced provided BGP address family configuration (idempotent)
       register: result
@@ -114,5 +69,6 @@
       ansible.builtin.assert:
         that:
           - result['changed'] == false
+        msg: "FAILED: Task was not idempotent."
   always:
     - ansible.builtin.include_tasks: _remove_config.yaml

--- a/tests/integration/targets/ios_bgp_address_family/vars/main.yaml
+++ b/tests/integration/targets/ios_bgp_address_family/vars/main.yaml
@@ -2,26 +2,31 @@
 merged:
   before: {}
   commands:
-    - router bgp 65000
-    - address-family ipv4 multicast
-    - default-metric 12
-    - distance bgp 10 10 100
-    - table-map test_tableMap filter
-    - network 198.51.111.11 mask 255.255.255.255 route-map test
-    - aggregate-address 192.0.3.1 255.255.255.255 as-confed-set
-    - address-family ipv6
-    - redistribute ospf 124 metric 10 match internal external 1 external 2 nssa-external 1 nssa-external 2 route-map bar include-connected
-    - address-family ipv4 mdt
-    - bgp dmzlink-bw
-    - bgp soft-reconfig-backup
-    - bgp dampening 1 10 100 5
-    - address-family ipv4
-    - maximum-paths 12
-    - maximum-secondary-paths eibgp 2
-    - redistribute connected metric 10
-    - redistribute ospf 124
-    - redistribute ospf 123 metric 10 match internal external 1 external 2 nssa-external 1 nssa-external 2 route-map bar
-    - redistribute ospfv3 123 metric 10 match internal external 1 external 2 nssa-external 1 nssa-external 2 route-map bar
+  - router bgp 65000
+  - address-family ipv4 unicast
+  - maximum-paths 12
+  - maximum-secondary-paths eibgp 2
+  - redistribute connected metric 10
+  - redistribute ospf 124
+  - redistribute ospf 123 metric 10 match internal external 1 external 2 nssa-external 1 nssa-external 2 route-map bar
+  - redistribute ospfv3 123 metric 10 match internal external 1 external 2 nssa-external 1 nssa-external 2 route-map bar
+  - exit-address-family
+  - address-family ipv4 mdt
+  - bgp dmzlink-bw
+  - bgp soft-reconfig-backup
+  - bgp dampening 1 10 100 5
+  - exit-address-family
+  - address-family ipv4 multicast
+  - default-metric 12
+  - distance bgp 10 10 100
+  - table-map test_tableMap filter
+  - network 198.51.111.11 mask 255.255.255.255 route-map test
+  - aggregate-address 192.0.3.1 255.255.255.255 as-confed-set
+  - exit-address-family
+  - address-family ipv6 unicast
+  - redistribute ospf 124 metric 10 match internal external 1 external 2 nssa-external 1 nssa-external 2 route-map bar include-connected
+  - exit-address-family
+
 
   after:
     address_family:
@@ -119,36 +124,39 @@ merged:
 
 overridden:
   commands:
-    - router bgp 65000
-    - address-family ipv4 mdt
-    - no bgp dmzlink-bw
-    - no bgp soft-reconfig-backup
-    - no bgp dampening 1 10 100 5
-    - address-family ipv6
-    - no redistribute ospf 124
-    - address-family ipv4
-    - no redistribute connected
-    - no redistribute ospf 123
-    - redistribute ospf 123 metric 15 match external 1 nssa-external 2 route-map foo
-    - no redistribute ospf 124
-    - no redistribute ospfv3 123
-    - redistribute ospfv3 123 metric 15 match internal external 2 nssa-external 1 route-map foo
-    - address-family ipv4 multicast
-    - no default-metric 12
-    - no distance bgp 10 10 100
-    - no table-map test_tableMap filter
-    - bgp aggregate-timer 10
-    - bgp dampening 10 10 100 50
-    - bgp slow-peer detection threshold 150
-    - network 198.51.110.10 mask 255.255.255.255 backdoor
-    - no network 198.51.111.11 mask 255.255.255.255 route-map test
-    - aggregate-address 192.0.2.1 255.255.255.255 as-confed-set
-    - no aggregate-address 192.0.3.1 255.255.255.255 as-confed-set
-    - address-family ipv6 multicast
-    - bgp aggregate-timer 10
-    - bgp dampening 10 10 10 10
-    - bgp slow-peer detection threshold 200
-    - network 2001:DB8:0:3::/64 route-map test_ipv6
+  - router bgp 65000
+  - no neighbor 10.1.1.1
+  - address-family ipv4 mdt
+  - no bgp dmzlink-bw
+  - no bgp soft-reconfig-backup
+  - no bgp dampening 1 10 100 5
+  - exit-address-family
+  - address-family ipv6 unicast
+  - no redistribute ospf 124
+  - exit-address-family
+  - address-family ipv4 unicast
+  - no redistribute connected
+  - no redistribute ospf 123
+  - redistribute ospf 123 metric 15 match external 1 nssa-external 2 route-map foo
+  - no redistribute ospf 124
+  - no redistribute ospfv3 123
+  - redistribute ospfv3 123 metric 15 match internal external 2 nssa-external 1 route-map foo
+  - exit-address-family
+  - address-family ipv4 multicast
+  - no default-metric 12
+  - no distance bgp 10 10 100
+  - no table-map test_tableMap filter
+  - bgp dampening 10 10 100 50
+  - neighbor 10.1.1.2 activate
+  - no network 198.51.111.11 mask 255.255.255.255 route-map test
+  - no aggregate-address 192.0.3.1 255.255.255.255 as-confed-set
+  - exit-address-family
+  - address-family ipv6 multicast
+  - bgp aggregate-timer 10
+  - bgp dampening 10 10 10 10
+  - bgp slow-peer detection threshold 200
+  - network 2001:DB8:0:3::/64 route-map test_ipv6
+  - exit-address-family
 
   after:
     address_family:
@@ -217,24 +225,25 @@ overridden:
 replaced:
   commands:
     - router bgp 65000
-    - address-family ipv4
+    - no neighbor 10.1.1.1
+    - address-family ipv4 unicast
     - no redistribute connected
     - no redistribute ospf 123
     - redistribute ospf 123 metric 15 match external 1 nssa-external 2 route-map foo
     - no redistribute ospf 124
     - no redistribute ospfv3 123
     - redistribute ospfv3 123 metric 15 match internal external 2 nssa-external 1 route-map foo
+    - exit-address-family
     - address-family ipv4 multicast
     - no default-metric 12
     - no distance bgp 10 10 100
     - no table-map test_tableMap filter
-    - bgp aggregate-timer 10
-    - bgp dampening 10 10 10 10
-    - bgp slow-peer detection threshold 200
+    - no bgp dampening 1 1 1 1
+    - neighbor 10.1.1.3 activate
     - network 192.0.2.1 mask 255.255.255.255 route-map test
     - no network 198.51.111.11 mask 255.255.255.255 route-map test
     - no aggregate-address 192.0.3.1 255.255.255.255 as-confed-set
-
+    - exit-address-family
   after:
     address_family:
       - afi: ipv4
@@ -299,38 +308,41 @@ replaced:
               metric: 10
               route_map: bar
               include_connected: true
-    as_number: "65000"
 
 deleted:
   commands:
     - router bgp 65000
     - no address-family ipv4 multicast
     - no address-family ipv4 mdt
-    - no address-family ipv4
-    - no address-family ipv6
+    - no address-family ipv4 unicast
+    - no address-family ipv6 unicast
 
 rendered:
   commands:
     - router bgp 65000
-    - address-family ipv4
+    - address-family ipv4 unicast
     - maximum-paths 12
     - maximum-secondary-paths eibgp 2
     - redistribute connected metric 10
     - redistribute ospf 124
     - redistribute ospf 123 metric 10 match internal external 1 external 2 nssa-external 1 nssa-external 2 route-map bar
     - redistribute ospfv3 123 metric 10 match internal external 1 external 2 nssa-external 1 nssa-external 2 route-map bar
+    - exit-address-family
     - address-family ipv4 multicast
     - default-metric 12
     - distance bgp 10 10 100
     - table-map test_tableMap filter
     - network 198.51.111.11 mask 255.255.255.255 route-map test
     - aggregate-address 192.0.3.1 255.255.255.255 as-confed-set
+    - exit-address-family
     - address-family ipv4 mdt
     - bgp dmzlink-bw
     - bgp soft-reconfig-backup
     - bgp dampening 1 10 100 5
-    - address-family ipv6
+    - exit-address-family
+    - address-family ipv6 unicast
     - redistribute ospf 124 metric 10 match internal external 1 external 2 nssa-external 1 nssa-external 2 route-map bar include-connected
+    - exit-address-family
 
 deleted_all:
   after:
@@ -351,4 +363,5 @@ parsed:
           - address: 192.0.2.0
           - address: 192.0.3.0
           - address: 192.0.4.0
+        safi: unicast
     as_number: "65536"

--- a/tests/unit/modules/network/ios/test_ios_bgp_address_family.py
+++ b/tests/unit/modules/network/ios/test_ios_bgp_address_family.py
@@ -145,6 +145,7 @@ class TestIosBgpAddressFamilyModule(TestIosModule):
             "address-family ipv4 multicast vrf blue",
             "bgp dampening 10 10 10 10",
             "aggregate-address 192.0.3.1 255.255.255.255 as-confed-set",
+            "exit-address-family",
             "address-family nsap",
             "bgp aggregate-timer 20",
             "bgp dmzlink-bw",
@@ -153,6 +154,7 @@ class TestIosBgpAddressFamilyModule(TestIosModule):
             "neighbor 198.51.100.1 route-map test-route-out out",
             "network 192.0.1.1 route-map test_route",
             "default-metric 10",
+            "exit-address-family",
         ]
         result = self.execute_module(changed=True)
         self.assertEqual(sorted(result["commands"]), sorted(commands))
@@ -189,6 +191,7 @@ class TestIosBgpAddressFamilyModule(TestIosModule):
             "neighbor 192.0.3.1 prefix-list PREFIX-OUT out",
             "neighbor 192.0.3.1 soft-reconfiguration inbound",
             "network 192.0.3.1 mask 255.255.255.0",
+            "exit-address-family",
         ]
 
         result = self.execute_module(changed=True)
@@ -465,6 +468,7 @@ class TestIosBgpAddressFamilyModule(TestIosModule):
             "neighbor 198.51.110.1 route-map test-replaced-route out",
             "no neighbor 198.51.100.1",
             "no network 198.51.110.10 mask 255.255.255.255 backdoor",
+            "exit-address-family",
         ]
         result = self.execute_module(changed=True)
         self.assertEqual(sorted(result["commands"]), sorted(commands))
@@ -506,7 +510,7 @@ class TestIosBgpAddressFamilyModule(TestIosModule):
               bgp slow-peer detection threshold 150
               bgp dampening 1 1 1 1
               network 198.51.110.10 mask 255.255.255.255 backdoor
-              aggregate-address 192.0.2.1 255.255.255.255 as-confed-set
+              aggregate-address 192.0.2.10 255.255.255.255 as-confed-set
               neighbor 198.51.100.1 remote-as 10
               neighbor 198.51.100.1 local-as 20
               neighbor 198.51.100.1 activate
@@ -530,7 +534,7 @@ class TestIosBgpAddressFamilyModule(TestIosModule):
                             vrf="blue",
                             aggregate_address=[
                                 dict(
-                                    address="192.0.2.1",
+                                    address="192.0.2.10",
                                     netmask="255.255.255.255",
                                     as_confed_set=True,
                                 ),
@@ -857,7 +861,7 @@ class TestIosBgpAddressFamilyModule(TestIosModule):
         set_module_args(dict(state="deleted"))
         commands = [
             "router bgp 65000",
-            "no address-family ipv4",
+            "no address-family ipv4 unicast",
             "no address-family ipv4 multicast vrf blue",
             "no address-family ipv4 mdt",
             "no address-family ipv4 multicast",
@@ -1044,6 +1048,7 @@ class TestIosBgpAddressFamilyModule(TestIosModule):
             "neighbor 198.51.100.1 slow-peer detection threshold 150",
             "network 198.51.110.10 mask 255.255.255.255 backdoor",
             "aggregate-address 192.0.2.1 255.255.255.255 as-confed-set",
+            "exit-address-family",
             "address-family ipv4 multicast",
             "network 198.51.111.11 mask 255.255.255.255 route-map test",
             "aggregate-address 192.0.3.1 255.255.255.255 as-confed-set",
@@ -1051,6 +1056,7 @@ class TestIosBgpAddressFamilyModule(TestIosModule):
             "distance bgp 10 10 100",
             "table-map test_tableMap filter",
             "snmp context testsnmp user abc credential encrypted access ipv6 ipcal",
+            "exit-address-family",
         ]
         result = self.execute_module(changed=False)
         self.assertEqual(sorted(result["rendered"]), sorted(commands))
@@ -1127,16 +1133,11 @@ class TestIosBgpAddressFamilyModule(TestIosModule):
                                 "metric": 100,
                                 "match": {
                                     "internal": True,
-                                    "externals": {
-                                        "type_1": True,
-                                        "type_2": True,
-                                    },
+                                    "externals": {"type_1": True, "type_2": True},
                                 },
                             },
                         },
                     ],
-                    "maximum_paths": {"paths": 12},
-                    "maximum_secondary_paths": {"eibgp": 2},
                     "neighbors": [
                         {
                             "send_community": {"set": True},
@@ -1145,8 +1146,14 @@ class TestIosBgpAddressFamilyModule(TestIosModule):
                         },
                         {"neighbor_address": "2001:db8::1", "activate": True},
                     ],
+                    # --- CHANGE: Key order adjusted to match desired output ---
+                    "maximum_secondary_paths": {"eibgp": 2},
+                    "maximum_paths": {"paths": 12},
+                    # --- CHANGE: 'safi' key added ---
+                    "safi": "unicast",
                 },
                 {
+                    # Second address-family (ipv4 multicast) - NO CHANGES
                     "afi": "ipv4",
                     "safi": "multicast",
                     "table_map": {"name": "test_tableMap", "filter": True},
@@ -1168,6 +1175,7 @@ class TestIosBgpAddressFamilyModule(TestIosModule):
                     "distance": {"external": 10, "internal": 10, "local": 100},
                 },
                 {
+                    # Third address-family (ipv4 mdt) - NO CHANGES
                     "afi": "ipv4",
                     "safi": "mdt",
                     "bgp": {
@@ -1182,6 +1190,7 @@ class TestIosBgpAddressFamilyModule(TestIosModule):
                     },
                 },
                 {
+                    # Fourth address-family (ipv4 multicast vrf blue)
                     "afi": "ipv4",
                     "safi": "multicast",
                     "vrf": "blue",
@@ -1213,8 +1222,9 @@ class TestIosBgpAddressFamilyModule(TestIosModule):
                         {
                             "remote_as": "10",
                             "local_as": {"set": True, "number": "20"},
-                            "activate": True,
+                            # --- CHANGE: Key order adjusted to match desired output ---
                             "neighbor_address": "198.51.100.1",
+                            "activate": True,
                             "nexthop_self": {"all": True},
                             "aigp": {
                                 "send": {
@@ -1225,9 +1235,7 @@ class TestIosBgpAddressFamilyModule(TestIosModule):
                                 },
                             },
                             "route_server_client": True,
-                            "prefix_lists": [
-                                {"name": "AS65100-PREFIX-OUT", "out": True},
-                            ],
+                            "prefix_lists": [{"name": "AS65100-PREFIX-OUT", "out": True}],
                             "slow_peer_options": {"detection": {"threshold": 150}},
                             "route_maps": [{"name": "test-out", "out": True}],
                         },
@@ -1270,7 +1278,7 @@ class TestIosBgpAddressFamilyModule(TestIosModule):
         )
         commands = [
             "router bgp 65000",
-            "address-family ipv4",
+            "address-family ipv4 unicast",
             "neighbor 192.31.39.212 activate",
             "neighbor 192.31.39.212 soft-reconfiguration inbound",
             "neighbor 192.31.47.206 activate",
@@ -1278,6 +1286,7 @@ class TestIosBgpAddressFamilyModule(TestIosModule):
             "network 192.0.3.1 mask 255.255.255.0",
             "network 192.0.2.1 mask 255.255.255.0",
             "network 192.0.4.1 mask 255.255.255.0",
+            "exit-address-family",
         ]
         result = self.execute_module(changed=True)
         self.assertEqual(sorted(result["commands"]), sorted(commands))
@@ -1304,6 +1313,7 @@ class TestIosBgpAddressFamilyModule(TestIosModule):
               table-map test_tableMap filter
               network 198.51.111.11 mask 255.255.255.255 route-map test
               aggregate-address 192.0.3.1 255.255.255.255 as-confed-set
+              redistribute ospf 200 metric 100 match internal external 1 external 2
               default-metric 12
               distance bgp 10 10 100
              exit-address-family
@@ -1364,6 +1374,9 @@ class TestIosBgpAddressFamilyModule(TestIosModule):
         )
         commands = [
             "router bgp 65000",
+            "no neighbor TEST-PEER-GROUP",
+            "no neighbor 2001:db8::1",
+            "no neighbor 198.51.100.1",
             "address-family ipv4 multicast",
             "no default-metric 12",
             "no distance bgp 10 10 100",
@@ -1371,29 +1384,31 @@ class TestIosBgpAddressFamilyModule(TestIosModule):
             "no table-map test_tableMap filter",
             "no network 198.51.111.11 mask 255.255.255.255 route-map test",
             "no aggregate-address 192.0.3.1 255.255.255.255 as-confed-set",
+            "exit-address-family",
             "address-family ipv4 mdt",
             "no bgp dmzlink-bw",
             "no bgp soft-reconfig-backup",
             "no bgp dampening 1 10 100 5",
+            "exit-address-family",
             "address-family ipv4 multicast vrf blue",
             "no bgp aggregate-timer 10",
             "no bgp dampening 1 1 1 1",
             "no bgp slow-peer detection threshold 150",
-            "no neighbor 198.51.100.1",
             "no network 198.51.110.10 mask 255.255.255.255 backdoor",
             "no aggregate-address 192.0.2.1 255.255.255.255 as-confed-set",
-            "address-family ipv4",
+            "exit-address-family",
+            "address-family ipv4 unicast",
             "no bgp redistribute-internal",
             "no redistribute connected",
+            "no redistribute ospf 200",
             "neighbor 192.31.39.212 activate",
             "neighbor 192.31.39.212 soft-reconfiguration inbound",
             "neighbor 192.31.47.206 activate",
             "neighbor 192.31.47.206 soft-reconfiguration inbound",
-            "no neighbor TEST-PEER-GROUP",
-            "no neighbor 2001:db8::1",
             "network 192.0.3.1 mask 255.255.255.0",
             "network 192.0.2.1 mask 255.255.255.0",
             "network 192.0.4.1 mask 255.255.255.0",
+            "exit-address-family",
         ]
         result = self.execute_module(changed=True)
         self.assertEqual(sorted(result["commands"]), sorted(commands))


### PR DESCRIPTION
##### SUMMARY
This update moves the no neighbor command logic out of the address-family block to the correct global BGP context, fixing a CLI syntax error from issue 1187.
It refines the behavior of replaced and overridden states to only manage sub-sections like neighbors when they are explicitly defined in the playbook.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
cisco.ios.ios_bgp_address_family
