### PR TITLE
Handle dangling preempt

### DIFF
--- a/docs/cisco.ios.ios_hsrp_interfaces_module.rst
+++ b/docs/cisco.ios.ios_hsrp_interfaces_module.rst
@@ -818,6 +818,28 @@ Parameters
                     <td class="elbow-placeholder"></td>
                 <td colspan="3">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>enabled</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                    </div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li>no</li>
+                                    <li>yes</li>
+                        </ul>
+                </td>
+                <td>
+                        <div>Enables preempt, drives the lone `standby &lt;grp_no&gt; preempt` command</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                    <td class="elbow-placeholder"></td>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="3">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>minimum</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">

--- a/plugins/module_utils/network/ios/argspec/hsrp_interfaces/hsrp_interfaces.py
+++ b/plugins/module_utils/network/ios/argspec/hsrp_interfaces/hsrp_interfaces.py
@@ -58,10 +58,12 @@ class Hsrp_interfacesArgs(object):  # pylint: disable=R0903
                                     "options": {
                                         "key_chain": {
                                             "type": "str",
-                                            "no_log": True,
                                         },
                                         "key_string": {"type": "bool"},
-                                        "encryption": {"type": "str"},
+                                        "encryption": {
+                                            "type": "str",
+                                            "no_log": True,
+                                        },
                                         "time_out": {"type": "int"},
                                         "password_text": {
                                             "type": "str",
@@ -124,7 +126,6 @@ class Hsrp_interfacesArgs(object):  # pylint: disable=R0903
                                     "options": {
                                         "key_chain": {
                                             "type": "str",
-                                            "no_log": True,
                                         },
                                         "key_string": {"type": "bool"},
                                         "encryption": {"type": "int"},
@@ -149,6 +150,7 @@ class Hsrp_interfacesArgs(object):  # pylint: disable=R0903
                         "preempt": {
                             "type": "dict",
                             "options": {
+                                "enabled": {"type": "bool"},
                                 "minimum": {"type": "int"},
                                 "reload": {"type": "int"},
                                 "sync": {"type": "int"},

--- a/plugins/module_utils/network/ios/rm_templates/hsrp_interfaces.py
+++ b/plugins/module_utils/network/ios/rm_templates/hsrp_interfaces.py
@@ -230,16 +230,13 @@ class Hsrp_interfacesTemplate(NetworkTemplate):
             ),
             "setval": "standby "
                       "{{ preempt.group_no|string if preempt.group_no is defined else ''}}"
-                      " preempt"
-                      "{{ ' delay' if preempt.delay|d(False) else ''}}"
-                      "{{ ' minimum ' + preempt.minimum|string if preempt.minimum is defined else ''}}"
-                      "{{ ' reload ' + preempt.reload|string if preempt.reload is defined else ''}}"
-                      "{{ ' sync ' + preempt.sync|string if preempt.sync is defined else ''}}",
+                      " preempt",
             "result": {
                 "{{ name }}": {
                     "standby_groups": [{
                         "group_no": "{{ group_no }}",
                         "preempt": {
+                            "enabled": True,
                             "delay": "{{ not not delay }}",
                             "minimum": "{{ minimum }}",
                             "reload": "{{ reload }}",

--- a/plugins/modules/ios_hsrp_interfaces.py
+++ b/plugins/modules/ios_hsrp_interfaces.py
@@ -199,6 +199,9 @@ options:
             description: Overthrow lower priority Active routers
             type: dict
             suboptions:
+              enabled:
+                description: Enables preempt, drives the lone `standby <grp_no> preempt` command
+                type: bool
               minimum:
                 description: Delay at least this long
                 type: int


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
fix dangling hrsp preempt configuration.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios_hsrp_interfaces

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
    commands:
    - interface Vlan10
    - no standby 10 preempt
    - standby 10 preempt
    - interface Vlan939
    - no standby 934 preempt
    - standby 934 preempt
    - no standby 920 preempt
```
