### PR TITLE
fix: ignore reserved vlans 1002-1005

### DIFF
--- a/changelogs/fragments/ignore_reserved_vlans.yml
+++ b/changelogs/fragments/ignore_reserved_vlans.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - ios_vlans - exclude reserved VLANs 1002-1005 when gathering facts.

--- a/docs/cisco.ios.ios_vlans_module.rst
+++ b/docs/cisco.ios.ios_vlans_module.rst
@@ -511,6 +511,26 @@ Examples
     #   shutdown: disabled
     #   state: active
     #   vlan_id: 20
+    # - mtu: 1500
+    #   name: fddi-default
+    #   shutdown: enabled
+    #   state: active
+    #   vlan_id: 1002
+    # - mtu: 1500
+    #   name: token-ring-default
+    #   shutdown: enabled
+    #   state: active
+    #   vlan_id: 1003
+    # - mtu: 1500
+    #   name: fddinet-default
+    #   shutdown: enabled
+    #   state: active
+    #   vlan_id: 1004
+    # - mtu: 1500
+    #   name: trnet-default
+    #   shutdown: enabled
+    #   state: active
+    #   vlan_id: 1005
 
     # before:
     # - mtu: 1500
@@ -538,11 +558,36 @@ Examples
     #   shutdown: disabled
     #   state: suspend
     #   vlan_id: 44
+    # - mtu: 1500
+    #   name: fddi-default
+    #   shutdown: enabled
+    #   state: active
+    #   vlan_id: 1002
+    # - mtu: 1500
+    #   name: token-ring-default
+    #   shutdown: enabled
+    #   state: active
+    #   vlan_id: 1003
+    # - mtu: 1500
+    #   name: fddinet-default
+    #   shutdown: enabled
+    #   state: active
+    #   vlan_id: 1004
+    # - mtu: 1500
+    #   name: trnet-default
+    #   shutdown: enabled
+    #   state: active
+    #   vlan_id: 1005
 
     # commands:
+    # - no vlan 1
     # - no vlan 10
     # - no vlan 30
     # - no vlan 44
+    # - no vlan 1002
+    # - no vlan 1003
+    # - no vlan 1004
+    # - no vlan 1005
     # - vlan 20
     # - name Vlan_2020
     # - no mtu 610
@@ -550,6 +595,10 @@ Examples
     # - no vlan configuration 10
     # - no vlan configuration 30
     # - no vlan configuration 44
+    # - no vlan configuration 1002
+    # - no vlan configuration 1003
+    # - no vlan configuration 1004
+    # - no vlan configuration 1005
 
     # After state:
     # ------------
@@ -630,6 +679,26 @@ Examples
     #   shutdown: disabled
     #   state: active
     #   vlan_id: 1
+    # - mtu: 1500
+    #   name: fddi-default
+    #   shutdown: enabled
+    #   state: active
+    #   vlan_id: 1002
+    # - mtu: 1500
+    #   name: token-ring-default
+    #   shutdown: enabled
+    #   state: active
+    #   vlan_id: 1003
+    # - mtu: 1500
+    #   name: fddinet-default
+    #   shutdown: enabled
+    #   state: active
+    #   vlan_id: 1004
+    # - mtu: 1500
+    #   name: trnet-default
+    #   shutdown: enabled
+    #   state: active
+    #   vlan_id: 1005
 
     # before:
     # - mtu: 1500
@@ -642,11 +711,40 @@ Examples
     #   shutdown: disabled
     #   state: active
     #   vlan_id: 20
+    # - mtu: 1500
+    #   name: fddi-default
+    #   shutdown: enabled
+    #   state: active
+    #   vlan_id: 1002
+    # - mtu: 1500
+    #   name: token-ring-default
+    #   shutdown: enabled
+    #   state: active
+    #   vlan_id: 1003
+    # - mtu: 1500
+    #   name: fddinet-default
+    #   shutdown: enabled
+    #   state: active
+    #   vlan_id: 1004
+    # - mtu: 1500
+    #   name: trnet-default
+    #   shutdown: enabled
+    #   state: active
+    #   vlan_id: 1005
 
     # commands:
+    # - no vlan 1
     # - no vlan 20
+    # - no vlan 1002
+    # - no vlan 1003
+    # - no vlan 1004
+    # - no vlan 1005
     # - no vlan configuration 1
     # - no vlan configuration 20
+    # - no vlan configuration 1002
+    # - no vlan configuration 1003
+    # - no vlan configuration 1004
+    # - no vlan configuration 1005
 
     # After state:
     # ------------
@@ -1159,6 +1257,34 @@ Examples
     #             "shutdown": "enabled",
     #             "state": "suspend",
     #             "vlan_id": 30
+    #         },
+    #         {
+    #             "mtu": 1500,
+    #             "name": "fddi-default",
+    #             "shutdown": "enabled",
+    #             "state": "active",
+    #             "vlan_id": 1002
+    #         },
+    #         {
+    #             "mtu": 1500,
+    #             "name": "token-ring-default",
+    #             "shutdown": "enabled",
+    #             "state": "active",
+    #             "vlan_id": 1003
+    #         },
+    #         {
+    #             "mtu": 1500,
+    #             "name": "fddinet-default",
+    #             "shutdown": "enabled",
+    #             "state": "active",
+    #             "vlan_id": 1004
+    #         },
+    #         {
+    #             "mtu": 1500,
+    #             "name": "trnet-default",
+    #             "shutdown": "enabled",
+    #             "state": "active",
+    #             "vlan_id": 1005
     #         }
     #     ]
 
@@ -1295,6 +1421,34 @@ Examples
     #         "shutdown": "disabled",
     #         "mtu": 1500,
     #     },
+    #     {
+    #         "name": "fddi-default",
+    #         "vlan_id": 1002,
+    #         "state": "active",
+    #         "shutdown": "enabled",
+    #         "mtu": 1500,
+    #     },
+    #     {
+    #         "name": "trcrf-default",
+    #         "vlan_id": 1003,
+    #         "state": "active",
+    #         "shutdown": "enabled",
+    #         "mtu": 4472,
+    #     },
+    #     {
+    #         "name": "fddinet-default",
+    #         "vlan_id": 1004,
+    #         "state": "active",
+    #         "shutdown": "enabled",
+    #         "mtu": 1500,
+    #     },
+    #     {
+    #         "name": "trbrf-default",
+    #         "vlan_id": 1005,
+    #         "state": "active",
+    #         "shutdown": "enabled",
+    #         "mtu": 4472,
+    #     },
     #     {"vlan_id": 102, "member": {"evi": 102, "vni": 10102}},
     #     {"vlan_id": 901, "member": {"vni": 50901}},
     # ]
@@ -1426,7 +1580,6 @@ Status
 Authors
 ~~~~~~~
 
-- Jørn Ivar Holland (@jiholland)
 - Sumit Jaiswal (@justjais)
 - Sagar Paul (@KB-perByte)
 - Padmini Priyadarshini Sivaraj (@PadminiSivaraj)

--- a/docs/cisco.ios.ios_vlans_module.rst
+++ b/docs/cisco.ios.ios_vlans_module.rst
@@ -511,26 +511,6 @@ Examples
     #   shutdown: disabled
     #   state: active
     #   vlan_id: 20
-    # - mtu: 1500
-    #   name: fddi-default
-    #   shutdown: enabled
-    #   state: active
-    #   vlan_id: 1002
-    # - mtu: 1500
-    #   name: token-ring-default
-    #   shutdown: enabled
-    #   state: active
-    #   vlan_id: 1003
-    # - mtu: 1500
-    #   name: fddinet-default
-    #   shutdown: enabled
-    #   state: active
-    #   vlan_id: 1004
-    # - mtu: 1500
-    #   name: trnet-default
-    #   shutdown: enabled
-    #   state: active
-    #   vlan_id: 1005
 
     # before:
     # - mtu: 1500
@@ -558,36 +538,11 @@ Examples
     #   shutdown: disabled
     #   state: suspend
     #   vlan_id: 44
-    # - mtu: 1500
-    #   name: fddi-default
-    #   shutdown: enabled
-    #   state: active
-    #   vlan_id: 1002
-    # - mtu: 1500
-    #   name: token-ring-default
-    #   shutdown: enabled
-    #   state: active
-    #   vlan_id: 1003
-    # - mtu: 1500
-    #   name: fddinet-default
-    #   shutdown: enabled
-    #   state: active
-    #   vlan_id: 1004
-    # - mtu: 1500
-    #   name: trnet-default
-    #   shutdown: enabled
-    #   state: active
-    #   vlan_id: 1005
 
     # commands:
-    # - no vlan 1
     # - no vlan 10
     # - no vlan 30
     # - no vlan 44
-    # - no vlan 1002
-    # - no vlan 1003
-    # - no vlan 1004
-    # - no vlan 1005
     # - vlan 20
     # - name Vlan_2020
     # - no mtu 610
@@ -595,10 +550,6 @@ Examples
     # - no vlan configuration 10
     # - no vlan configuration 30
     # - no vlan configuration 44
-    # - no vlan configuration 1002
-    # - no vlan configuration 1003
-    # - no vlan configuration 1004
-    # - no vlan configuration 1005
 
     # After state:
     # ------------
@@ -679,26 +630,6 @@ Examples
     #   shutdown: disabled
     #   state: active
     #   vlan_id: 1
-    # - mtu: 1500
-    #   name: fddi-default
-    #   shutdown: enabled
-    #   state: active
-    #   vlan_id: 1002
-    # - mtu: 1500
-    #   name: token-ring-default
-    #   shutdown: enabled
-    #   state: active
-    #   vlan_id: 1003
-    # - mtu: 1500
-    #   name: fddinet-default
-    #   shutdown: enabled
-    #   state: active
-    #   vlan_id: 1004
-    # - mtu: 1500
-    #   name: trnet-default
-    #   shutdown: enabled
-    #   state: active
-    #   vlan_id: 1005
 
     # before:
     # - mtu: 1500
@@ -711,40 +642,11 @@ Examples
     #   shutdown: disabled
     #   state: active
     #   vlan_id: 20
-    # - mtu: 1500
-    #   name: fddi-default
-    #   shutdown: enabled
-    #   state: active
-    #   vlan_id: 1002
-    # - mtu: 1500
-    #   name: token-ring-default
-    #   shutdown: enabled
-    #   state: active
-    #   vlan_id: 1003
-    # - mtu: 1500
-    #   name: fddinet-default
-    #   shutdown: enabled
-    #   state: active
-    #   vlan_id: 1004
-    # - mtu: 1500
-    #   name: trnet-default
-    #   shutdown: enabled
-    #   state: active
-    #   vlan_id: 1005
 
     # commands:
-    # - no vlan 1
     # - no vlan 20
-    # - no vlan 1002
-    # - no vlan 1003
-    # - no vlan 1004
-    # - no vlan 1005
     # - no vlan configuration 1
     # - no vlan configuration 20
-    # - no vlan configuration 1002
-    # - no vlan configuration 1003
-    # - no vlan configuration 1004
-    # - no vlan configuration 1005
 
     # After state:
     # ------------
@@ -1257,34 +1159,6 @@ Examples
     #             "shutdown": "enabled",
     #             "state": "suspend",
     #             "vlan_id": 30
-    #         },
-    #         {
-    #             "mtu": 1500,
-    #             "name": "fddi-default",
-    #             "shutdown": "enabled",
-    #             "state": "active",
-    #             "vlan_id": 1002
-    #         },
-    #         {
-    #             "mtu": 1500,
-    #             "name": "token-ring-default",
-    #             "shutdown": "enabled",
-    #             "state": "active",
-    #             "vlan_id": 1003
-    #         },
-    #         {
-    #             "mtu": 1500,
-    #             "name": "fddinet-default",
-    #             "shutdown": "enabled",
-    #             "state": "active",
-    #             "vlan_id": 1004
-    #         },
-    #         {
-    #             "mtu": 1500,
-    #             "name": "trnet-default",
-    #             "shutdown": "enabled",
-    #             "state": "active",
-    #             "vlan_id": 1005
     #         }
     #     ]
 
@@ -1421,34 +1295,6 @@ Examples
     #         "shutdown": "disabled",
     #         "mtu": 1500,
     #     },
-    #     {
-    #         "name": "fddi-default",
-    #         "vlan_id": 1002,
-    #         "state": "active",
-    #         "shutdown": "enabled",
-    #         "mtu": 1500,
-    #     },
-    #     {
-    #         "name": "trcrf-default",
-    #         "vlan_id": 1003,
-    #         "state": "active",
-    #         "shutdown": "enabled",
-    #         "mtu": 4472,
-    #     },
-    #     {
-    #         "name": "fddinet-default",
-    #         "vlan_id": 1004,
-    #         "state": "active",
-    #         "shutdown": "enabled",
-    #         "mtu": 1500,
-    #     },
-    #     {
-    #         "name": "trbrf-default",
-    #         "vlan_id": 1005,
-    #         "state": "active",
-    #         "shutdown": "enabled",
-    #         "mtu": 4472,
-    #     },
     #     {"vlan_id": 102, "member": {"evi": 102, "vni": 10102}},
     #     {"vlan_id": 901, "member": {"vni": 50901}},
     # ]
@@ -1580,6 +1426,7 @@ Status
 Authors
 ~~~~~~~
 
+- Jørn Ivar Holland (@jiholland)
 - Sumit Jaiswal (@justjais)
 - Sagar Paul (@KB-perByte)
 - Padmini Priyadarshini Sivaraj (@PadminiSivaraj)

--- a/plugins/module_utils/network/ios/facts/vlans/vlans.py
+++ b/plugins/module_utils/network/ios/facts/vlans/vlans.py
@@ -195,8 +195,10 @@ class VlansFacts(object):
             if vlan_conf_data:  # if any vlan configuration data is pending add it to facts
                 for vlanid, conf in vlan_conf_data.items():
                     objs.append(conf)
-
         if objs:
+            # Exclude reserved VLANs.
+            objs = [v for v in objs if v.get("vlan_id") not in [1002, 1003, 1004, 1005]]
+
             facts["vlans"] = []
             params = utils.validate_config(self.argument_spec, {"config": objs})
 


### PR DESCRIPTION
##### SUMMARY
This change modifies the `VlansFacts` class in `facts.py` to explicitly ignore reserved VLANs 1002–1005 during facts gathering.

Fixes #1182

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
cisco.ios.ios_vlans

##### Additional information

Before pull request

```yaml
# Before state:
# -------------
# switch#show vlan brief
# VLAN Name                             Status    Ports
# ---- -------------------------------- --------- -------------------------------
# 1    default                          active    Gi0/0, Gi0/1, Gi0/2, Gi0/3
# 10   Vlan_10                          active
# 1002 fddi-default                     act/unsup
# 1003 token-ring-default               act/unsup
# 1004 fddinet-default                  act/unsup
# 1005 trnet-default                    act/unsup

- name: Ensure vlans.
  cisco.ios.ios_vlans:
    config:
      - vlan_id: 20
        name: Vlan_20
    state: overridden

# Task output:
# ------------

# after:
# - mtu: 1500
#   name: default
#   shutdown: disabled
#   state: active
#   vlan_id: 1
# - mtu: 1500
#   name: Vlan_20
#   shutdown: disabled
#   state: active
#   vlan_id: 20
# - mtu: 1500
#   name: fddi-default
#   shutdown: enabled
#   state: active
#   vlan_id: 1002
# - mtu: 1500
#   name: token-ring-default
#   shutdown: enabled
#   state: active
#   vlan_id: 1003
# - mtu: 1500
#   name: fddinet-default
#   shutdown: enabled
#   state: active
#   vlan_id: 1004
# - mtu: 1500
#   name: trnet-default
#   shutdown: enabled
#   state: active
#   vlan_id: 1005

# before:
# - mtu: 1500
#   name: default
#   shutdown: disabled
#   state: active
#   vlan_id: 1
# - mtu: 1500
#   name: Vlan_10
#   shutdown: disabled
#   state: active
#   vlan_id: 10
# - mtu: 1500
#   name: Vlan_20
#   shutdown: disabled
#   state: active
#   vlan_id: 20
# - mtu: 1500
#   name: fddi-default
#   shutdown: enabled
#   state: active
#   vlan_id: 1002
# - mtu: 1500
#   name: token-ring-default
#   shutdown: enabled
#   state: active
#   vlan_id: 1003
# - mtu: 1500
#   name: fddinet-default
#   shutdown: enabled
#   state: active
#   vlan_id: 1004
# - mtu: 1500
#   name: trnet-default
#   shutdown: enabled
#   state: active
#   vlan_id: 1005

# commands:
# - no vlan 10
# - no vlan 1002
# - no vlan 1003
# - no vlan 1004
# - no vlan 1005

# After state:
# -------------
# switch#show vlan brief
# VLAN Name                             Status    Ports
# ---- -------------------------------- --------- -------------------------------
# 1    default                          active    Gi0/0, Gi0/1, Gi0/2, Gi0/3
# 20   Vlan_20                          active
# 1002 fddi-default                     act/unsup
# 1003 token-ring-default               act/unsup
# 1004 fddinet-default                  act/unsup
# 1005 trnet-default                    act/unsup
```

After pull request

```yaml
# Before state:
# -------------
# switch#show vlan brief
# VLAN Name                             Status    Ports
# ---- -------------------------------- --------- -------------------------------
# 1    default                          active    Gi0/0, Gi0/1, Gi0/2, Gi0/3
# 10   Vlan_10                          active
# 1002 fddi-default                     act/unsup
# 1003 token-ring-default               act/unsup
# 1004 fddinet-default                  act/unsup
# 1005 trnet-default                    act/unsup

- name: Ensure vlans.
  cisco.ios.ios_vlans:
    config:
      - vlan_id: 20
        name: Vlan_20
    state: overridden

# Task output:
# ------------

# after:
# - mtu: 1500
#   name: default
#   shutdown: disabled
#   state: active
#   vlan_id: 1
# - mtu: 1500
#   name: Vlan_20
#   shutdown: disabled
#   state: active
#   vlan_id: 20

# before:
# - mtu: 1500
#   name: default
#   shutdown: disabled
#   state: active
#   vlan_id: 1
# - mtu: 1500
#   name: Vlan_10
#   shutdown: disabled
#   state: active
#   vlan_id: 10
# - mtu: 1500
#   name: Vlan_20
#   shutdown: disabled
#   state: active
#   vlan_id: 20

# commands:
# - no vlan 10

# After state:
# -------------
# switch#show vlan brief
# VLAN Name                             Status    Ports
# ---- -------------------------------- --------- -------------------------------
# 1    default                          active    Gi0/0, Gi0/1, Gi0/2, Gi0/3
# 20   Vlan_20                          active
# 1002 fddi-default                     act/unsup
# 1003 token-ring-default               act/unsup
# 1004 fddinet-default                  act/unsup
# 1005 trnet-default                    act/unsup
```
