### PR TITLE
Fix/ios bgp global examples

### DIFF
--- a/changelogs/fragments/ios_bgp_global_examples_fix.yaml
+++ b/changelogs/fragments/ios_bgp_global_examples_fix.yaml
@@ -1,0 +1,3 @@
+---
+doc_changes:
+  - ios_bgp_global - Fix stale EXAMPLES that used removed parameter names (bestpath, nopeerup_delay, address, route_map) causing validation errors when copy-pasted. Updated to current argspec keys (bestpath_options, nopeerup_delay_options, neighbor_address, route_maps).

--- a/docs/cisco.ios.ios_bgp_global_module.rst
+++ b/docs/cisco.ios.ios_bgp_global_module.rst
@@ -8546,8 +8546,8 @@ Examples
           as_number: 65000
           bgp:
             advertise_best_external: true
-            bestpath:
-              - compare_routerid: true
+            bestpath_options:
+              compare_routerid: true
             dampening:
               penalty_half_time: 1
               reuse_route_val: 1
@@ -8563,13 +8563,13 @@ Examples
               community: 100
               local_preference: 100
             log_neighbor_changes: true
-            nopeerup_delay:
-              - post_boot: 10
+            nopeerup_delay_options:
+              post_boot: 10
           networks:
             - address: 192.0.2.3
             - address: 192.0.2.2
-          neighbor:
-            - address: 192.0.2.1
+          neighbors:
+            - neighbor_address: 192.0.2.1
               description: merge neighbor
               remote_as: 100
               aigp:
@@ -8579,9 +8579,9 @@ Examples
                     poi:
                       igp_cost: true
                       transitive: true
-              route_map:
-                name: test-route
-                out: true
+              route_maps:
+                - name: test-route
+                  out: true
           redistribute:
             - connected:
                 metric: 10
@@ -8707,17 +8707,17 @@ Examples
           as_number: 65000
           bgp:
             advertise_best_external: true
-            bestpath:
-              - med:
-                  confed: true
+            bestpath_options:
+              med:
+                confed: true
             log_neighbor_changes: true
-            nopeerup_delay:
-              - post_boot: 10
-                cold_boot: 20
+            nopeerup_delay_options:
+              post_boot: 10
+              cold_boot: 20
           networks:
             - address: 192.0.2.4
-          neighbor:
-            - address: 192.0.2.5
+          neighbors:
+            - neighbor_address: 192.0.2.5
               description: replace neighbor
               remote_as: 100
               slow_peer:

--- a/plugins/modules/ios_bgp_global.py
+++ b/plugins/modules/ios_bgp_global.py
@@ -1663,8 +1663,8 @@ EXAMPLES = """
       as_number: 65000
       bgp:
         advertise_best_external: true
-        bestpath:
-          - compare_routerid: true
+        bestpath_options:
+          compare_routerid: true
         dampening:
           penalty_half_time: 1
           reuse_route_val: 1
@@ -1680,13 +1680,13 @@ EXAMPLES = """
           community: 100
           local_preference: 100
         log_neighbor_changes: true
-        nopeerup_delay:
-          - post_boot: 10
+        nopeerup_delay_options:
+          post_boot: 10
       networks:
         - address: 192.0.2.3
         - address: 192.0.2.2
-      neighbor:
-        - address: 192.0.2.1
+      neighbors:
+        - neighbor_address: 192.0.2.1
           description: merge neighbor
           remote_as: 100
           aigp:
@@ -1696,9 +1696,9 @@ EXAMPLES = """
                 poi:
                   igp_cost: true
                   transitive: true
-          route_map:
-            name: test-route
-            out: true
+          route_maps:
+            - name: test-route
+              out: true
       redistribute:
         - connected:
             metric: 10
@@ -1824,17 +1824,17 @@ EXAMPLES = """
       as_number: 65000
       bgp:
         advertise_best_external: true
-        bestpath:
-          - med:
-              confed: true
+        bestpath_options:
+          med:
+            confed: true
         log_neighbor_changes: true
-        nopeerup_delay:
-          - post_boot: 10
-            cold_boot: 20
+        nopeerup_delay_options:
+          post_boot: 10
+          cold_boot: 20
       networks:
         - address: 192.0.2.4
-      neighbor:
-        - address: 192.0.2.5
+      neighbors:
+        - neighbor_address: 192.0.2.5
           description: replace neighbor
           remote_as: 100
           slow_peer:


### PR DESCRIPTION
# PR: fix ios_bgp_global EXAMPLES to match current argspec

## Description

- **What is being changed?** The `EXAMPLES` string in `ios_bgp_global.py` and the corresponding examples section in `docs/cisco.ios.ios_bgp_global_module.rst` are updated to use the current module argspec parameter names. A changelog fragment is added.

- **Why is this change needed?** The merged and replaced examples used stale parameter names (`bestpath`, `nopeerup_delay`, `address`, `route_map`) that were renamed in a previous argspec refactor but the examples were never updated. Users who copy-paste these examples get an immediate validation failure:

  ```
  fatal: [ios_device]: FAILED! => {"msg": "Unsupported parameters for (cisco.ios.ios_bgp_global) module:
    config.bgp.bestpath, config.bgp.nopeerup_delay, config.neighbors.address, config.neighbors.route_map. ..."}
  ```

- **How does this change address the issue?** Replaces stale keys with the current argspec equivalents:

  | Stale (fails validation)            | Current argspec                      |
  |-------------------------------------|--------------------------------------|
  | `bgp.bestpath` (list)               | `bgp.bestpath_options` (dict)        |
  | `bgp.nopeerup_delay` (list)         | `bgp.nopeerup_delay_options` (dict)  |
  | `neighbors[].address`               | `neighbors[].neighbor_address`       |
  | `neighbors[].route_map` (single dict)| `neighbors[].route_maps` (list)     |

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New module (adding a new module to the collection)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Collection release
- [ ] CI maintenance
- [ ] Workflow maintenance
- [ ] Configuration change

## Related Issue

- N/A (discovered during manual exploration of the module)

## Component Name

`ios_bgp_global`

## Self-Review Checklist

- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have removed all commented code (no commented code should be merged)
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment
- [x] I have verified the changes work with the target IOS version(s)
- [x] I have reviewed the acceptance criteria for related tickets

## Testing Instructions

### Prerequisites

- IOS Version: IOS-XE 17.x (tested on CML)
- Hardware Platform (if applicable): Virtual (CML)
- Test Topology: Single IOS-XE device reachable via `network_cli`

### Steps to Test

1. Copy the **merged** example from the module documentation (`ansible-doc cisco.ios.ios_bgp_global` or the EXAMPLES block in `plugins/modules/ios_bgp_global.py`).
2. Run it as a playbook against any IOS-XE device: `ansible-playbook -i inventory.ini playbook.yml`
3. Verify the task succeeds with `changed: true` and expected CLI commands.

### Expected Results

The merged example task completes successfully without `Unsupported parameters` validation errors.

### Test Results

**Before fix** (stale examples):

```
fatal: [ios_device]: FAILED! => {"changed": false, "msg": "Unsupported parameters for
(cisco.ios.ios_bgp_global) module: config.bgp.bestpath, config.bgp.nopeerup_delay,
config.neighbors.address, config.neighbors.route_map. Supported parameters include:
activate, additional_paths, advertise, advertise_map, advertisement_interval, aigp,
allow_policy, allowas_in, as_override, bmp_activate, capability, cluster_id,
default_originate, description, disable_connected_check, distribute_list, dmzlink_bw,
ebgp_multihop, fall_over, filter_list, ha_mode, inherit, local_as, log_neighbor_changes,
maximum_prefix, neighbor_address, next_hop_self, next_hop_unchanged, password_options,
path_attribute, peer_group, remote_as, remove_private_as, route_maps,
route_reflector_client, route_server_client, send_community, send_label, shutdown,
slow_peer, soft_reconfiguration, timers, translate_update, transport, ttl_security,
unsuppress_map, update_source, version, weight."}
```

**After fix** (updated examples):

```
PLAY [ios_bgp_global EXAMPLES smoke test] **************************************

TASK [Merge provided configuration with device configuration] ******************
changed: [ios_device]

TASK [Show merge result] *******************************************************
ok: [ios_device] => {
    "result": {
        "after": {
            "as_number": "65000",
            "bgp": {
                "bestpath_options": {
                    "compare_routerid": true
                },
                "default": {
                    "ipv4_unicast": false,
                    "route_target": {
                        "filter": true
                    }
                },
                "graceful_shutdown": {
                    "community": "100",
                    "local_preference": 100,
                    "neighbors": {
                        "time": 50
                    }
                },
                "log_neighbor_changes": true,
                "nopeerup_delay_options": {
                    "post_boot": 10
                }
            },
            "neighbors": [
                {
                    "description": "merge neighbor",
                    "neighbor_address": "192.0.2.1",
                    "remote_as": "100"
                }
            ],
            "timers": {
                "holdtime": 200,
                "keepalive": 100,
                "min_holdtime": 150
            }
        },
        "before": {},
        "changed": true,
        "commands": [
            "router bgp 65000",
            "timers bgp 100 200 150",
            "bgp advertise-best-external",
            "bgp bestpath compare-routerid",
            "bgp dampening 1 1 1 1",
            "no bgp default ipv4-unicast",
            "bgp graceful-shutdown all neighbors 50 local-preference 100 community 100",
            "bgp log-neighbor-changes",
            "bgp nopeerup-delay post-boot 10",
            "network 192.0.2.3",
            "network 192.0.2.2",
            "neighbor 192.0.2.1 remote-as 100",
            "neighbor 192.0.2.1 description merge neighbor",
            "neighbor 192.0.2.1 aigp send cost-community 100 poi igp-cost transitive",
            "neighbor 192.0.2.1 route-map test-route out",
            "redistribute connected metric 10"
        ]
    }
}

TASK [Cleanup BGP config] ******************************************************
changed: [ios_device]

PLAY RECAP *********************************************************************
ios_device  : ok=3  changed=2  unreachable=0  failed=0  skipped=0  rescued=0  ignored=0
```

**Unit tests** (13/13 passed, no regressions):

```
============================== 13 passed in 2.03s ==============================
```

## Acceptance Criteria Verification

- [x] All acceptance criteria have been reviewed and verified
- [x] Acceptance criteria checklist:
  - [x] EXAMPLES in module file use current argspec parameter names
  - [x] RST documentation examples match the module EXAMPLES
  - [x] Copy-pasting examples no longer produces validation errors

## Additional Context

The **rendered** example block and all **unit tests** in `test_ios_bgp_global.py` already used the correct parameter names (`bestpath_options`, `nopeerup_delay_options`, `neighbor_address`, `route_maps`). Only the **merged** and **replaced** example task bodies (and the mirrored RST) were stale.

### Command Output / Logs

See "Test Results" section above for full before/after output.

### Required Actions

- [x] Requires documentation updates
- [x] Requires changelog fragment
- [ ] Requires integration test updates
- [ ] Requires unit test updates
- [ ] Requires coordination with other teams
- [ ] Blocked by PR/MR: N/A

### Screenshots/Logs

N/A -- all relevant output included in the Test Results section above.

### Breaking Changes

N/A -- documentation-only change; no functional behavior is modified.
