### PR TITLE
[ios_hsrp_interfaces] ipv6 attributes handling issues

### DIFF
--- a/plugins/module_utils/network/ios/argspec/hsrp_interfaces/hsrp_interfaces.py
+++ b/plugins/module_utils/network/ios/argspec/hsrp_interfaces/hsrp_interfaces.py
@@ -112,8 +112,8 @@ class Hsrp_interfacesArgs(object):  # pylint: disable=R0903
                             "type": "list",
                             "elements": "dict",
                             "options": {
-                                "ipv6_link": {"type": "str"},
-                                "ipv6_prefix": {"type": "str"},
+                                "link_local_address": {"type": "str"},
+                                "prefix": {"type": "str"},
                                 "autoconfig": {"type": "bool"},
                             },
                         },

--- a/plugins/module_utils/network/ios/rm_templates/hsrp_interfaces.py
+++ b/plugins/module_utils/network/ios/rm_templates/hsrp_interfaces.py
@@ -307,69 +307,69 @@ class Hsrp_interfacesTemplate(NetworkTemplate):
             },
         },
         {
-            "name": "ipv6.link",
+            "name": "link_local_address",
             "getval": re.compile(
                 r"""
-                \s*standby
-                (?:\s+(?P<group_no>\d+))?
-                \s+ipv6\s+
-                (?P<virtual_ipv6>[a-fA-F0-9:]+)
+                \s+standby
+                (\s(?P<group_no>\d+))
+                \sipv6
+                (\s(?P<link_local_address>[a-fA-F0-9:]+))
                 $""", re.VERBOSE,
             ),
             "setval": "standby"
-                      "{{ ' ' + ipv6.group_no|string if ipv6.group_no is defined else ''}}"
+                      "{{ ' ' + group_no|string if group_no is defined else ''}}"
                       " ipv6"
-                      "{{ ' ' + ipv6.virtual_ipv6 if ipv6.virtual_ipv6 is defined else ''}}",
+                      "{{ ' ' + link_local_address if link_local_address is defined else ''}}",
             "result": {
                 "{{ name }}": {
                     "standby_groups": [{
                         "group_no": "{{ group_no }}",
                         "ipv6": [{
-                            "virtual_ipv6": "{{ virtual_ipv6 }}",
+                            "link_local_address": "{{ link_local_address }}",
                         }],
                     }],
                 },
             },
         },
         {
-            "name": "ipv6.prefix",
+            "name": "prefix",
             "getval": re.compile(
                 r"""
                 \s*standby
                 (?:\s+(?P<group_no>\d+))?
                 \s+ipv6\s+
-                (?P<virtual_ipv6_prefix>[a-fA-F0-9:]+\/\d+)
+                (?P<prefix>[a-fA-F0-9:]+\/\d+)
                 $""", re.VERBOSE,
             ),
             "setval": "standby"
-                      "{{ ' ' + ipv6.group_no|string if ipv6.group_no is defined else ''}}"
+                      "{{ ' ' + group_no|string if group_no is defined else ''}}"
                       " ipv6"
-                      "{{ ' ' + ipv6.virtual_ipv6_prefix if ipv6.virtual_ipv6_prefix is defined else ''}}",
+                      "{{ ' ' + prefix if prefix is defined else ''}}",
             "result": {
                 "{{ name }}": {
                     "standby_groups": [{
                         "group_no": "{{ group_no }}",
                         "ipv6": [{
-                            "virtual_ipv6_prefix": "{{ virtual_ipv6_prefix }}",
+                            "prefix": "{{ prefix }}",
                         }],
                     }],
                 },
             },
         },
         {
-            "name": "ipv6.autoconfig",
+            "name": "autoconfig",
             "getval": re.compile(
                 r"""
                 \s*standby
                 (?:\s+(?P<group_no>\d+))
                 \s+ipv6
-                (?:\s+(?P<autoconfig>autoconfig))?
+                (?:\s+(?P<autoconfig>autoconfig))
                 $""", re.VERBOSE,
             ),
             "setval": "standby"
-                      "{{ ' ' + ipv6.group_no|string if ipv6.group_no is defined else ''}}"
+                      "{{ ' ' + group_no|string if group_no is defined else ''}}"
                       " ipv6"
-                      "{{ ' autoconfig' if ipv6.autoconfig|d(False) else ''}}",
+                      "{{ ' autoconfig' if autoconfig|d(False) else ''}}",
             "result": {
                 "{{ name }}": {
                     "standby_groups": [{

--- a/plugins/modules/ios_hsrp_interfaces.py
+++ b/plugins/modules/ios_hsrp_interfaces.py
@@ -150,10 +150,10 @@ options:
             type: list
             elements: dict
             suboptions:
-              ipv6_link:
+              link_local_address:
                 description: 'X:x:X:x::X  IPv6 link-local address'
                 type: str
-              ipv6_prefix:
+              prefix:
                 description: 'X:x:X:x::X/<0-128>  IPv6 prefix'
                 type: str
               autoconfig:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Updated attributes doesn't implement a breaking change as the attributes never got processed due to the bug.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios_hsrp_interfaces

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
interface Vlan70
 description ansible testing hsrp facts
 no ip address
 no ip redirects
 no ip proxy-arp
 standby delay minimum 30 reload 120
 standby version 2
 standby 70 ipv6 xxxx:1:2:1BC4::1/64
 standby 70 priority 110
 standby 70 preempt
 standby 70 track 1 decrement 10
 standby 70 track 101 decrement 50
 ipv6 address xxxx:1:2:1BC4::2/64
 ipv6 enable
 ipv6 nd managed-config-flag
 ipv6 nd other-config-flag
 no ipv6 redirects
 ipv6 dhcp relay destination xxxx:1:2:1::6
 ipv6 dhcp relay destination xxxx:1:2:2::6
```


