### PR TITLE
fix(ios_bgp_address_family): add vpls as valid safi for l2vpn

### DIFF
--- a/changelogs/fragments/fix_bgp_af_vpls_safi.yaml
+++ b/changelogs/fragments/fix_bgp_af_vpls_safi.yaml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - ios_bgp_address_family - Add ``vpls`` as a valid ``safi`` choice for the
+    ``l2vpn`` address family configuration.

--- a/docs/cisco.ios.ios_bgp_address_family_module.rst
+++ b/docs/cisco.ios.ios_bgp_address_family_module.rst
@@ -7502,6 +7502,7 @@ Parameters
                                     <li>mvpn</li>
                                     <li>evpn</li>
                                     <li>unicast</li>
+                                    <li>vpls</li>
                         </ul>
                 </td>
                 <td>

--- a/plugins/module_utils/network/ios/argspec/bgp_address_family/bgp_address_family.py
+++ b/plugins/module_utils/network/ios/argspec/bgp_address_family/bgp_address_family.py
@@ -54,7 +54,15 @@ class Bgp_address_familyArgs(object):  # pylint: disable=R0903
                         },
                         "safi": {
                             "type": "str",
-                            "choices": ["flowspec", "mdt", "multicast", "mvpn", "evpn", "unicast", "vpls"],
+                            "choices": [
+                                "flowspec",
+                                "mdt",
+                                "multicast",
+                                "mvpn",
+                                "evpn",
+                                "unicast",
+                                "vpls",
+                            ],
                         },
                         "vrf": {"type": "str"},
                         "aggregate_addresses": {

--- a/plugins/module_utils/network/ios/argspec/bgp_address_family/bgp_address_family.py
+++ b/plugins/module_utils/network/ios/argspec/bgp_address_family/bgp_address_family.py
@@ -54,7 +54,7 @@ class Bgp_address_familyArgs(object):  # pylint: disable=R0903
                         },
                         "safi": {
                             "type": "str",
-                            "choices": ["flowspec", "mdt", "multicast", "mvpn", "evpn", "unicast"],
+                            "choices": ["flowspec", "mdt", "multicast", "mvpn", "evpn", "unicast", "vpls"],
                         },
                         "vrf": {"type": "str"},
                         "aggregate_addresses": {

--- a/plugins/module_utils/network/ios/config/bgp_address_family/bgp_address_family.py
+++ b/plugins/module_utils/network/ios/config/bgp_address_family/bgp_address_family.py
@@ -18,8 +18,11 @@ necessary to bring the current configuration to its desired end-state is
 created.
 """
 
+import re
+
 from copy import deepcopy
 
+from ansible.module_utils.connection import ConnectionError
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.rm_base.resource_module import (
     ResourceModule,
 )
@@ -100,6 +103,8 @@ class Bgp_address_family(ResourceModule):
             tmplt=Bgp_address_familyTemplate(),
         )
 
+    _TOPOLOGY_INIT_RE = re.compile(r"Error initializing topology", re.I)
+
     def execute_module(self):
         """Execute the module
 
@@ -110,6 +115,28 @@ class Bgp_address_family(ResourceModule):
             self.generate_commands()
             self.run_commands()
         return self.result
+
+    def run_commands(self):
+        """Send commands to the device, with a human-friendly error
+        when an address-family requires a platform license that is
+        not active (e.g. l2vpn vpls needs DNA-Advantage)."""
+        try:
+            super().run_commands()
+        except ConnectionError as exc:
+            if self._TOPOLOGY_INIT_RE.search(str(exc)):
+                self._module.fail_json(
+                    msg=(
+                        "The device rejected an address-family with "
+                        "'%% BGP: Error initializing topology'. "
+                        "This typically means the required platform license "
+                        "is not active (e.g. 'license boot level ax' on "
+                        "CSR1000v, or 'license boot level network-advantage "
+                        "addon dna-advantage' on Catalyst 8000v/9000). "
+                        "Enable the appropriate license and reload the device."
+                    ),
+                    commands=self.commands,
+                )
+            raise
 
     def generate_commands(self):
         """Generate configuration commands to send based on

--- a/plugins/modules/ios_bgp_address_family.py
+++ b/plugins/modules/ios_bgp_address_family.py
@@ -48,7 +48,7 @@ options:
           safi:
             description: Address Family modifier
             type: str
-            choices: ["flowspec", "mdt", "multicast", "mvpn", "evpn", "unicast"]
+            choices: ["flowspec", "mdt", "multicast", "mvpn", "evpn", "unicast", "vpls"]
           vrf:
             description: Specify parameters for a VPN Routing/Forwarding instance
             type: str

--- a/tests/integration/targets/ios_bgp_address_family/tests/cli/_check_l2vpn_vpls_support.yaml
+++ b/tests/integration/targets/ios_bgp_address_family/tests/cli/_check_l2vpn_vpls_support.yaml
@@ -1,0 +1,34 @@
+---
+# Probe whether the device has the platform license required for the
+# l2vpn vpls address-family active (e.g. DNA-Advantage / 'ax'). Devices
+# without the license reject this with '% BGP: Error initializing
+# topology'. This lets l2vpn vpls specific scenarios skip gracefully on
+# unlicensed platforms instead of failing CI.
+- name: Probe l2vpn vpls address-family support
+  register: l2vpn_vpls_probe
+  ignore_errors: true
+  cisco.ios.ios_config:
+    lines:
+      - address-family l2vpn vpls
+      - exit-address-family
+    parents: router bgp 65000
+
+- name: Remove the probe address-family so it doesn't leak into facts
+  when: not (l2vpn_vpls_probe.failed | default(false))
+  cisco.ios.ios_config:
+    lines:
+      - no address-family l2vpn vpls
+    parents: router bgp 65000
+
+- name: Set fact for l2vpn vpls support
+  ansible.builtin.set_fact:
+    l2vpn_vpls_supported: "{{ not (l2vpn_vpls_probe.failed | default(false)) }}"
+
+- name: Notice when l2vpn vpls scenarios will be skipped
+  when: not l2vpn_vpls_supported
+  ansible.builtin.debug:
+    msg: >-
+      Skipping l2vpn vpls scenarios: device rejected the address-family
+      (likely missing platform license, e.g. 'license boot level ax' on
+      CSR1000v, or 'license boot level network-advantage addon
+      dna-advantage' on Catalyst 8000v/9000).

--- a/tests/integration/targets/ios_bgp_address_family/tests/cli/_parsed.cfg
+++ b/tests/integration/targets/ios_bgp_address_family/tests/cli/_parsed.cfg
@@ -17,3 +17,6 @@ router bgp 65536
   aggregate-address 2001:DB8:1234::/48 summary-only
   aggregate-address 2001:DB8:5678::/48 as-confed-set
  exit-address-family
+ address-family l2vpn vpls
+  neighbor 198.51.110.212 activate
+ exit-address-family

--- a/tests/integration/targets/ios_bgp_address_family/tests/cli/_populate_config.yaml
+++ b/tests/integration/targets/ios_bgp_address_family/tests/cli/_populate_config.yaml
@@ -58,6 +58,11 @@
           table_map:
             name: test_tableMap
             filter: true
+        - afi: l2vpn
+          safi: vpls
+          neighbors:
+            - neighbor_address: "10.1.1.1"
+              activate: true
         - afi: ipv4
           safi: mdt
           bgp:

--- a/tests/integration/targets/ios_bgp_address_family/tests/cli/_populate_config.yaml
+++ b/tests/integration/targets/ios_bgp_address_family/tests/cli/_populate_config.yaml
@@ -16,6 +16,12 @@
       - neighbor 10.1.1.2 remote-as 200
       - neighbor 10.1.1.3 remote-as 200
 
+# Probes device capability and sets the `l2vpn_vpls_supported` fact. Some
+# platforms/images used in CI don't have the license required for l2vpn
+# vpls (see _check_l2vpn_vpls_support.yaml), so that piece of the baseline
+# is populated separately below and skipped gracefully when unsupported.
+- ansible.builtin.include_tasks: _check_l2vpn_vpls_support.yaml
+
 - name: Populate BGP address family configuration
   cisco.ios.ios_bgp_address_family:
     config:
@@ -58,11 +64,6 @@
           table_map:
             name: test_tableMap
             filter: true
-        - afi: l2vpn
-          safi: vpls
-          neighbors:
-            - neighbor_address: "10.1.1.1"
-              activate: true
         - afi: ipv4
           safi: mdt
           bgp:
@@ -119,4 +120,21 @@
                 metric: 10
                 route_map: bar
 
+    state: merged
+
+# l2vpn vpls requires a platform license (e.g. 'ax' on CSR1000v or
+# 'network-advantage addon dna-advantage' on Catalyst 8000v/9000). Kept as
+# its own call so it can be skipped independently of the rest of the
+# baseline on devices/images that lack the license.
+- name: Populate l2vpn vpls address family (requires platform license)
+  when: l2vpn_vpls_supported
+  cisco.ios.ios_bgp_address_family:
+    config:
+      as_number: "65000"
+      address_family:
+        - afi: l2vpn
+          safi: vpls
+          neighbors:
+            - neighbor_address: "10.1.1.1"
+              activate: true
     state: merged

--- a/tests/integration/targets/ios_bgp_address_family/tests/cli/deleted.yaml
+++ b/tests/integration/targets/ios_bgp_address_family/tests/cli/deleted.yaml
@@ -18,6 +18,8 @@
               safi: mdt
             - afi: ipv4
             - afi: ipv6
+            - afi: l2vpn
+              safi: vpls
 
         state: deleted
 

--- a/tests/integration/targets/ios_bgp_address_family/tests/cli/merged.yaml
+++ b/tests/integration/targets/ios_bgp_address_family/tests/cli/merged.yaml
@@ -28,6 +28,11 @@
             #   advertise:
             #     afi: l2vpn
             #     safi: evpn
+            - afi: l2vpn
+              safi: vpls
+              neighbors:
+                - neighbor_address: 10.1.1.1
+                  activate: true
             - afi: ipv4
               maximum_paths:
                 paths: 12

--- a/tests/integration/targets/ios_bgp_address_family/tests/cli/merged.yaml
+++ b/tests/integration/targets/ios_bgp_address_family/tests/cli/merged.yaml
@@ -5,6 +5,12 @@
 - ansible.builtin.include_tasks: _initial_vrf_setup.yaml
 - ansible.builtin.include_tasks: _ospf_proc_setup.yaml
 
+- name: Define BGP neighbors globally (required for l2vpn vpls neighbor activation)
+  cisco.ios.ios_config:
+    lines:
+      - router bgp 65000
+      - neighbor 10.1.1.1 remote-as 100
+
 - block:
     - name: Merge provided configuration with device configuration
       register: result

--- a/tests/integration/targets/ios_bgp_address_family/tests/cli/merged.yaml
+++ b/tests/integration/targets/ios_bgp_address_family/tests/cli/merged.yaml
@@ -4,8 +4,10 @@
 
 - ansible.builtin.include_tasks: _initial_vrf_setup.yaml
 - ansible.builtin.include_tasks: _ospf_proc_setup.yaml
+- ansible.builtin.include_tasks: _check_l2vpn_vpls_support.yaml
 
 - name: Define BGP neighbors globally (required for l2vpn vpls neighbor activation)
+  when: l2vpn_vpls_supported
   cisco.ios.ios_config:
     lines:
       - router bgp 65000
@@ -34,11 +36,6 @@
             #   advertise:
             #     afi: l2vpn
             #     safi: evpn
-            - afi: l2vpn
-              safi: vpls
-              neighbors:
-                - neighbor_address: 10.1.1.1
-                  activate: true
             - afi: ipv4
               maximum_paths:
                 paths: 12
@@ -148,6 +145,41 @@
         that:
           - result['changed'] == false
           - result.commands|length == 0
+
+    # l2vpn vpls requires a platform license (e.g. 'ax' on CSR1000v or
+    # 'network-advantage addon dna-advantage' on Catalyst 8000v/9000), kept
+    # as its own call/assertion so it can be skipped independently of the
+    # rest of this scenario on devices/images that lack the license.
+    - name: Merge l2vpn vpls address family (requires platform license)
+      when: l2vpn_vpls_supported
+      register: vpls_result
+      cisco.ios.ios_bgp_address_family: &id002
+        config:
+          address_family:
+            - afi: l2vpn
+              safi: vpls
+              neighbors:
+                - neighbor_address: 10.1.1.1
+                  activate: true
+          as_number: "65000"
+        state: merged
+
+    - name: Assert that correct l2vpn vpls commands were generated
+      when: l2vpn_vpls_supported
+      ansible.builtin.assert:
+        that:
+          - "{{ merged_vpls['commands'] | symmetric_difference(vpls_result['commands']) | length == 0 }}"
+
+    - name: Merge l2vpn vpls address family (idempotent)
+      when: l2vpn_vpls_supported
+      register: vpls_result
+      cisco.ios.ios_bgp_address_family: *id002
+
+    - name: Assert that the previous l2vpn vpls task was idempotent
+      when: l2vpn_vpls_supported
+      ansible.builtin.assert:
+        that:
+          - vpls_result['changed'] == false
 
   always:
     - ansible.builtin.include_tasks: _remove_config.yaml

--- a/tests/integration/targets/ios_bgp_address_family/tests/cli/rendered.yaml
+++ b/tests/integration/targets/ios_bgp_address_family/tests/cli/rendered.yaml
@@ -8,6 +8,11 @@
       cisco.ios.ios_bgp_address_family:
         config:
           address_family:
+            - afi: l2vpn
+              safi: vpls
+              neighbors:
+                - neighbor_address: 10.1.1.1
+                  activate: true
             - afi: ipv4
               maximum_paths:
                 paths: 12

--- a/tests/integration/targets/ios_bgp_address_family/vars/main.yaml
+++ b/tests/integration/targets/ios_bgp_address_family/vars/main.yaml
@@ -139,6 +139,9 @@ overridden:
   commands:
     - router bgp 65000
     - no neighbor 10.1.1.1
+    - address-family l2vpn vpls
+    - no neighbor 10.1.1.1 activate
+    - exit-address-family
     - address-family ipv4 mdt
     - no bgp dmzlink-bw
     - no bgp soft-reconfig-backup
@@ -217,6 +220,8 @@ overridden:
         # vrf: "blue"
       - afi: "ipv4"
         safi: "mdt"
+      - afi: "l2vpn"
+        safi: "vpls"
       - afi: "ipv6"
       - afi: "ipv6"
         bgp:
@@ -338,6 +343,7 @@ deleted:
     - no address-family ipv4 mdt
     - no address-family ipv4 unicast
     - no address-family ipv6 unicast
+    - no address-family l2vpn vpls
 
 rendered:
   commands:

--- a/tests/integration/targets/ios_bgp_address_family/vars/main.yaml
+++ b/tests/integration/targets/ios_bgp_address_family/vars/main.yaml
@@ -3,6 +3,9 @@ merged:
   before: {}
   commands:
     - router bgp 65000
+    - address-family l2vpn vpls
+    - neighbor 10.1.1.1 activate
+    - exit-address-family
     - address-family ipv4 unicast
     - maximum-paths 12
     - maximum-secondary-paths eibgp 2
@@ -339,6 +342,9 @@ deleted:
 rendered:
   commands:
     - router bgp 65000
+    - address-family l2vpn vpls
+    - neighbor 10.1.1.1 activate
+    - exit-address-family
     - address-family ipv4 unicast
     - maximum-paths 12
     - maximum-secondary-paths eibgp 2
@@ -390,4 +396,9 @@ parsed:
             summary_only: true
           - address: 2001:DB8:5678::/48
             as_confed_set: true
+      - afi: l2vpn
+        safi: vpls
+        neighbors:
+          - activate: true
+            neighbor_address: 198.51.110.212
     as_number: "65536"

--- a/tests/integration/targets/ios_bgp_address_family/vars/main.yaml
+++ b/tests/integration/targets/ios_bgp_address_family/vars/main.yaml
@@ -1,11 +1,19 @@
 ---
-merged:
-  before: {}
+# l2vpn vpls is populated/asserted via its own dedicated call in
+# merged.yaml (requires a platform license, e.g. 'ax' on CSR1000v or
+# 'network-advantage addon dna-advantage' on Catalyst 8000v/9000), so it's
+# skipped independently and kept separate from the main `merged` commands.
+merged_vpls:
   commands:
     - router bgp 65000
     - address-family l2vpn vpls
     - neighbor 10.1.1.1 activate
     - exit-address-family
+
+merged:
+  before: {}
+  commands:
+    - router bgp 65000
     - address-family ipv4 unicast
     - maximum-paths 12
     - maximum-secondary-paths eibgp 2
@@ -135,44 +143,54 @@ merged:
               route_map: bar
     as_number: "65000"
 
+# l2vpn vpls is only populated by _populate_config.yaml when the platform
+# license is available (see l2vpn_vpls_supported), so these commands only
+# show up in the overridden diff on devices/images that support it.
+overridden_vpls_commands:
+  - address-family l2vpn vpls
+  - no neighbor 10.1.1.1 activate
+  - exit-address-family
+
+overridden_commands_static:
+  - address-family ipv4 mdt
+  - no bgp dmzlink-bw
+  - no bgp soft-reconfig-backup
+  - no bgp dampening 1 10 100 5
+  - exit-address-family
+  - address-family ipv6 unicast
+  - no redistribute ospf 124
+  - exit-address-family
+  - address-family ipv4 unicast
+  - no redistribute connected
+  - no redistribute ospf 123
+  - redistribute ospf 123 metric 15 match external 1 nssa-external 2 route-map foo
+  - no redistribute ospf 124
+  - no redistribute ospfv3 123
+  - redistribute ospfv3 123 metric 15 match internal external 2 nssa-external 1 route-map foo
+  - exit-address-family
+  - address-family ipv4 multicast
+  - no default-metric 12
+  - no distance bgp 10 10 100
+  - no table-map test_tableMap filter
+  - bgp dampening 10 10 100 50
+  - neighbor 10.1.1.2 activate
+  - no network 198.51.111.11 mask 255.255.255.255 route-map test
+  - no aggregate-address 192.0.3.1 255.255.255.255 as-confed-set
+  - exit-address-family
+  - address-family ipv6 multicast
+  - bgp aggregate-timer 10
+  - bgp dampening 10 10 10 10
+  - bgp slow-peer detection threshold 200
+  - network 2001:DB8:0:3::/64 route-map test_ipv6
+  - exit-address-family
+
 overridden:
-  commands:
-    - router bgp 65000
-    - no neighbor 10.1.1.1
-    - address-family l2vpn vpls
-    - no neighbor 10.1.1.1 activate
-    - exit-address-family
-    - address-family ipv4 mdt
-    - no bgp dmzlink-bw
-    - no bgp soft-reconfig-backup
-    - no bgp dampening 1 10 100 5
-    - exit-address-family
-    - address-family ipv6 unicast
-    - no redistribute ospf 124
-    - exit-address-family
-    - address-family ipv4 unicast
-    - no redistribute connected
-    - no redistribute ospf 123
-    - redistribute ospf 123 metric 15 match external 1 nssa-external 2 route-map foo
-    - no redistribute ospf 124
-    - no redistribute ospfv3 123
-    - redistribute ospfv3 123 metric 15 match internal external 2 nssa-external 1 route-map foo
-    - exit-address-family
-    - address-family ipv4 multicast
-    - no default-metric 12
-    - no distance bgp 10 10 100
-    - no table-map test_tableMap filter
-    - bgp dampening 10 10 100 50
-    - neighbor 10.1.1.2 activate
-    - no network 198.51.111.11 mask 255.255.255.255 route-map test
-    - no aggregate-address 192.0.3.1 255.255.255.255 as-confed-set
-    - exit-address-family
-    - address-family ipv6 multicast
-    - bgp aggregate-timer 10
-    - bgp dampening 10 10 10 10
-    - bgp slow-peer detection threshold 200
-    - network 2001:DB8:0:3::/64 route-map test_ipv6
-    - exit-address-family
+  commands: >-
+    {{
+      ['router bgp 65000', 'no neighbor 10.1.1.1']
+      + (overridden_vpls_commands if l2vpn_vpls_supported | default(true) else [])
+      + overridden_commands_static
+    }}
 
   after:
     address_family:
@@ -336,14 +354,19 @@ replaced:
           - address: "2001:DB8:1234::/48"
             as_set: true
 
+# l2vpn vpls is only populated by _populate_config.yaml when the platform
+# license is available (see l2vpn_vpls_supported), so there's nothing to
+# delete for it on devices/images that don't support it.
+deleted_vpls_commands:
+  - no address-family l2vpn vpls
+
 deleted:
-  commands:
-    - router bgp 65000
-    - no address-family ipv4 multicast
-    - no address-family ipv4 mdt
-    - no address-family ipv4 unicast
-    - no address-family ipv6 unicast
-    - no address-family l2vpn vpls
+  commands: >-
+    {{
+      ['router bgp 65000', 'no address-family ipv4 multicast', 'no address-family ipv4 mdt',
+       'no address-family ipv4 unicast', 'no address-family ipv6 unicast']
+      + (deleted_vpls_commands if l2vpn_vpls_supported | default(true) else [])
+    }}
 
 rendered:
   commands:

--- a/tests/unit/modules/network/ios/test_ios_bgp_address_family.py
+++ b/tests/unit/modules/network/ios/test_ios_bgp_address_family.py
@@ -1603,3 +1603,40 @@ class TestIosBgpAddressFamilyModule(TestIosModule):
 
         result = self.execute_module(changed=True)
         self.assertEqual(sorted(result["commands"]), sorted(commands))
+
+    def test_ios_bgp_address_family_merged_l2vpn_vpls(self):
+        self.execute_show_command.return_value = dedent(
+            """\
+            router bgp 12345
+             bgp log-neighbor-changes
+            """,
+        )
+
+        set_module_args(
+            dict(
+                config=dict(
+                    as_number="12345",
+                    address_family=[
+                        dict(
+                            afi="l2vpn",
+                            safi="vpls",
+                            neighbors=[
+                                dict(
+                                    neighbor_address="192.168.2.1",
+                                    activate=True,
+                                ),
+                            ],
+                        ),
+                    ],
+                ),
+                state="merged",
+            ),
+        )
+        commands = [
+            "router bgp 12345",
+            "address-family l2vpn vpls",
+            "neighbor 192.168.2.1 activate",
+            "exit-address-family",
+        ]
+        result = self.execute_module(changed=True)
+        self.assertEqual(sorted(result["commands"]), sorted(commands))

--- a/tests/unit/modules/network/ios/test_ios_bgp_address_family.py
+++ b/tests/unit/modules/network/ios/test_ios_bgp_address_family.py
@@ -10,6 +10,8 @@ __metaclass__ = type
 from textwrap import dedent
 from unittest.mock import patch
 
+from ansible.module_utils.connection import ConnectionError
+
 from ansible_collections.cisco.ios.plugins.modules import ios_bgp_address_family
 from ansible_collections.cisco.ios.tests.unit.modules.utils import set_module_args
 
@@ -1640,3 +1642,61 @@ class TestIosBgpAddressFamilyModule(TestIosModule):
         ]
         result = self.execute_module(changed=True)
         self.assertEqual(sorted(result["commands"]), sorted(commands))
+
+    @patch(
+        "ansible_collections.ansible.netcommon.plugins.module_utils.network.common."
+        "rm_base.resource_module.ResourceModule.run_commands",
+    )
+    def test_ios_bgp_address_family_topology_init_error(self, mock_run):
+        """Module should fail with a license hint when the device returns
+        '% BGP: Error initializing topology'."""
+        mock_run.side_effect = ConnectionError(
+            "address-family l2vpn vpls\r\n% BGP: Error initializing topology",
+        )
+        self.execute_show_command.return_value = dedent(
+            """\
+            router bgp 65000
+             bgp log-neighbor-changes
+            """,
+        )
+        set_module_args(
+            dict(
+                config=dict(
+                    as_number="65000",
+                    address_family=[
+                        dict(afi="l2vpn", safi="vpls"),
+                    ],
+                ),
+                state="merged",
+            ),
+        )
+        result = self.execute_module(failed=True)
+        self.assertIn("Error initializing topology", result["msg"])
+        self.assertIn("license", result["msg"])
+
+    @patch(
+        "ansible_collections.ansible.netcommon.plugins.module_utils.network.common."
+        "rm_base.resource_module.ResourceModule.run_commands",
+    )
+    def test_ios_bgp_address_family_non_topology_connection_error(self, mock_run):
+        """Non-topology ConnectionError should be re-raised, not swallowed."""
+        mock_run.side_effect = ConnectionError("some other connection problem")
+        self.execute_show_command.return_value = dedent(
+            """\
+            router bgp 65000
+             bgp log-neighbor-changes
+            """,
+        )
+        set_module_args(
+            dict(
+                config=dict(
+                    as_number="65000",
+                    address_family=[
+                        dict(afi="l2vpn", safi="vpls"),
+                    ],
+                ),
+                state="merged",
+            ),
+        )
+        with self.assertRaises(ConnectionError):
+            self.module.main()


### PR DESCRIPTION
Closes ansible-collections/cisco.ios#1202

> **Note:** This contribution was developed with AI assistance (Cursor IDE). 
 - Note added as per -> https://docs.ansible.com/projects/ansible/latest/community/ai_policy.html
> All changes have been reviewed and validated with `ansible-test units --docker`.

## Description

- **What is being changed?** Added `vpls` as a valid `safi` choice for the `ios_bgp_address_family` module's address-family configuration.
- **Why is this change needed?** The module rejects `safi: vpls` with a validation error (`value of safi must be one of: flowspec, mdt, multicast, mvpn, evpn, unicast, got: vpls`), even though the parser regex already recognizes `vpls` and the config is successfully applied to the device.
- **How does this change address the issue?** Adds `vpls` to the `safi` choices list in both the module docstring and the argspec, aligning input validation with the parser and actual IOS device behavior.


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New module (adding a new module to the collection)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Test update
- [ ] Refactoring (no functional changes)
- [ ] Collection release
- [ ] CI maintenance
- [ ] Workflow maintenance
- [ ] Configuration change

## Related Issue

- Fixes #1202

## Component Name

ios_bgp_address_family

## Self-Review Checklist

- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have removed all commented code (no commented code should be merged)
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment
- [ ] I have verified the changes work with the target IOS version(s)
- [x] I have reviewed the acceptance criteria for related tickets

## Testing Instructions

### Prerequisites

- IOS Version: Any IOS/IOS-XE with L2VPN VPLS support (e.g., ASR-920 with IOS-XE 17.x)
- Hardware Platform (if applicable): N/A (unit tests only; no device required)
- Test Topology: N/A

### Steps to Test

1. Set up the collection namespace directory:
   ```bash
   mkdir -p /tmp/test-collections/ansible_collections/cisco/ios
   rsync -a --exclude='.git' --exclude='.venv' ~/ansibleProjects/cisco.ios/ \
     /tmp/test-collections/ansible_collections/cisco/ios/
   ansible-galaxy collection install ansible.netcommon ansible.utils -p /tmp/test-collections