### PR TITLE
Add ios_atomic_vlan_migration module

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Name | Description
 --- | ---
 [cisco.ios.ios_acl_interfaces](https://github.com/ansible-collections/cisco.ios/blob/main/docs/cisco.ios.ios_acl_interfaces_module.rst)|Resource module to configure ACL interfaces.
 [cisco.ios.ios_acls](https://github.com/ansible-collections/cisco.ios/blob/main/docs/cisco.ios.ios_acls_module.rst)|Resource module to configure ACLs.
+[cisco.ios.ios_atomic_vlan_migration](https://github.com/ansible-collections/cisco.ios/blob/main/docs/cisco.ios.ios_atomic_vlan_migration_module.rst)|Atomic migration of Management IP and Trunk Cleanup on Cisco IOS.
 [cisco.ios.ios_banner](https://github.com/ansible-collections/cisco.ios/blob/main/docs/cisco.ios.ios_banner_module.rst)|Module to configure multiline banners.
 [cisco.ios.ios_bfd_interfaces](https://github.com/ansible-collections/cisco.ios/blob/main/docs/cisco.ios.ios_bfd_interfaces_module.rst)|Resource module to configure bfd in interfaces.
 [cisco.ios.ios_bfd_templates](https://github.com/ansible-collections/cisco.ios/blob/main/docs/cisco.ios.ios_bfd_templates_module.rst)|Bidirectional Forwarding Detection (BFD) templates configurations

--- a/plugins/modules/ios_atomic_vlan_migration.py
+++ b/plugins/modules/ios_atomic_vlan_migration.py
@@ -3,10 +3,12 @@
 # (c) 2026, Divesh (@vishnusingh2700)
 # GNU General Public License v3.0+
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
+
+
 __metaclass__ = type
 
-DOCUMENTATION = r'''
+DOCUMENTATION = r"""
 ---
 module: ios_atomic_vlan_migration
 short_description: Atomic migration of Management IP and Trunk Cleanup on Cisco IOS.
@@ -50,9 +52,9 @@ options:
   mgmt_iface:
     description: Physical interface for management if is_root is true.
     type: str
-'''
+"""
 
-EXAMPLES = r'''
+EXAMPLES = r"""
 - name: Migrate Management to VLAN 99
   cisco.ios.ios_atomic_vlan_migration:
     new_ip: "192.168.100.10"
@@ -60,29 +62,31 @@ EXAMPLES = r'''
     vlan_id: 99
     trunks: ["GigabitEthernet0/0", "GigabitEthernet0/1"]
     native_vlan: 999
-'''
+"""
 
-RETURN = r'''
+RETURN = r"""
 msg:
   description: The status of the EEM applet creation.
   returned: always
   type: str
   sample: "EEM Applet MIGRATE_MGMT created successfully"
-'''
+"""
 
 from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.ios import load_config
+
 
 def generate_eem_commands(params):
     """EEM Script generate karne ka logic (Bulletproof Version)"""
-    applet_name = params['applet_name']
-    new_ip = params['new_ip']
-    mgmt_gateway = params['mgmt_gateway']
-    vlan_id = params['vlan_id']
-    mgmt_iface = params['mgmt_iface']
-    is_root = params['is_root']
-    trunks = ",".join(params['trunks'])
-    native_vlan = params['native_vlan']
+    applet_name = params["applet_name"]
+    new_ip = params["new_ip"]
+    mgmt_gateway = params["mgmt_gateway"]
+    vlan_id = params["vlan_id"]
+    mgmt_iface = params["mgmt_iface"]
+    is_root = params["is_root"]
+    trunks = ",".join(params["trunks"])
+    native_vlan = params["native_vlan"]
 
     commands = [
         f"no event manager applet {applet_name}",
@@ -98,47 +102,54 @@ def generate_eem_commands(params):
         f' action 3.1 cli command "ip address {new_ip} 255.255.255.0"',
         ' action 3.2 cli command "no shutdown"',
         ' action 3.3 cli command "exit"',
-        f' action 3.4 cli command "ip default-gateway {mgmt_gateway}"'
+        f' action 3.4 cli command "ip default-gateway {mgmt_gateway}"',
     ]
 
     if is_root and mgmt_iface:
-        commands.extend([
-            f' action 4.0 cli command "interface {mgmt_iface}"',
-            ' action 4.1 cli command "switchport mode access"',
-            f' action 4.2 cli command "switchport access vlan {vlan_id}"',
-            ' action 4.3 cli command "no switchport port-security"',
-            ' action 4.4 cli command "no spanning-tree bpduguard"'
-        ])
+        commands.extend(
+            [
+                f' action 4.0 cli command "interface {mgmt_iface}"',
+                ' action 4.1 cli command "switchport mode access"',
+                f' action 4.2 cli command "switchport access vlan {vlan_id}"',
+                ' action 4.3 cli command "no switchport port-security"',
+                ' action 4.4 cli command "no spanning-tree bpduguard"',
+            ]
+        )
     else:
-        commands.extend([
-            f' action 4.0 cli command "interface Vlan{vlan_id}"',
-            ' action 4.1 cli command "no shutdown"',
-            ' action 4.2 cli command "exit"'
-        ])
+        commands.extend(
+            [
+                f' action 4.0 cli command "interface Vlan{vlan_id}"',
+                ' action 4.1 cli command "no shutdown"',
+                ' action 4.2 cli command "exit"',
+            ]
+        )
 
-    commands.extend([
-        f' action 4.6 cli command "interface range {trunks}"',
-        f' action 4.7 cli command "switchport trunk allowed vlan add {vlan_id},999"',
-        ' action 4.8 cli command "switchport trunk allowed vlan remove 1"',
-        f' action 4.9 cli command "switchport trunk native vlan {native_vlan}"',
-        ' action 5.0 cli command "exit"',
-        f' action 5.1 cli command "no event manager applet {applet_name}"',
-        ' action 5.2 cli command "do write memory"',
-        ' action 6.0 cli command "end"'
-    ])
-    
+    commands.extend(
+        [
+            f' action 4.6 cli command "interface range {trunks}"',
+            f' action 4.7 cli command "switchport trunk allowed vlan add {vlan_id},999"',
+            ' action 4.8 cli command "switchport trunk allowed vlan remove 1"',
+            f' action 4.9 cli command "switchport trunk native vlan {native_vlan}"',
+            ' action 5.0 cli command "exit"',
+            f' action 5.1 cli command "no event manager applet {applet_name}"',
+            ' action 5.2 cli command "do write memory"',
+            ' action 6.0 cli command "end"',
+        ]
+    )
+
     return commands
+
 
 def main():
     module_args = dict(
-        applet_name=dict(type='str', default='MIGRATE_MGMT'),
-        new_ip=dict(type='str', required=True),
-        vlan_id=dict(type='int', default=99),
-        mgmt_iface=dict(type='str', required=False),
-        mgmt_gateway=dict(type='str', required=True),
-        is_root=dict(type='bool', default=False),
-        trunks=dict(type='list', required=True),
-        native_vlan=dict(type='int', default=999)
+        applet_name=dict(type="str", default="MIGRATE_MGMT"),
+        new_ip=dict(type="str", required=True),
+        vlan_id=dict(type="int", default=99),
+        mgmt_iface=dict(type="str", required=False),
+        mgmt_gateway=dict(type="str", required=True),
+        is_root=dict(type="bool", default=False),
+        trunks=dict(type="list", required=True),
+        native_vlan=dict(type="int", default=999),
     )
 
     module = AnsibleModule(argument_spec=module_args, supports_check_mode=True)
@@ -146,9 +157,12 @@ def main():
 
     if not module.check_mode:
         load_config(module, commands)
-        module.exit_json(changed=True, msg=f"EEM Applet {module.params['applet_name']} created successfully")
+        module.exit_json(
+            changed=True, msg=f"EEM Applet {module.params['applet_name']} created successfully"
+        )
     else:
         module.exit_json(changed=False, msg="Check mode: Commands generated but not pushed")
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/plugins/modules/ios_atomic_vlan_migration.py
+++ b/plugins/modules/ios_atomic_vlan_migration.py
@@ -1,0 +1,91 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.cisco.ios.plugins.module_utils.network.ios.ios import get_config, load_config
+
+def generate_eem_commands(params):
+    """EEM Script generate karne ka logic (Bulletproof Version)"""
+    applet_name = params['applet_name']
+    new_ip = params['new_ip']
+    mgmt_gateway = params['mgmt_gateway']
+    vlan_id = params['vlan_id']
+    mgmt_iface = params['mgmt_iface']
+    is_root = params['is_root']
+    trunks = ",".join(params['trunks'])
+    native_vlan = params['native_vlan']
+
+    commands = [
+        f"no event manager applet {applet_name}",
+        f"event manager applet {applet_name}",
+        " event timer countdown time 3600",
+        ' action 1.0 cli command "enable"',
+        ' action 1.1 cli command "conf t"',
+        ' action 2.0 cli command "interface Vlan1"',
+        ' action 2.1 cli command "no ip address dhcp"',
+        ' action 2.2 cli command "no ip address"',
+        ' action 2.3 cli command "shutdown"',
+        f' action 3.0 cli command "interface Vlan{vlan_id}"',
+        f' action 3.1 cli command "ip address {new_ip} 255.255.255.0"',
+        ' action 3.2 cli command "no shutdown"',
+        ' action 3.3 cli command "exit"',
+        f' action 3.4 cli command "ip default-gateway {mgmt_gateway}"'
+    ]
+
+    # Root Bridge vs Non-Root Logic (Playbook style)
+    if is_root and mgmt_iface:
+        commands.extend([
+            f' action 4.0 cli command "interface {mgmt_iface}"',
+            ' action 4.1 cli command "switchport mode access"',
+            f' action 4.2 cli command "switchport access vlan {vlan_id}"',
+            ' action 4.3 cli command "no switchport port-security"',
+            ' action 4.4 cli command "no spanning-tree bpduguard"'
+        ])
+    else:
+        commands.extend([
+            f' action 4.0 cli command "interface Vlan{vlan_id}"',
+            ' action 4.1 cli command "no shutdown"',
+            ' action 4.2 cli command "exit"'
+        ])
+
+    # Trunk Updates (VLAN 1 Removal Fixed!)
+    commands.extend([
+        f' action 4.6 cli command "interface range {trunks}"',
+        f' action 4.7 cli command "switchport trunk allowed vlan add {vlan_id},999"',
+        ' action 4.8 cli command "switchport trunk allowed vlan remove 1"',
+        f' action 4.9 cli command "switchport trunk native vlan {native_vlan}"',
+        ' action 5.0 cli command "exit"',
+        f' action 5.1 cli command "no event manager applet {applet_name}"',
+        ' action 5.2 cli command "do write memory"',
+        ' action 6.0 cli command "end"'
+    ])
+    
+    return commands
+
+def main():
+    # 1. Inputs define karna (Argument Spec)
+    module_args = dict(
+        applet_name=dict(type='str', default='MIGRATE_MGMT'),
+        new_ip=dict(type='str', required=True),
+        vlan_id=dict(type='int', default=99),
+        mgmt_iface=dict(type='str', required=False),
+        mgmt_gateway=dict(type='str', required=True),
+        is_root=dict(type='bool', default=False),
+        trunks=dict(type='list', required=True),
+        native_vlan=dict(type='int', default=999)
+    )
+
+    module = AnsibleModule(argument_spec=module_args, supports_check_mode=True)
+
+    # 2. Logic chalana
+    commands = generate_eem_commands(module.params)
+
+    # 3. Switch par push karna
+    if not module.check_mode:
+        load_config(module, commands)
+        module.exit_json(changed=True, msg=f"EEM Applet {module.params['applet_name']} created successfully")
+    else:
+        module.exit_json(changed=False, msg="Check mode: Commands generated but not pushed")
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/ios_atomic_vlan_migration.py
+++ b/plugins/modules/ios_atomic_vlan_migration.py
@@ -6,6 +6,7 @@
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 DOCUMENTATION = r"""
@@ -92,7 +93,12 @@ gathered:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.cisco.ios.plugins.module_utils.network.ios.ios import load_config, get_config
+
+from ansible_collections.cisco.ios.plugins.module_utils.network.ios.ios import (
+    get_config,
+    load_config,
+)
+
 
 def generate_eem_commands(params):
     """EEM Script logic - Takes data from config dictionary"""
@@ -105,16 +111,16 @@ def generate_eem_commands(params):
     vlan_id = params.get("vlan_id", 99)
     vrf_name = params.get("vrf", "MGMT")
     mgmt_iface = params.get("mgmt_iface")
-    
+
     trunk_list = params.get("trunks", [])
     trunks = ", ".join(trunk_list) if isinstance(trunk_list, list) else trunk_list
-    
+
     native_vlan = params.get("native_vlan", 999)
 
     commands = [
         "no event manager applet {0}".format(applet_name),
         "event manager applet {0}".format(applet_name),
-        ' event none',
+        " event none",
         ' action 1.0 cli command "enable"',
         ' action 1.1 cli command "conf t"',
         ' action 1.2 cli command "ip vrf {0}"'.format(vrf_name),
@@ -129,73 +135,97 @@ def generate_eem_commands(params):
         ' action 3.2 cli command "ip address {0} 255.255.255.0"'.format(new_ip),
         ' action 3.3 cli command "no shutdown"',
         ' action 3.4 cli command "exit"',
-        ' action 3.5 cli command "ip route vrf {0} 0.0.0.0 0.0.0.0 {1}"'.format(vrf_name, mgmt_gateway),
+        ' action 3.5 cli command "ip route vrf {0} 0.0.0.0 0.0.0.0 {1}"'.format(
+            vrf_name, mgmt_gateway
+        ),
     ]
 
     if mgmt_iface:
-        commands.extend([
-            ' action 4.0 cli command "interface {0}"'.format(mgmt_iface),
-            ' action 4.1 cli command "switchport mode access"',
-            ' action 4.2 cli command "switchport access vlan {0}"'.format(vlan_id),
-        ])
+        commands.extend(
+            [
+                ' action 4.0 cli command "interface {0}"'.format(mgmt_iface),
+                ' action 4.1 cli command "switchport mode access"',
+                ' action 4.2 cli command "switchport access vlan {0}"'.format(vlan_id),
+            ]
+        )
 
-    commands.extend([
-        ' action 5.0 cli command "interface range {0}"'.format(trunks),
-        ' action 5.1 cli command "switchport trunk allowed vlan add {0},{1}"'.format(vlan_id, native_vlan),
-        ' action 5.2 cli command "switchport trunk allowed vlan remove 1"',
-        ' action 5.3 cli command "switchport trunk native vlan {0}"'.format(native_vlan),
-        ' action 6.0 cli command "exit"',
-        ' action 6.1 cli command "conf t"',
-        ' action 6.2 cli command "no event manager applet {0}"'.format(applet_name),
-        ' action 6.3 cli command "do write memory"',
-        ' action 7.0 cli command "end"',
-    ])
+    commands.extend(
+        [
+            ' action 5.0 cli command "interface range {0}"'.format(trunks),
+            ' action 5.1 cli command "switchport trunk allowed vlan add {0},{1}"'.format(
+                vlan_id, native_vlan
+            ),
+            ' action 5.2 cli command "switchport trunk allowed vlan remove 1"',
+            ' action 5.3 cli command "switchport trunk native vlan {0}"'.format(native_vlan),
+            ' action 6.0 cli command "exit"',
+            ' action 6.1 cli command "conf t"',
+            ' action 6.2 cli command "no event manager applet {0}"'.format(applet_name),
+            ' action 6.3 cli command "do write memory"',
+            ' action 7.0 cli command "end"',
+        ]
+    )
 
     return commands
 
+
 def main():
     module_args = dict(
-        config=dict(type='dict', options=dict(
-            applet_name=dict(type='str', default='MIGRATE_MGMT'),
-            new_ip=dict(type='str', required=False), 
-            mgmt_gateway=dict(type='str', required=False),
-            vlan_id=dict(type='int', default=99),
-            vrf=dict(type='str', default='MGMT'),
-            trunks=dict(type='list', elements='str', required=False),
-            native_vlan=dict(type='int', default=999),
-            mgmt_iface=dict(type='str', required=False)
-        )),
-        state=dict(type='str', 
-                   choices=['merged', 'replaced', 'overridden', 'deleted', 'gathered', 'rendered', 'parsed'], 
-                   default='merged')
+        config=dict(
+            type="dict",
+            options=dict(
+                applet_name=dict(type="str", default="MIGRATE_MGMT"),
+                new_ip=dict(type="str", required=False),
+                mgmt_gateway=dict(type="str", required=False),
+                vlan_id=dict(type="int", default=99),
+                vrf=dict(type="str", default="MGMT"),
+                trunks=dict(type="list", elements="str", required=False),
+                native_vlan=dict(type="int", default=999),
+                mgmt_iface=dict(type="str", required=False),
+            ),
+        ),
+        state=dict(
+            type="str",
+            choices=[
+                "merged",
+                "replaced",
+                "overridden",
+                "deleted",
+                "gathered",
+                "rendered",
+                "parsed",
+            ],
+            default="merged",
+        ),
     )
 
     module = AnsibleModule(argument_spec=module_args, supports_check_mode=True)
-    state = module.params.get('state')
-    config = module.params.get('config') or {}
+    state = module.params.get("state")
+    config = module.params.get("config") or {}
 
-    if state not in ['deleted', 'gathered']:
-        missing = [k for k in ['new_ip', 'mgmt_gateway', 'trunks'] if not config.get(k)]
+    if state not in ["deleted", "gathered"]:
+        missing = [k for k in ["new_ip", "mgmt_gateway", "trunks"] if not config.get(k)]
         if missing:
             module.fail_json(msg="State {0} requires: {1}".format(state, ", ".join(missing)))
 
-    if state == 'parsed':
+    if state == "parsed":
         module.exit_json(parsed=config)
 
-    if state == 'rendered':
+    if state == "rendered":
         cmds = generate_eem_commands(config)
         module.exit_json(rendered=cmds)
-        
-    if state == 'gathered':
-        current_config = get_config(module, flags='| section event manager')
+
+    if state == "gathered":
+        current_config = get_config(module, flags="| section event manager")
         gathered_data = {
             "raw_config": current_config,
-            "status": "Applet found" if "event manager applet" in current_config else "No applet found"
+            "status": (
+                "Applet found" if "event manager applet" in current_config else "No applet found"
+            ),
         }
         module.exit_json(gathered=gathered_data, msg="Successfully fetched data from switch")
-        
-    if state == 'deleted':
-        applet = config.get('applet_name', 'MIGRATE_MGMT')
+
+    if state == "deleted":
+        applet = config.get("applet_name", "MIGRATE_MGMT")
         cleanup_cmds = ["no event manager applet {0}".format(applet)]
         load_config(module, cleanup_cmds)
         module.exit_json(changed=True, msg="Applet deleted", commands=cleanup_cmds)
@@ -204,9 +234,12 @@ def main():
         commands = generate_eem_commands(config)
         if not module.check_mode:
             load_config(module, commands)
-            module.exit_json(changed=True, msg="Resource {0} applied via EEM".format(state), commands=commands)
+            module.exit_json(
+                changed=True, msg="Resource {0} applied via EEM".format(state), commands=commands
+            )
         else:
             module.exit_json(changed=False, msg="Check mode: commands generated but not pushed")
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/plugins/modules/ios_atomic_vlan_migration.py
+++ b/plugins/modules/ios_atomic_vlan_migration.py
@@ -1,8 +1,77 @@
-#!/usr/bin/python
 # -*- coding: utf-8 -*-
 
+# (c) 2026, Divesh (@vishnusingh2700)
+# GNU General Public License v3.0+
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+DOCUMENTATION = r'''
+---
+module: ios_atomic_vlan_migration
+short_description: Atomic migration of Management IP and Trunk Cleanup on Cisco IOS.
+description:
+  - This module automates the migration of a management IP from VLAN 1 to a target VLAN.
+  - It uses Cisco EEM (Event Manager) to ensure the migration is atomic, preventing lockouts.
+  - It specifically handles the removal of VLAN 1 from trunk allowed lists and sets a new native VLAN.
+version_added: "1.0.0"
+author:
+  - Divesh (@vishnusingh2700)
+options:
+  applet_name:
+    description: Name of the EEM applet to be created on the switch.
+    type: str
+    default: MIGRATE_MGMT
+  new_ip:
+    description: The new Management IP address for the target VLAN.
+    type: str
+    required: true
+  mgmt_gateway:
+    description: The default gateway for the new management network.
+    type: str
+    required: true
+  vlan_id:
+    description: The ID of the new Management VLAN.
+    type: int
+    default: 99
+  trunks:
+    description: List of trunk interfaces to be updated.
+    type: list
+    elements: str
+    required: true
+  native_vlan:
+    description: The new native VLAN ID (Blackhole VLAN).
+    type: int
+    default: 999
+  is_root:
+    description: Set to true if the switch is the Root Bridge/Gateway.
+    type: bool
+    default: false
+  mgmt_iface:
+    description: Physical interface for management if is_root is true.
+    type: str
+'''
+
+EXAMPLES = r'''
+- name: Migrate Management to VLAN 99
+  cisco.ios.ios_atomic_vlan_migration:
+    new_ip: "192.168.100.10"
+    mgmt_gateway: "192.168.100.1"
+    vlan_id: 99
+    trunks: ["GigabitEthernet0/0", "GigabitEthernet0/1"]
+    native_vlan: 999
+'''
+
+RETURN = r'''
+msg:
+  description: The status of the EEM applet creation.
+  returned: always
+  type: str
+  sample: "EEM Applet MIGRATE_MGMT created successfully"
+'''
+
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.cisco.ios.plugins.module_utils.network.ios.ios import get_config, load_config
+from ansible_collections.cisco.ios.plugins.module_utils.network.ios.ios import load_config
 
 def generate_eem_commands(params):
     """EEM Script generate karne ka logic (Bulletproof Version)"""
@@ -32,7 +101,6 @@ def generate_eem_commands(params):
         f' action 3.4 cli command "ip default-gateway {mgmt_gateway}"'
     ]
 
-    # Root Bridge vs Non-Root Logic (Playbook style)
     if is_root and mgmt_iface:
         commands.extend([
             f' action 4.0 cli command "interface {mgmt_iface}"',
@@ -48,7 +116,6 @@ def generate_eem_commands(params):
             ' action 4.2 cli command "exit"'
         ])
 
-    # Trunk Updates (VLAN 1 Removal Fixed!)
     commands.extend([
         f' action 4.6 cli command "interface range {trunks}"',
         f' action 4.7 cli command "switchport trunk allowed vlan add {vlan_id},999"',
@@ -63,7 +130,6 @@ def generate_eem_commands(params):
     return commands
 
 def main():
-    # 1. Inputs define karna (Argument Spec)
     module_args = dict(
         applet_name=dict(type='str', default='MIGRATE_MGMT'),
         new_ip=dict(type='str', required=True),
@@ -76,11 +142,8 @@ def main():
     )
 
     module = AnsibleModule(argument_spec=module_args, supports_check_mode=True)
-
-    # 2. Logic chalana
     commands = generate_eem_commands(module.params)
 
-    # 3. Switch par push karna
     if not module.check_mode:
         load_config(module, commands)
         module.exit_json(changed=True, msg=f"EEM Applet {module.params['applet_name']} created successfully")

--- a/plugins/modules/ios_atomic_vlan_migration.py
+++ b/plugins/modules/ios_atomic_vlan_migration.py
@@ -1,10 +1,10 @@
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 
 # (c) 2026, Divesh (@vishnusingh2700)
 # GNU General Public License v3.0+
 
 from __future__ import absolute_import, division, print_function
-
 
 __metaclass__ = type
 
@@ -20,149 +20,193 @@ version_added: "1.0.0"
 author:
   - Divesh (@vishnusingh2700)
 options:
-  applet_name:
-    description: Name of the EEM applet to be created on the switch.
+  config:
+    description: The configuration objects for the network resource.
+    type: dict
+    suboptions:
+      applet_name:
+        description: Name of the EEM applet to be created.
+        type: str
+        default: MIGRATE_MGMT
+      new_ip:
+        description: The new Management IP address for the target VLAN.
+        type: str
+      mgmt_gateway:
+        description: The default gateway for the new management network.
+        type: str
+      vlan_id:
+        description: The ID of the new Management VLAN.
+        type: int
+        default: 99
+      vrf:
+        description: VRF name for management.
+        type: str
+        default: MGMT
+      trunks:
+        description: List of trunk interfaces to be updated.
+        type: list
+        elements: str
+      native_vlan:
+        description: The new native VLAN ID (Blackhole VLAN).
+        type: int
+        default: 999
+      mgmt_iface:
+        description: Physical interface for management if needed.
+        type: str
+  state:
+    description: The state of the configuration.
     type: str
-    default: MIGRATE_MGMT
-  new_ip:
-    description: The new Management IP address for the target VLAN.
-    type: str
-    required: true
-  mgmt_gateway:
-    description: The default gateway for the new management network.
-    type: str
-    required: true
-  vlan_id:
-    description: The ID of the new Management VLAN.
-    type: int
-    default: 99
-  trunks:
-    description: List of trunk interfaces to be updated.
-    type: list
-    elements: str
-    required: true
-  native_vlan:
-    description: The new native VLAN ID (Blackhole VLAN).
-    type: int
-    default: 999
-  is_root:
-    description: Set to true if the switch is the Root Bridge/Gateway.
-    type: bool
-    default: false
-  mgmt_iface:
-    description: Physical interface for management if is_root is true.
-    type: str
+    choices: [merged, replaced, overridden, deleted, gathered, rendered, parsed]
+    default: merged
 """
 
 EXAMPLES = r"""
-- name: Migrate Management to VLAN 99
+- name: Migrate Management to VLAN 99 (Merged)
   cisco.ios.ios_atomic_vlan_migration:
-    new_ip: "192.168.100.10"
-    mgmt_gateway: "192.168.100.1"
-    vlan_id: 99
-    trunks: ["GigabitEthernet0/0", "GigabitEthernet0/1"]
-    native_vlan: 999
+    config:
+      new_ip: "192.168.100.10"
+      mgmt_gateway: "192.168.100.1"
+      vlan_id: 99
+      trunks: ["GigabitEthernet0/0", "GigabitEthernet0/1"]
+    state: merged
+
+- name: Gather current EEM status
+  cisco.ios.ios_atomic_vlan_migration:
+    state: gathered
+
+- name: Render commands without pushing to switch
+  cisco.ios.ios_atomic_vlan_migration:
+    config:
+      new_ip: "192.168.100.10"
+      mgmt_gateway: "192.168.100.1"
+      trunks: ["Gi0/1"]
+    state: rendered
 """
 
 RETURN = r"""
-msg:
-  description: The status of the EEM applet creation.
-  returned: always
-  type: str
-  sample: "EEM Applet MIGRATE_MGMT created successfully"
+gathered:
+  description: The current configuration of the EEM applet.
+  returned: when state is gathered
+  type: dict
+  sample: {"raw_config": "event manager applet MIGRATE_MGMT...", "status": "Applet found"}
 """
 
 from ansible.module_utils.basic import AnsibleModule
-
-from ansible_collections.cisco.ios.plugins.module_utils.network.ios.ios import load_config
-
+from ansible_collections.cisco.ios.plugins.module_utils.network.ios.ios import load_config, get_config
 
 def generate_eem_commands(params):
-    """EEM Script generate karne ka logic (Bulletproof Version)"""
-    applet_name = params["applet_name"]
-    new_ip = params["new_ip"]
-    mgmt_gateway = params["mgmt_gateway"]
-    vlan_id = params["vlan_id"]
-    mgmt_iface = params["mgmt_iface"]
-    is_root = params["is_root"]
-    trunks = ",".join(params["trunks"])
-    native_vlan = params["native_vlan"]
+    """EEM Script logic - Takes data from config dictionary"""
+    if not params:
+        return []
+
+    applet_name = params.get("applet_name", "MIGRATE_MGMT")
+    new_ip = params.get("new_ip")
+    mgmt_gateway = params.get("mgmt_gateway")
+    vlan_id = params.get("vlan_id", 99)
+    vrf_name = params.get("vrf", "MGMT")
+    mgmt_iface = params.get("mgmt_iface")
+    
+    trunk_list = params.get("trunks", [])
+    trunks = ", ".join(trunk_list) if isinstance(trunk_list, list) else trunk_list
+    
+    native_vlan = params.get("native_vlan", 999)
 
     commands = [
-        f"no event manager applet {applet_name}",
-        f"event manager applet {applet_name}",
-        " event timer countdown time 3600",
+        "no event manager applet {0}".format(applet_name),
+        "event manager applet {0}".format(applet_name),
+        ' event none',
         ' action 1.0 cli command "enable"',
         ' action 1.1 cli command "conf t"',
+        ' action 1.2 cli command "ip vrf {0}"'.format(vrf_name),
+        ' action 1.3 cli command "rd 1:1"',
+        ' action 1.4 cli command "exit"',
         ' action 2.0 cli command "interface Vlan1"',
         ' action 2.1 cli command "no ip address dhcp"',
         ' action 2.2 cli command "no ip address"',
         ' action 2.3 cli command "shutdown"',
-        f' action 3.0 cli command "interface Vlan{vlan_id}"',
-        f' action 3.1 cli command "ip address {new_ip} 255.255.255.0"',
-        ' action 3.2 cli command "no shutdown"',
-        ' action 3.3 cli command "exit"',
-        f' action 3.4 cli command "ip default-gateway {mgmt_gateway}"',
+        ' action 3.0 cli command "interface Vlan{0}"'.format(vlan_id),
+        ' action 3.1 cli command "ip vrf forwarding {0}"'.format(vrf_name),
+        ' action 3.2 cli command "ip address {0} 255.255.255.0"'.format(new_ip),
+        ' action 3.3 cli command "no shutdown"',
+        ' action 3.4 cli command "exit"',
+        ' action 3.5 cli command "ip route vrf {0} 0.0.0.0 0.0.0.0 {1}"'.format(vrf_name, mgmt_gateway),
     ]
 
-    if is_root and mgmt_iface:
-        commands.extend(
-            [
-                f' action 4.0 cli command "interface {mgmt_iface}"',
-                ' action 4.1 cli command "switchport mode access"',
-                f' action 4.2 cli command "switchport access vlan {vlan_id}"',
-                ' action 4.3 cli command "no switchport port-security"',
-                ' action 4.4 cli command "no spanning-tree bpduguard"',
-            ]
-        )
-    else:
-        commands.extend(
-            [
-                f' action 4.0 cli command "interface Vlan{vlan_id}"',
-                ' action 4.1 cli command "no shutdown"',
-                ' action 4.2 cli command "exit"',
-            ]
-        )
+    if mgmt_iface:
+        commands.extend([
+            ' action 4.0 cli command "interface {0}"'.format(mgmt_iface),
+            ' action 4.1 cli command "switchport mode access"',
+            ' action 4.2 cli command "switchport access vlan {0}"'.format(vlan_id),
+        ])
 
-    commands.extend(
-        [
-            f' action 4.6 cli command "interface range {trunks}"',
-            f' action 4.7 cli command "switchport trunk allowed vlan add {vlan_id},999"',
-            ' action 4.8 cli command "switchport trunk allowed vlan remove 1"',
-            f' action 4.9 cli command "switchport trunk native vlan {native_vlan}"',
-            ' action 5.0 cli command "exit"',
-            f' action 5.1 cli command "no event manager applet {applet_name}"',
-            ' action 5.2 cli command "do write memory"',
-            ' action 6.0 cli command "end"',
-        ]
-    )
+    commands.extend([
+        ' action 5.0 cli command "interface range {0}"'.format(trunks),
+        ' action 5.1 cli command "switchport trunk allowed vlan add {0},{1}"'.format(vlan_id, native_vlan),
+        ' action 5.2 cli command "switchport trunk allowed vlan remove 1"',
+        ' action 5.3 cli command "switchport trunk native vlan {0}"'.format(native_vlan),
+        ' action 6.0 cli command "exit"',
+        ' action 6.1 cli command "conf t"',
+        ' action 6.2 cli command "no event manager applet {0}"'.format(applet_name),
+        ' action 6.3 cli command "do write memory"',
+        ' action 7.0 cli command "end"',
+    ])
 
     return commands
 
-
 def main():
     module_args = dict(
-        applet_name=dict(type="str", default="MIGRATE_MGMT"),
-        new_ip=dict(type="str", required=True),
-        vlan_id=dict(type="int", default=99),
-        mgmt_iface=dict(type="str", required=False),
-        mgmt_gateway=dict(type="str", required=True),
-        is_root=dict(type="bool", default=False),
-        trunks=dict(type="list", required=True),
-        native_vlan=dict(type="int", default=999),
+        config=dict(type='dict', options=dict(
+            applet_name=dict(type='str', default='MIGRATE_MGMT'),
+            new_ip=dict(type='str', required=False), 
+            mgmt_gateway=dict(type='str', required=False),
+            vlan_id=dict(type='int', default=99),
+            vrf=dict(type='str', default='MGMT'),
+            trunks=dict(type='list', elements='str', required=False),
+            native_vlan=dict(type='int', default=999),
+            mgmt_iface=dict(type='str', required=False)
+        )),
+        state=dict(type='str', 
+                   choices=['merged', 'replaced', 'overridden', 'deleted', 'gathered', 'rendered', 'parsed'], 
+                   default='merged')
     )
 
     module = AnsibleModule(argument_spec=module_args, supports_check_mode=True)
-    commands = generate_eem_commands(module.params)
+    state = module.params.get('state')
+    config = module.params.get('config') or {}
 
-    if not module.check_mode:
-        load_config(module, commands)
-        module.exit_json(
-            changed=True, msg=f"EEM Applet {module.params['applet_name']} created successfully"
-        )
+    if state not in ['deleted', 'gathered']:
+        missing = [k for k in ['new_ip', 'mgmt_gateway', 'trunks'] if not config.get(k)]
+        if missing:
+            module.fail_json(msg="State {0} requires: {1}".format(state, ", ".join(missing)))
+
+    if state == 'parsed':
+        module.exit_json(parsed=config)
+
+    if state == 'rendered':
+        cmds = generate_eem_commands(config)
+        module.exit_json(rendered=cmds)
+        
+    if state == 'gathered':
+        current_config = get_config(module, flags='| section event manager')
+        gathered_data = {
+            "raw_config": current_config,
+            "status": "Applet found" if "event manager applet" in current_config else "No applet found"
+        }
+        module.exit_json(gathered=gathered_data, msg="Successfully fetched data from switch")
+        
+    if state == 'deleted':
+        applet = config.get('applet_name', 'MIGRATE_MGMT')
+        cleanup_cmds = ["no event manager applet {0}".format(applet)]
+        load_config(module, cleanup_cmds)
+        module.exit_json(changed=True, msg="Applet deleted", commands=cleanup_cmds)
+
     else:
-        module.exit_json(changed=False, msg="Check mode: Commands generated but not pushed")
+        commands = generate_eem_commands(config)
+        if not module.check_mode:
+            load_config(module, commands)
+            module.exit_json(changed=True, msg="Resource {0} applied via EEM".format(state), commands=commands)
+        else:
+            module.exit_json(changed=False, msg="Check mode: commands generated but not pushed")
 
-
-if __name__ == "__main__":
+if __name__ == '__main__':
     main()


### PR DESCRIPTION
## Description
Hi team,

I have added a new module ios_atomic_vlan_migration that allows for a seamless, atomic migration of Management IPs and Trunk allowed-vlan cleanup on Cisco IOS devices.

Key Features:

Uses Cisco EEM applets to execute configuration changes atomically, which prevents administrative lockouts during IP migration.

Handles VLAN 1 removal from trunks and sets a new Native VLAN (Blackhole) for enhanced security.

Includes logic for both Root Bridge and non-root switches.

Request for Feedback:
This is my first contribution to the Cisco collection. I would appreciate it if the maintainers could review the code and suggest improvements to make it more robust or "Ansible-native." Specifically, I'm open to better ways of handling the EEM timer or making the subnet mask more dynamic.

Looking forward to your suggestions to make this module even better for the community!