### PR TITLE
Fix phantom/missing commands in ios_interfaces and ios_l3_interfaces integration vars

### DIFF
--- a/changelogs/fragments/fix_integration_vars_phantom_commands.yaml
+++ b/changelogs/fragments/fix_integration_vars_phantom_commands.yaml
@@ -1,0 +1,8 @@
+---
+bugfixes:
+  - ios_interfaces - Align integration test ``deleted`` expected commands with device
+    behavior; remove phantom ``shutdown`` on GigabitEthernet3 that the module skips
+    when the interface is already shut down.
+  - ios_l3_interfaces - Align integration test ``replaced`` expected commands with
+    device output; add missing redirect/unreachable negations on GigabitEthernet3
+    and correct command order to match the module.

--- a/changelogs/fragments/fix_integration_vars_phantom_commands.yaml
+++ b/changelogs/fragments/fix_integration_vars_phantom_commands.yaml
@@ -1,5 +1,5 @@
 ---
-bugfixes:
+trivial:
   - ios_interfaces - Align integration test ``deleted`` expected commands with device
     behavior; remove phantom ``shutdown`` on GigabitEthernet3 that the module skips
     when the interface is already shut down.

--- a/tests/integration/targets/ios_interfaces/vars/main.yaml
+++ b/tests/integration/targets/ios_interfaces/vars/main.yaml
@@ -156,7 +156,6 @@ deleted:
     - interface GigabitEthernet3
     - no description this is interface for testing
     - no speed 1000
-    - shutdown
   after:
     - description: Management interface do not change
       enabled: true

--- a/tests/integration/targets/ios_l3_interfaces/vars/main.yaml
+++ b/tests/integration/targets/ios_l3_interfaces/vars/main.yaml
@@ -97,16 +97,20 @@ replaced:
     - no ip unreachables
     - no ipv6 redirects
     - no ipv6 unreachables
-    - no ip address 203.0.113.27 255.255.255.0
     - ip address 203.0.114.1 255.255.255.0
+    - no ip address 203.0.113.27 255.255.255.0
     - interface GigabitEthernet3
-    - no ipv6 address autoconfig
-    - no ipv6 address 2001:db8:0:3::/64
-    - no ip address 192.0.2.2 255.255.255.0
-    - no ip address 192.0.2.1 255.255.255.0 secondary
-    - ipv6 address 2001:db8:1:1::/64
+    - no ip redirects
+    - no ip unreachables
+    - no ipv6 redirects
+    - no ipv6 unreachables
     - ip address 198.51.100.2 255.255.255.0
     - ip address 198.51.100.1 255.255.255.0 secondary
+    - no ip address 192.0.2.1 255.255.255.0 secondary
+    - no ip address 192.0.2.2 255.255.255.0
+    - ipv6 address 2001:db8:1:1::/64
+    - no ipv6 address 2001:db8:0:3::/64
+    - no ipv6 address autoconfig
   after:
     # - name: Loopback888
     # - name: Loopback999


### PR DESCRIPTION
## Summary

Corrects integration test `vars/main.yaml` expected command lists for two states where **CI passed but vars did not match real device output**. Assertions use `symmetric_difference`, which compares commands as a **set**, so these issues were bypassed:

- **Extra commands in vars** (phantom) still pass if the device sends a subset with the same strings elsewhere in the list.
- **Missing commands in vars** still pass if the multiset matches after set conversion.
- **Order differences** also pass (not addressed in this PR).

This PR fixes only the two **count mismatch** cases found by auditing resource modules against a cat8000v device.

## Changes

### `ios_interfaces` — `deleted`

- **Problem**: vars listed 8 commands; device sent 7. Extra `shutdown` on GigabitEthernet3.
- **Cause**: populate leaves GE3 shut down; module correctly skips redundant `shutdown`. The phantom line was never sent on device but remained in vars.
- **Fix**: Remove `shutdown` from `deleted.commands` for GigabitEthernet3.

### `ios_l3_interfaces` — `replaced`

- **Problem**: vars listed 15 commands; device sent 19.
- **Cause**: vars included redirect/unreachable negations only under GigabitEthernet2; module also emits `no ip redirects`, `no ip unreachables`, `no ipv6 redirects`, and `no ipv6 unreachables` on GigabitEthernet3 when applying `redirects`/`unreachables` false in replaced config.
- **Fix**: Add the four missing lines on GE3 and reorder commands to match module output.

## How CI was bypassed

Example assertion (unchanged by this PR):

```yaml
- "{{ deleted['commands'] | symmetric_difference(result['commands']) | length == 0 }}"
```

For `ios_interfaces` deleted, expected and actual differ by one `shutdown` on GE3, but symmetric difference is empty because another `shutdown` exists on GE2 — same string in the set.

## Test plan

- [ ] `ansible-test network-integration --target ios_interfaces` (deleted state)
- [ ] `ansible-test network-integration --target ios_l3_interfaces` (replaced state)
- [ ] CML integration workflow (label **safe to test**)