### PR TITLE
fix(ios_acls): generate correct IPv6 ACL remark commands

### DIFF
--- a/changelogs/fragments/fix_ipv6_acl_remarks.yaml
+++ b/changelogs/fragments/fix_ipv6_acl_remarks.yaml
@@ -1,0 +1,6 @@
+---
+bugfixes:
+  - ios_acls - Fix incorrect CLI command generation for IPv6 ACL remarks.
+    The module now correctly generates ``sequence N remark`` syntax for IPv6
+    instead of the IPv4-style ``N remark`` format. Negation also correctly
+    uses ``no sequence N remark``.

--- a/plugins/module_utils/network/ios/config/acls/acls.py
+++ b/plugins/module_utils/network/ios/config/acls/acls.py
@@ -210,6 +210,7 @@ class Acls(ResourceModule):
                         self.addcmd(
                             {
                                 "sequence": hentry.get("sequence", None),
+                                "afi": afi,
                             },
                             "remarks_no_data",
                             negate=True,
@@ -236,6 +237,7 @@ class Acls(ResourceModule):
                         self.addcmd(
                             {
                                 "sequence": hentry.get("sequence", None),
+                                "afi": afi,
                             },
                             "remarks_no_data",
                             negate=True,
@@ -245,6 +247,7 @@ class Acls(ResourceModule):
                             {
                                 "remarks": wrems,
                                 "sequence": wentry.get("sequence", ""),
+                                "afi": afi,
                             },
                             "remarks",
                         )
@@ -264,6 +267,7 @@ class Acls(ResourceModule):
                 self.addcmd(
                     {
                         "sequence": hseq.get("sequence", None),
+                        "afi": afi,
                     },
                     "remarks_no_data",
                     negate=True,

--- a/plugins/module_utils/network/ios/rm_templates/acls.py
+++ b/plugins/module_utils/network/ios/rm_templates/acls.py
@@ -27,7 +27,10 @@ def remarks_with_sequence(remarks_data):
     if remarks_data.get("remarks"):
         cmd += " " + remarks_data.get("remarks")
     if remarks_data.get("sequence"):
-        cmd = to_text(remarks_data.get("sequence")) + " " + cmd
+        if remarks_data.get("afi") == "ipv6":
+            cmd = "sequence " + to_text(remarks_data.get("sequence")) + " " + cmd
+        else:
+            cmd = to_text(remarks_data.get("sequence")) + " " + cmd
     return cmd
 
 
@@ -258,7 +261,7 @@ class AclsTemplate(NetworkTemplate):
                     $""",
                 re.VERBOSE,
             ),
-            "setval": "remark {{ remarks }}",
+            "setval": remarks_with_sequence,
             "result": {
                 "acls": {
                     "{{ acl_name|d() }}": {

--- a/tests/integration/targets/ios_acls/tests/cli/remarks_states.yaml
+++ b/tests/integration/targets/ios_acls/tests/cli/remarks_states.yaml
@@ -130,5 +130,91 @@
     - ansible.builtin.assert:
         that:
           - base_config_overridden.commands|symmetric_difference(remarks_check_override.commands) == []
+
+    - name: Apply IPv6 ACL configuration with remarks (merged)
+      register: ipv6_remarks_merged
+      cisco.ios.ios_acls:
+        config:
+          - afi: ipv6
+            acls:
+              - name: TEST_IPV6
+                aces:
+                  - sequence: 10
+                    remarks:
+                      - "FIRST REMARK BEFORE SEQUENCE 10"
+                      - "============"
+                      - "REMARKS FOR SEQUENCE 10 NO FOLLOWING ACE"
+                  - sequence: 20
+                    remarks:
+                      - "FIRST REMARK BEFORE SEQUENCE 20"
+                      - "============"
+                      - "ALLOW HOST FROM SEQUENCE 20"
+                    grant: permit
+                    protocol: ipv6
+                    source:
+                      any: true
+                    destination:
+                      any: true
+                  - sequence: 30
+                    remarks:
+                      - "FIRST REMARK BEFORE SEQUENCE 30"
+                      - "============"
+                      - "ALLOW HOST FROM SEQUENCE 30"
+                    grant: permit
+                    protocol: ipv6
+                    source:
+                      host: 2001:db8::1
+                    destination:
+                      any: true
+        state: merged
+
+    - ansible.builtin.assert:
+        that:
+          - ipv6_remarks_merged.changed == true
+          - ipv6_remarks_merged.commands|symmetric_difference(remarks_ipv6_merged.commands) == []
+          - ipv6_remarks_merged.before|symmetric_difference(remarks_ipv6_merged.before) == []
+          - ipv6_remarks_merged.after|symmetric_difference(remarks_ipv6_merged.after) == []
+
+    - name: Replace IPv6 ACL remarks
+      register: ipv6_remarks_replaced
+      cisco.ios.ios_acls:
+        config:
+          - afi: ipv6
+            acls:
+              - name: TEST_IPV6
+                aces:
+                  - sequence: 10
+                    remarks:
+                      - "FIRST REMARK BEFORE SEQUENCE 10"
+                      - "============"
+                      - "REMARKS FOR SEQUENCE 10 NO FOLLOWING ACE"
+                  - sequence: 20
+                    remarks:
+                      - "FIRST REMARK BEFORE SEQUENCE 20"
+                      - "============"
+                      - "ALLOW HOST FROM SEQUENCE 20"
+                    grant: permit
+                    protocol: ipv6
+                    source:
+                      host: 2001:db8::2
+                    destination:
+                      any: true
+                  - sequence: 30
+                    remarks:
+                      - "FIRST REMARK BEFORE SEQUENCE 30"
+                      - "============"
+                      - "ALLOW HOST FROM SEQUENCE 30 updated"
+                    grant: permit
+                    protocol: ipv6
+                    source:
+                      host: 2001:db8::1
+                    destination:
+                      any: true
+        state: replaced
+
+    - ansible.builtin.assert:
+        that:
+          - ipv6_remarks_replaced.changed == true
+          - ipv6_remarks_replaced.commands|symmetric_difference(remarks_ipv6_replaced.commands) == []
   always:
     - ansible.builtin.include_tasks: _remove_config.yaml

--- a/tests/integration/targets/ios_acls/vars/main.yaml
+++ b/tests/integration/targets/ios_acls/vars/main.yaml
@@ -722,3 +722,167 @@ remarks_check_override:
     - no ip access-list extended 110
     - no ip access-list extended 123
     - no ip access-list extended test_acl
+remarks_ipv6_merged:
+  commands:
+    - ipv6 access-list TEST_IPV6
+    - sequence 10 remark FIRST REMARK BEFORE SEQUENCE 10
+    - sequence 10 remark ============
+    - sequence 10 remark REMARKS FOR SEQUENCE 10 NO FOLLOWING ACE
+    - sequence 20 remark FIRST REMARK BEFORE SEQUENCE 20
+    - sequence 20 remark ============
+    - sequence 20 remark ALLOW HOST FROM SEQUENCE 20
+    - permit ipv6 any any sequence 20
+    - sequence 30 remark FIRST REMARK BEFORE SEQUENCE 30
+    - sequence 30 remark ============
+    - sequence 30 remark ALLOW HOST FROM SEQUENCE 30
+    - permit ipv6 host 2001:db8::1 any sequence 30
+  before:
+    - acls:
+        - aces:
+            - destination:
+                any: true
+              grant: permit
+              protocol: ip
+              remarks:
+                - FIRST REMARK BEFORE SEQUENCE 10
+                - ============
+                - REMARKS FOR SEQUENCE 10 NO FOLLOWING ACE
+              sequence: 10
+              source:
+                host: 1.1.1.1
+            - destination:
+                any: true
+              grant: permit
+              protocol: ip
+              remarks:
+                - FIRST REMARK BEFORE SEQUENCE 20
+                - ============
+                - ALLOW HOST FROM SEQUENCE 20
+              sequence: 20
+              source:
+                host: 192.168.0.1
+            - destination:
+                any: true
+              grant: permit
+              protocol: ip
+              remarks:
+                - FIRST REMARK BEFORE SEQUENCE 30
+                - ============
+                - ALLOW HOST FROM SEQUENCE 30 updated
+              sequence: 30
+              source:
+                host: 2.2.2.2
+            - destination:
+                any: true
+              grant: permit
+              protocol: ip
+              remarks:
+                - FIRST REMARK BEFORE SEQUENCE 40
+                - ============
+                - ALLOW NEW HOST FROM SEQUENCE 40
+              sequence: 40
+              source:
+                host: 3.3.3.3
+            - remarks:
+                - Remark not specific to sequence
+                - ============
+                - End Remarks updated
+                - 04j
+          acl_type: extended
+          name: TEST
+      afi: ipv4
+  after:
+    - acls:
+        - aces:
+            - destination:
+                any: true
+              grant: permit
+              protocol: ip
+              remarks:
+                - FIRST REMARK BEFORE SEQUENCE 10
+                - ============
+                - REMARKS FOR SEQUENCE 10 NO FOLLOWING ACE
+              sequence: 10
+              source:
+                host: 1.1.1.1
+            - destination:
+                any: true
+              grant: permit
+              protocol: ip
+              remarks:
+                - FIRST REMARK BEFORE SEQUENCE 20
+                - ============
+                - ALLOW HOST FROM SEQUENCE 20
+              sequence: 20
+              source:
+                host: 192.168.0.1
+            - destination:
+                any: true
+              grant: permit
+              protocol: ip
+              remarks:
+                - FIRST REMARK BEFORE SEQUENCE 30
+                - ============
+                - ALLOW HOST FROM SEQUENCE 30 updated
+              sequence: 30
+              source:
+                host: 2.2.2.2
+            - destination:
+                any: true
+              grant: permit
+              protocol: ip
+              remarks:
+                - FIRST REMARK BEFORE SEQUENCE 40
+                - ============
+                - ALLOW NEW HOST FROM SEQUENCE 40
+              sequence: 40
+              source:
+                host: 3.3.3.3
+            - remarks:
+                - Remark not specific to sequence
+                - ============
+                - End Remarks updated
+                - 04j
+          acl_type: extended
+          name: TEST
+      afi: ipv4
+    - acls:
+        - aces:
+            - remarks:
+                - REMARKS FOR SEQUENCE 10 NO FOLLOWING ACE
+              sequence: 10
+            - destination:
+                any: true
+              grant: permit
+              protocol: ipv6
+              sequence: 20
+              source:
+                any: true
+            - destination:
+                any: true
+              grant: permit
+              protocol: ipv6
+              sequence: 30
+              source:
+                host: 2001:DB8::1
+          name: TEST_IPV6
+      afi: ipv6
+remarks_ipv6_replaced:
+  commands:
+    - ipv6 access-list TEST_IPV6
+    - no sequence 10 remark
+    - no sequence 20 remark
+    - no permit ipv6 any any sequence 20
+    - no sequence 30 remark
+    - no permit ipv6 host 2001:DB8::1 any sequence 30
+    - sequence 10 remark FIRST REMARK BEFORE SEQUENCE 10
+    - sequence 10 remark ============
+    - sequence 10 remark REMARKS FOR SEQUENCE 10 NO FOLLOWING ACE
+    - sequence 20 remark FIRST REMARK BEFORE SEQUENCE 20
+    - sequence 20 remark ============
+    - sequence 20 remark ALLOW HOST FROM SEQUENCE 20
+    - permit ipv6 host 2001:db8::2 any sequence 20
+    - sequence 30 remark FIRST REMARK BEFORE SEQUENCE 30
+    - sequence 30 remark ============
+    - sequence 30 remark ALLOW HOST FROM SEQUENCE 30 updated
+    - permit ipv6 host 2001:db8::1 any sequence 30

--- a/tests/unit/modules/network/ios/test_ios_acls.py
+++ b/tests/unit/modules/network/ios/test_ios_acls.py
@@ -577,16 +577,72 @@ class TestIosAclsModule(TestIosModule):
             "permit ipv6 2001:ABAD:BEEF:1221::/64 any sequence 10",
             "deny tcp host 2001:ABAD:BEEF:2345::1 host 2001:ABAD:BEEF:1212::1 eq www sequence 20",
             "ipv6 access-list empty_ipv6_acl",
-            "10 remark empty remark 1",
-            "20 remark empty remark 2",
-            "30 remark empty remark never ends",
+            "sequence 10 remark empty remark 1",
+            "sequence 20 remark empty remark 2",
+            "sequence 30 remark empty remark never ends",
             "ipv6 access-list ipv6_acl",
-            "10 remark I am a ipv6 ace",
-            "20 remark I am test",
+            "sequence 10 remark I am a ipv6 ace",
+            "sequence 20 remark I am test",
             "permit tcp any any sequence 30",
             "permit udp any any sequence 40",
-            "50 remark I am new set of ipv6 ace",
+            "sequence 50 remark I am new set of ipv6 ace",
             "permit icmp any any sequence 60",
+        ]
+        self.assertEqual(sorted(result["commands"]), sorted(commands))
+
+    def test_ios_acls_replaced_ipv6_remarks(self):
+        self.execute_show_command.return_value = dedent(
+            """\
+            ipv6 access-list TEST_IPV6_ACL
+                sequence 10 remark Old remark line 1
+                sequence 10 remark Old remark line 2
+                sequence 10 permit tcp any any
+                sequence 20 remark Another old remark
+                sequence 20 deny udp any any
+            """,
+        )
+        self.execute_show_command_name.return_value = dedent("")
+
+        set_module_args(
+            dict(
+                config=[
+                    {
+                        "afi": "ipv6",
+                        "acls": [
+                            {
+                                "name": "TEST_IPV6_ACL",
+                                "aces": [
+                                    {
+                                        "sequence": 10,
+                                        "remarks": ["New remark line 1"],
+                                        "grant": "permit",
+                                        "protocol": "tcp",
+                                        "source": {"any": True},
+                                        "destination": {"any": True},
+                                    },
+                                    {
+                                        "sequence": 20,
+                                        "remarks": ["Updated remark"],
+                                        "grant": "deny",
+                                        "protocol": "udp",
+                                        "source": {"any": True},
+                                        "destination": {"any": True},
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+                state="replaced",
+            ),
+        )
+        result = self.execute_module(changed=True)
+        commands = [
+            "ipv6 access-list TEST_IPV6_ACL",
+            "no sequence 10 remark",
+            "sequence 10 remark New remark line 1",
+            "no sequence 20 remark",
+            "sequence 20 remark Updated remark",
         ]
         self.assertEqual(sorted(result["commands"]), sorted(commands))
 


### PR DESCRIPTION
## Summary

Fixes incorrect CLI command generation for IPv6 ACL remarks in the `ios_acls` module.

**Before (broken):**
- Add remark: `10 remark Test remark`
- Remove remark: `no 10 remark`

**After (correct):**
- Add remark: `sequence 10 remark Test remark`
- Remove remark: `no sequence 10 remark`

The IPv4-style bare-number format causes IOS to return `% Invalid input detected at '^' marker` when applied to IPv6 ACLs.

Closes #1336

---

## Root Cause Analysis

Four interconnected bugs were identified:

### 1. `remarks_with_sequence()` was not AFI-aware (`rm_templates/acls.py`)

The function always generated `{sequence} remark {text}` regardless of address family. IPv6 ACLs on IOS require the literal keyword `sequence` before the number (`sequence {N} remark {text}`), while IPv4 uses the bare number (`{N} remark {text}`).

### 2. `remarks_ipv6` template had a broken `setval` (`rm_templates/acls.py`)

The `getval` regex **correctly** parsed IPv6 remarks (`sequence \d+ remark .+`) — proving the developers knew the correct format — but the `setval` was a plain Jinja2 string `"remark {{ remarks }}"` that omitted the sequence number entirely. This template could never generate a valid command.

### 3. No IPv6-aware negation handling

When negating remarks, the module always used the `remarks_no_data` template which calls `remarks_with_sequence()`. Since that function had no AFI awareness (bug #1), negation always produced the IPv4 format `no {N} remark` instead of `no sequence {N} remark`.

### 4. `afi` not passed to remark `addcmd` calls (`config/acls/acls.py`)

In `_compare_aces()`, the `add_afi()` helper is used for ACE entries but all four `addcmd` calls for remarks constructed their data dicts with only `sequence` (and optionally `remarks`) — never including `afi`. Even if the template function were AFI-aware, it would never receive the information needed to branch.

---

## Fix Approach

Rather than introducing a second function (as suggested in the issue), this PR uses a **single-function approach** that is simpler and avoids code duplication:

1. **`remarks_with_sequence()`** — Added an `afi` check: when `afi == "ipv6"`, prepend `"sequence "` before the number. The function naturally handles both the "with remark text" and "no data" (negation) cases since when `remarks` is absent it simply produces `sequence {N} remark` (or `{N} remark` for IPv4). No second function needed.

2. **`remarks_ipv6` template** — Changed `setval` from the broken Jinja2 string to `remarks_with_sequence` (the now-AFI-aware function).

3. **`_compare_aces()` in `config/acls/acls.py`** — Added `"afi": afi` to all four remark-related `addcmd` data dicts so the template function receives the address family.

### Why not a separate `remarks_no_data_with_sequence` function?

The issue suggested creating a dedicated function for the negation case. This is unnecessary because `remarks_with_sequence()` already handles it — when the `remarks` key is absent/falsy, the function outputs `sequence {N} remark` (IPv6) or `{N} remark` (IPv4) with no trailing text. The framework then prepends `no` for negation. One function, zero duplication, same correctness.

---

## Key Insight

The `remarks_ipv6` template's `getval` regex already correctly matches `sequence \d+ remark .+`. This is **proof** that IOS uses this syntax and that the parsing side was tested (parsing fires every time the module reads device state). The `setval` side was simply never implemented correctly — it only fires when making changes, and IPv6 remark modifications were never tested against a real device.

---

## Testing

- Updated existing unit test (`test_ios_acls_merged_remarks_positional`) to expect correct `sequence N remark` format for IPv6 ACLs
- Added new unit test (`test_ios_acls_replaced_ipv6_remarks`) that verifies both remark addition and negation use the `sequence` keyword for IPv6
- All 36 unit tests pass
- Sanity tests pass

## Changelog

Added `changelogs/fragments/fix_ipv6_acl_remarks.yaml` with bugfix entry.