### PR TITLE
[DNM] Fixed issue where new/empty lines are stripped at the top of a banner

### DIFF
--- a/plugins/modules/ios_banner.py
+++ b/plugins/modules/ios_banner.py
@@ -132,7 +132,7 @@ def map_obj_to_commands(updates, module):
         if want["text"] and (want["text"].rstrip("\n") != haved):
             banner_cmd = "banner %s" % module.params["banner"]
             banner_cmd += " {0}\n".format(multiline_delimiter)
-            banner_cmd += want["text"].strip("\n")
+            banner_cmd += want["text"].rstrip("\n")
             banner_cmd += "\n{0}".format(multiline_delimiter)
             commands.append(banner_cmd)
     return commands


### PR DESCRIPTION
##### SUMMARY

Fixes #1178

This change allows banner text to have leading empty lines ("\n") which can be helpful for formatting. Before this change, this was not possible because the empty lines would be stripped before being converted into a CLI command.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

ios_banner

##### ADDITIONAL INFORMATION

The fix was to change a .strip(“\n”) call to .rstrip(“\n”) within the map_obj_to_commands function in the ios_banner.py file. Calling strip would remove any leading and trailing empty lines in the banner text, but changing it to rstrip would only remove trailing empty lines and keep the leading lines, allowing for clean space and formatting in the ASCII art banner.

For example, take the following playbook:


```
   - name: Set banner fact with leading newline
      set_fact:
        banner: |+

          ############################
          #                          #
          #     ASCII Art Banner     #
          #                          #
          ############################

    - name: Generate the banner configuration
      ios_banner:
        banner: login
        text: "{{ banner }}"
        state: present
```

Before the change, this would result in the following command being inputted to the device:

```
banner login @
############################
#                          #
#     ASCII Art Banner     #
#                          #
############################
@
```
The empty lines in the beginning of the banner that were specified in the playbook were removed. 
After the change, this is the command that is inputted to the device:


```
banner login @

############################
#                          #
#     ASCII Art Banner     #
#                          #
############################
@
```
This output now has the leading empty lines included in the banner.
