### PR TITLE
ios_bgp_add_fam - Check idempotent long hash password and fix inf

### DIFF
--- a/plugins/module_utils/network/ios/config/bgp_address_family/bgp_address_family.py
+++ b/plugins/module_utils/network/ios/config/bgp_address_family/bgp_address_family.py
@@ -386,14 +386,6 @@ class Bgp_address_family(ResourceModule):
                             neib["remote_as"] = str(neib.get("remote_as"))
                         if neib.get("local_as") and neib.get("local_as", {}).get("number"):
                             neib["local_as"]["number"] = str(neib["local_as"]["number"])
-                        if neib.get("password_options", {}).get("pass_key"):
-                            neib["password_options"]["pass_key"] = (
-                                neib.get("password_options", {}).get("pass_key").split("_")[1]
-                                if neib.get("password_options", {})
-                                .get("pass_key")
-                                .startswith("pass_")
-                                else neib.get("password_options", {}).get("pass_key")
-                            )
                         # make dict neighbors dict
                         tmp[neib[p_key[k]]] = neib
                     _af["neighbors"] = tmp

--- a/plugins/module_utils/network/ios/rm_templates/bgp_address_family.py
+++ b/plugins/module_utils/network/ios/rm_templates/bgp_address_family.py
@@ -1614,7 +1614,7 @@ class Bgp_address_familyTemplate(NetworkTemplate):
                                 "neighbor_address": UNIQUE_NEIB_ADD,
                                 "password_options": {
                                     "encryption": "{{ encryption }}",
-                                    "pass_key": "pass_{{ pass_key }}",
+                                    "pass_key": "'{{ pass_key }}'",
                                 },
                             },
                         },

--- a/tests/unit/modules/network/ios/test_ios_bgp_address_family.py
+++ b/tests/unit/modules/network/ios/test_ios_bgp_address_family.py
@@ -1113,6 +1113,7 @@ class TestIosBgpAddressFamilyModule(TestIosModule):
                       neighbor 198.51.100.1 local-as 20
                       neighbor 198.51.100.1 activate
                       neighbor 198.51.100.1 next-hop-self all
+                      neighbor 198.51.100.1 password 7 021E015232511520495706
                       neighbor 198.51.100.1 aigp send cost-community 100 poi igp-cost transitive
                       neighbor 198.51.100.1 route-server-client
                       neighbor 198.51.100.1 prefix-list AS65100-PREFIX-OUT out
@@ -1239,6 +1240,10 @@ class TestIosBgpAddressFamilyModule(TestIosModule):
                                         "poi": {"igp_cost": True, "transitive": True},
                                     },
                                 },
+                            },
+                            "password_options": {
+                                "encryption": 7,
+                                "pass_key": "021E015232511520495706",
                             },
                             "route_server_client": True,
                             "prefix_lists": [{"name": "AS65100-PREFIX-OUT", "out": True}],


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Why is this needed?
```
router bgp 560001
 address-family ipv4 vrf IAMGOINGCRAZY
  neighbor 1.1.1.2 password 7 021E015232511520495706
```
Would get parsed like - 
```
ok: [BATMON] => 
    changed: false
    invocation:
        module_args:
            config: null
            running_config: |-
                router bgp 560001
                 address-family ipv4 vrf IAMGOINGCRAZY
                  neighbor 1.1.1.2 password 7 021E015232511520495706 <<<<<<<<<<<<<<<<<< this
            state: parsed
    parsed:
        address_family:
        -   afi: ipv4
            neighbors:
            -   neighbor_address: 1.1.1.2
                password_options:
                    encryption: 7
                    pass_key: inf <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< to this
            safi: unicast
            vrf: IAMGOINGCRAZY
        as_number: '560001'
```
https://github.com/KB-perByte/netcommon/blob/preserve_templates/plugins/module_utils/network/common/utils.py#L698 << this
```
        if value:
            try:
                return ast.literal_eval(value) <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< this
            except Exception:
                return str(value)
```

would eval it to
```
>>> import ast
>>> ast.literal_eval('021E015232511520495706')
inf
>>>
```

The problem: `ast.literal_eval()` sees `021E015...` and interprets it as scientific notation (the E is an exponent marker)
This becomes `0.21 × 10^15232511520495706`, which is an astronomically large number that Python represents as inf (infinity)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios_bgp_address_family

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
