### PR TITLE
Remediate deprecated ansible.module_utils dependencies in cisco.ios

### DIFF
--- a/changelogs/fragments/remediate_deprecated_module_utils_imports.yaml
+++ b/changelogs/fragments/remediate_deprecated_module_utils_imports.yaml
@@ -1,0 +1,7 @@
+---
+minor_changes:
+  - Replace deprecated ``ansible.module_utils._text`` imports with
+    ``ansible.module_utils.common.text.converters``, replace
+    ``ansible.module_utils.common._collections_compat`` with ``collections.abc``,
+    and remove ``ansible.module_utils.six`` usage in favour of Python 3 builtins
+    to prepare for ansible-core 2.24 removal.

--- a/changelogs/fragments/remediate_deprecated_module_utils_imports.yaml
+++ b/changelogs/fragments/remediate_deprecated_module_utils_imports.yaml
@@ -1,7 +1,21 @@
 ---
 minor_changes:
+  - Remediate deprecated ``warnings`` parameter in ``exit_json`` calls by using
+    ``emit_warnings`` from ``ansible.netcommon`` across cisco.ios modules to
+    address deprecation warning from ansible-core 2.23.
+
+  - Updated all ``ResourceModule``-based resource modules to emit warnings via
+    ``AnsibleModule.warn()`` before calling ``exit_json``.
+
+  - Updated standalone modules (``ios_banner``, ``ios_command``, ``ios_config``,
+    ``ios_facts``, ``ios_ping``, ``ios_system``, ``ios_user``, ``ios_vrf``) to
+    emit warnings via ``AnsibleModule.warn()`` before calling ``exit_json``.
+
   - Replace deprecated ``ansible.module_utils._text`` imports with
-    ``ansible.module_utils.common.text.converters``, replace
-    ``ansible.module_utils.common._collections_compat`` with ``collections.abc``,
-    and remove ``ansible.module_utils.six`` usage in favour of Python 3 builtins
+    ``ansible.module_utils.common.text.converters``.
+
+  - Replace deprecated ``ansible.module_utils.common._collections_compat`` with
+    ``collections.abc`` from the Python standard library.
+
+  - Remove ``ansible.module_utils.six`` usage in favour of Python 3 builtins
     to prepare for ansible-core 2.24 removal.

--- a/plugins/cliconf/ios.py
+++ b/plugins/cliconf/ios.py
@@ -141,8 +141,8 @@ import re
 import time
 
 from ansible.errors import AnsibleConnectionFailure
-from ansible.module_utils._text import to_text
-from ansible.module_utils.common._collections_compat import Mapping
+from ansible.module_utils.common.text.converters import to_text
+from collections.abc import Mapping
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.config import (
     NetworkConfig,
     dumps,

--- a/plugins/cliconf/ios.py
+++ b/plugins/cliconf/ios.py
@@ -140,9 +140,10 @@ import json
 import re
 import time
 
+from collections.abc import Mapping
+
 from ansible.errors import AnsibleConnectionFailure
 from ansible.module_utils.common.text.converters import to_text
-from collections.abc import Mapping
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.config import (
     NetworkConfig,
     dumps,

--- a/plugins/module_utils/network/ios/config/acl_interfaces/acl_interfaces.py
+++ b/plugins/module_utils/network/ios/config/acl_interfaces/acl_interfaces.py
@@ -15,7 +15,7 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.rm_base.resource_module import (
     ResourceModule,
 )

--- a/plugins/module_utils/network/ios/config/acls/acls.py
+++ b/plugins/module_utils/network/ios/config/acls/acls.py
@@ -15,7 +15,7 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.rm_base.resource_module import (
     ResourceModule,
 )

--- a/plugins/module_utils/network/ios/config/logging_global/logging_global.py
+++ b/plugins/module_utils/network/ios/config/logging_global/logging_global.py
@@ -19,7 +19,7 @@ created.
 """
 from copy import deepcopy
 
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.rm_base.resource_module import (
     ResourceModule,
 )

--- a/plugins/module_utils/network/ios/facts/acls/acls.py
+++ b/plugins/module_utils/network/ios/facts/acls/acls.py
@@ -17,7 +17,7 @@ __metaclass__ = type
 
 import re
 
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import utils
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.rm_base.network_template import (
     NetworkTemplate,

--- a/plugins/module_utils/network/ios/facts/legacy/base.py
+++ b/plugins/module_utils/network/ios/facts/legacy/base.py
@@ -20,8 +20,6 @@ __metaclass__ = type
 import platform
 import re
 
-from ansible.module_utils.six.moves import zip
-
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.ios import (
     get_capabilities,
     normalize_interface,

--- a/plugins/module_utils/network/ios/ios.py
+++ b/plugins/module_utils/network/ios/ios.py
@@ -31,7 +31,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 import json
 
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.connection import Connection, ConnectionError
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import to_list
 

--- a/plugins/module_utils/network/ios/rm_templates/acls.py
+++ b/plugins/module_utils/network/ios/rm_templates/acls.py
@@ -16,7 +16,7 @@ the given network resource.
 """
 import re
 
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.rm_base.network_template import (
     NetworkTemplate,
 )

--- a/plugins/modules/ios_acl_interfaces.py
+++ b/plugins/modules/ios_acl_interfaces.py
@@ -593,7 +593,6 @@ parsed:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     emit_warnings,
 )

--- a/plugins/modules/ios_acl_interfaces.py
+++ b/plugins/modules/ios_acl_interfaces.py
@@ -594,6 +594,10 @@ parsed:
 
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    emit_warnings,
+)
+
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.argspec.acl_interfaces.acl_interfaces import (
     Acl_interfacesArgs,
 )
@@ -622,6 +626,7 @@ def main():
     )
 
     result = Acl_interfaces(module).execute_module()
+    emit_warnings(module, result)
     module.exit_json(**result)
 
 

--- a/plugins/modules/ios_acls.py
+++ b/plugins/modules/ios_acls.py
@@ -3147,6 +3147,10 @@ parsed:
 
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    emit_warnings,
+)
+
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.argspec.acls.acls import (
     AclsArgs,
 )
@@ -3173,6 +3177,7 @@ def main():
     )
 
     result = Acls(module).execute_module()
+    emit_warnings(module, result)
     module.exit_json(**result)
 
 

--- a/plugins/modules/ios_acls.py
+++ b/plugins/modules/ios_acls.py
@@ -3146,7 +3146,6 @@ parsed:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     emit_warnings,
 )

--- a/plugins/modules/ios_banner.py
+++ b/plugins/modules/ios_banner.py
@@ -110,7 +110,6 @@ commands:
 from re import M, search
 
 from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     emit_warnings,
 )

--- a/plugins/modules/ios_banner.py
+++ b/plugins/modules/ios_banner.py
@@ -111,6 +111,10 @@ from re import M, search
 
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    emit_warnings,
+)
+
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.ios import (
     get_config,
     load_config,
@@ -198,6 +202,7 @@ def main():
         if not module.check_mode:
             load_config(module, commands)
         result["changed"] = True
+    emit_warnings(module, result)
     module.exit_json(**result)
 
 

--- a/plugins/modules/ios_bfd_interfaces.py
+++ b/plugins/modules/ios_bfd_interfaces.py
@@ -710,6 +710,10 @@ parsed:
 
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    emit_warnings,
+)
+
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.argspec.bfd_interfaces.bfd_interfaces import (
     Bfd_interfacesArgs,
 )
@@ -738,6 +742,7 @@ def main():
     )
 
     result = Bfd_interfaces(module).execute_module()
+    emit_warnings(module, result)
     module.exit_json(**result)
 
 

--- a/plugins/modules/ios_bfd_interfaces.py
+++ b/plugins/modules/ios_bfd_interfaces.py
@@ -709,7 +709,6 @@ parsed:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     emit_warnings,
 )

--- a/plugins/modules/ios_bfd_templates.py
+++ b/plugins/modules/ios_bfd_templates.py
@@ -527,7 +527,6 @@ parsed:
 
 
 from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     emit_warnings,
 )

--- a/plugins/modules/ios_bfd_templates.py
+++ b/plugins/modules/ios_bfd_templates.py
@@ -528,6 +528,10 @@ parsed:
 
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    emit_warnings,
+)
+
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.argspec.bfd_templates.bfd_templates import (
     Bfd_templatesArgs,
 )
@@ -556,6 +560,7 @@ def main():
     )
 
     result = Bfd_templates(module).execute_module()
+    emit_warnings(module, result)
     module.exit_json(**result)
 
 

--- a/plugins/modules/ios_bgp_address_family.py
+++ b/plugins/modules/ios_bgp_address_family.py
@@ -3000,7 +3000,6 @@ parsed:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     emit_warnings,
 )

--- a/plugins/modules/ios_bgp_address_family.py
+++ b/plugins/modules/ios_bgp_address_family.py
@@ -3001,6 +3001,10 @@ parsed:
 
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    emit_warnings,
+)
+
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.argspec.bgp_address_family.bgp_address_family import (
     Bgp_address_familyArgs,
 )
@@ -3029,6 +3033,7 @@ def main():
     )
 
     result = Bgp_address_family(module).execute_module()
+    emit_warnings(module, result)
     module.exit_json(**result)
 
 

--- a/plugins/modules/ios_bgp_global.py
+++ b/plugins/modules/ios_bgp_global.py
@@ -2852,7 +2852,6 @@ parsed:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     emit_warnings,
 )

--- a/plugins/modules/ios_bgp_global.py
+++ b/plugins/modules/ios_bgp_global.py
@@ -2853,6 +2853,10 @@ parsed:
 
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    emit_warnings,
+)
+
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.argspec.bgp_global.bgp_global import (
     Bgp_globalArgs,
 )
@@ -2881,6 +2885,7 @@ def main():
     )
 
     result = Bgp_global(module).execute_module()
+    emit_warnings(module, result)
     module.exit_json(**result)
 
 

--- a/plugins/modules/ios_command.py
+++ b/plugins/modules/ios_command.py
@@ -358,7 +358,7 @@ failed_conditions:
 """
 import time
 
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.parsing import (
     Conditional,

--- a/plugins/modules/ios_command.py
+++ b/plugins/modules/ios_command.py
@@ -366,6 +366,7 @@ from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.p
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     to_lines,
     transform_commands,
+    emit_warnings,
 )
 
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.ios import run_commands
@@ -423,6 +424,7 @@ def main():
         msg = "One or more conditional statements have not been satisfied"
         module.fail_json(msg=msg, failed_conditions=failed_conditions)
     result.update({"stdout": responses, "stdout_lines": list(to_lines(responses))})
+    emit_warnings(module, result)
     module.exit_json(**result)
 
 

--- a/plugins/modules/ios_command.py
+++ b/plugins/modules/ios_command.py
@@ -358,15 +358,15 @@ failed_conditions:
 """
 import time
 
-from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.common.text.converters import to_text
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.parsing import (
     Conditional,
 )
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    emit_warnings,
     to_lines,
     transform_commands,
-    emit_warnings,
 )
 
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.ios import run_commands

--- a/plugins/modules/ios_config.py
+++ b/plugins/modules/ios_config.py
@@ -457,6 +457,10 @@ import re
 
 from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    emit_warnings,
+)
 from ansible.module_utils.connection import ConnectionError
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.config import (
     NetworkConfig,
@@ -838,7 +842,9 @@ def main():
         if "warnings" in result:
             result["warnings"].append(msg)
         else:
-            result["warnings"] = msg
+            result["warnings"] = [msg]
+
+    emit_warnings(module, result)
 
     module.exit_json(**result)
 

--- a/plugins/modules/ios_config.py
+++ b/plugins/modules/ios_config.py
@@ -455,16 +455,15 @@ time:
 import json
 import re
 
-from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.basic import AnsibleModule
-
-from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
-    emit_warnings,
-)
+from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.connection import ConnectionError
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.config import (
     NetworkConfig,
     dumps,
+)
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    emit_warnings,
 )
 
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.ios import (

--- a/plugins/modules/ios_config.py
+++ b/plugins/modules/ios_config.py
@@ -455,7 +455,7 @@ time:
 import json
 import re
 
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.connection import ConnectionError
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.config import (

--- a/plugins/modules/ios_evpn_ethernet.py
+++ b/plugins/modules/ios_evpn_ethernet.py
@@ -972,6 +972,10 @@ parsed:
 
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    emit_warnings,
+)
+
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.argspec.evpn_ethernet.evpn_ethernet import (
     Evpn_ethernetArgs,
 )
@@ -1000,6 +1004,7 @@ def main():
     )
 
     result = Evpn_ethernet(module).execute_module()
+    emit_warnings(module, result)
     module.exit_json(**result)
 
 

--- a/plugins/modules/ios_evpn_ethernet.py
+++ b/plugins/modules/ios_evpn_ethernet.py
@@ -971,7 +971,6 @@ parsed:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     emit_warnings,
 )

--- a/plugins/modules/ios_evpn_evi.py
+++ b/plugins/modules/ios_evpn_evi.py
@@ -504,7 +504,6 @@ commands:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     emit_warnings,
 )

--- a/plugins/modules/ios_evpn_evi.py
+++ b/plugins/modules/ios_evpn_evi.py
@@ -505,6 +505,10 @@ commands:
 
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    emit_warnings,
+)
+
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.argspec.evpn_evi.evpn_evi import (
     Evpn_eviArgs,
 )
@@ -533,6 +537,7 @@ def main():
     )
 
     result = Evpn_evi(module).execute_module()
+    emit_warnings(module, result)
     module.exit_json(**result)
 
 

--- a/plugins/modules/ios_evpn_global.py
+++ b/plugins/modules/ios_evpn_global.py
@@ -393,7 +393,6 @@ parsed:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     emit_warnings,
 )

--- a/plugins/modules/ios_evpn_global.py
+++ b/plugins/modules/ios_evpn_global.py
@@ -394,6 +394,10 @@ parsed:
 
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    emit_warnings,
+)
+
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.argspec.evpn_global.evpn_global import (
     Evpn_globalArgs,
 )
@@ -422,6 +426,7 @@ def main():
     )
 
     result = Evpn_global(module).execute_module()
+    emit_warnings(module, result)
     module.exit_json(**result)
 
 

--- a/plugins/modules/ios_facts.py
+++ b/plugins/modules/ios_facts.py
@@ -216,7 +216,6 @@ ansible_net_neighbors:
   type: dict
 """
 from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     emit_warnings,
 )

--- a/plugins/modules/ios_facts.py
+++ b/plugins/modules/ios_facts.py
@@ -217,6 +217,10 @@ ansible_net_neighbors:
 """
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    emit_warnings,
+)
+
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.argspec.facts.facts import (
     FactsArgs,
 )
@@ -243,7 +247,9 @@ def main():
     additional_facts, additional_warnings = result
     ansible_facts.update(additional_facts)
     warnings.extend(additional_warnings)
-    module.exit_json(ansible_facts=ansible_facts, warnings=warnings)
+    result = {"ansible_facts": ansible_facts, "warnings": warnings}
+    emit_warnings(module, result)
+    module.exit_json(**result)
 
 
 if __name__ == "__main__":

--- a/plugins/modules/ios_hostname.py
+++ b/plugins/modules/ios_hostname.py
@@ -297,6 +297,10 @@ parsed:
 
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    emit_warnings,
+)
+
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.argspec.hostname.hostname import (
     HostnameArgs,
 )
@@ -325,6 +329,7 @@ def main():
     )
 
     result = Hostname(module).execute_module()
+    emit_warnings(module, result)
     module.exit_json(**result)
 
 

--- a/plugins/modules/ios_hostname.py
+++ b/plugins/modules/ios_hostname.py
@@ -296,7 +296,6 @@ parsed:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     emit_warnings,
 )

--- a/plugins/modules/ios_hsrp_interfaces.py
+++ b/plugins/modules/ios_hsrp_interfaces.py
@@ -1511,7 +1511,6 @@ parsed:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     emit_warnings,
 )

--- a/plugins/modules/ios_hsrp_interfaces.py
+++ b/plugins/modules/ios_hsrp_interfaces.py
@@ -1512,6 +1512,10 @@ parsed:
 
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    emit_warnings,
+)
+
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.argspec.hsrp_interfaces.hsrp_interfaces import (
     Hsrp_interfacesArgs,
 )
@@ -1540,6 +1544,7 @@ def main():
     )
 
     result = Hsrp_interfaces(module).execute_module()
+    emit_warnings(module, result)
     module.exit_json(**result)
 
 

--- a/plugins/modules/ios_interfaces.py
+++ b/plugins/modules/ios_interfaces.py
@@ -1118,7 +1118,6 @@ parsed:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     emit_warnings,
 )

--- a/plugins/modules/ios_interfaces.py
+++ b/plugins/modules/ios_interfaces.py
@@ -1119,6 +1119,10 @@ parsed:
 
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    emit_warnings,
+)
+
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.argspec.interfaces.interfaces import (
     InterfacesArgs,
 )
@@ -1148,6 +1152,7 @@ def main():
     )
 
     result = Interfaces(module).execute_module()
+    emit_warnings(module, result)
     module.exit_json(**result)
 
 

--- a/plugins/modules/ios_l2_interfaces.py
+++ b/plugins/modules/ios_l2_interfaces.py
@@ -952,6 +952,10 @@ parsed:
 
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    emit_warnings,
+)
+
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.argspec.l2_interfaces.l2_interfaces import (
     L2_interfacesArgs,
 )
@@ -980,6 +984,7 @@ def main():
     )
 
     result = L2_interfaces(module).execute_module()
+    emit_warnings(module, result)
     module.exit_json(**result)
 
 

--- a/plugins/modules/ios_l2_interfaces.py
+++ b/plugins/modules/ios_l2_interfaces.py
@@ -951,7 +951,6 @@ parsed:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     emit_warnings,
 )

--- a/plugins/modules/ios_l3_interfaces.py
+++ b/plugins/modules/ios_l3_interfaces.py
@@ -1001,6 +1001,10 @@ parsed:
 
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    emit_warnings,
+)
+
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.argspec.l3_interfaces.l3_interfaces import (
     L3_interfacesArgs,
 )
@@ -1029,6 +1033,7 @@ def main():
     )
 
     result = L3_interfaces(module).execute_module()
+    emit_warnings(module, result)
     module.exit_json(**result)
 
 

--- a/plugins/modules/ios_l3_interfaces.py
+++ b/plugins/modules/ios_l3_interfaces.py
@@ -1000,7 +1000,6 @@ parsed:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     emit_warnings,
 )

--- a/plugins/modules/ios_lacp.py
+++ b/plugins/modules/ios_lacp.py
@@ -242,6 +242,10 @@ commands:
 
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    emit_warnings,
+)
+
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.argspec.lacp.lacp import (
     LacpArgs,
 )
@@ -271,6 +275,7 @@ def main():
         supports_check_mode=True,
     )
     result = Lacp(module).execute_module()
+    emit_warnings(module, result)
     module.exit_json(**result)
 
 

--- a/plugins/modules/ios_lacp.py
+++ b/plugins/modules/ios_lacp.py
@@ -241,7 +241,6 @@ commands:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     emit_warnings,
 )

--- a/plugins/modules/ios_lacp_interfaces.py
+++ b/plugins/modules/ios_lacp_interfaces.py
@@ -475,7 +475,6 @@ commands:
   sample: ['interface GigabitEthernet 0/1', 'lacp port-priority 30']
 """
 from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     emit_warnings,
 )

--- a/plugins/modules/ios_lacp_interfaces.py
+++ b/plugins/modules/ios_lacp_interfaces.py
@@ -476,6 +476,10 @@ commands:
 """
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    emit_warnings,
+)
+
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.argspec.lacp_interfaces.lacp_interfaces import (
     Lacp_InterfacesArgs,
 )
@@ -506,6 +510,7 @@ def main():
         supports_check_mode=True,
     )
     result = Lacp_Interfaces(module).execute_module()
+    emit_warnings(module, result)
     module.exit_json(**result)
 
 

--- a/plugins/modules/ios_lag_interfaces.py
+++ b/plugins/modules/ios_lag_interfaces.py
@@ -611,7 +611,6 @@ parsed:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     emit_warnings,
 )

--- a/plugins/modules/ios_lag_interfaces.py
+++ b/plugins/modules/ios_lag_interfaces.py
@@ -612,6 +612,10 @@ parsed:
 
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    emit_warnings,
+)
+
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.argspec.lag_interfaces.lag_interfaces import (
     Lag_InterfacesArgs,
 )
@@ -640,6 +644,7 @@ def main():
     )
 
     result = Lag_interfaces(module).execute_module()
+    emit_warnings(module, result)
     module.exit_json(**result)
 
 

--- a/plugins/modules/ios_lldp_global.py
+++ b/plugins/modules/ios_lldp_global.py
@@ -321,6 +321,10 @@ commands:
 
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    emit_warnings,
+)
+
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.argspec.lldp_global.lldp_global import (
     Lldp_globalArgs,
 )
@@ -351,6 +355,7 @@ def main():
         supports_check_mode=True,
     )
     result = Lldp_global(module).execute_module()
+    emit_warnings(module, result)
     module.exit_json(**result)
 
 

--- a/plugins/modules/ios_lldp_global.py
+++ b/plugins/modules/ios_lldp_global.py
@@ -320,7 +320,6 @@ commands:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     emit_warnings,
 )

--- a/plugins/modules/ios_lldp_interfaces.py
+++ b/plugins/modules/ios_lldp_interfaces.py
@@ -633,7 +633,6 @@ commands:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     emit_warnings,
 )

--- a/plugins/modules/ios_lldp_interfaces.py
+++ b/plugins/modules/ios_lldp_interfaces.py
@@ -634,6 +634,10 @@ commands:
 
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    emit_warnings,
+)
+
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.argspec.lldp_interfaces.lldp_interfaces import (
     Lldp_InterfacesArgs,
 )
@@ -664,6 +668,7 @@ def main():
         supports_check_mode=True,
     )
     result = Lldp_Interfaces(module).execute_module()
+    emit_warnings(module, result)
     module.exit_json(**result)
 
 

--- a/plugins/modules/ios_logging_global.py
+++ b/plugins/modules/ios_logging_global.py
@@ -1051,7 +1051,6 @@ commands:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     emit_warnings,
 )

--- a/plugins/modules/ios_logging_global.py
+++ b/plugins/modules/ios_logging_global.py
@@ -1052,6 +1052,10 @@ commands:
 
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    emit_warnings,
+)
+
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.argspec.logging_global.logging_global import (
     Logging_globalArgs,
 )
@@ -1080,6 +1084,7 @@ def main():
     )
 
     result = Logging_global(module).execute_module()
+    emit_warnings(module, result)
     module.exit_json(**result)
 
 

--- a/plugins/modules/ios_ntp_global.py
+++ b/plugins/modules/ios_ntp_global.py
@@ -1062,6 +1062,10 @@ parsed:
 
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    emit_warnings,
+)
+
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.argspec.ntp_global.ntp_global import (
     Ntp_globalArgs,
 )
@@ -1090,6 +1094,7 @@ def main():
     )
 
     result = Ntp_global(module).execute_module()
+    emit_warnings(module, result)
     module.exit_json(**result)
 
 

--- a/plugins/modules/ios_ntp_global.py
+++ b/plugins/modules/ios_ntp_global.py
@@ -1061,7 +1061,6 @@ parsed:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     emit_warnings,
 )

--- a/plugins/modules/ios_ospf_interfaces.py
+++ b/plugins/modules/ios_ospf_interfaces.py
@@ -1287,6 +1287,10 @@ parsed:
 
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    emit_warnings,
+)
+
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.argspec.ospf_interfaces.ospf_interfaces import (
     Ospf_interfacesArgs,
 )
@@ -1315,6 +1319,7 @@ def main():
     )
 
     result = Ospf_interfaces(module).execute_module()
+    emit_warnings(module, result)
     module.exit_json(**result)
 
 

--- a/plugins/modules/ios_ospf_interfaces.py
+++ b/plugins/modules/ios_ospf_interfaces.py
@@ -1286,7 +1286,6 @@ parsed:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     emit_warnings,
 )

--- a/plugins/modules/ios_ospfv2.py
+++ b/plugins/modules/ios_ospfv2.py
@@ -2053,7 +2053,6 @@ parsed:
 
 
 from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     emit_warnings,
 )

--- a/plugins/modules/ios_ospfv2.py
+++ b/plugins/modules/ios_ospfv2.py
@@ -2054,6 +2054,10 @@ parsed:
 
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    emit_warnings,
+)
+
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.argspec.ospfv2.ospfv2 import (
     Ospfv2Args,
 )
@@ -2085,6 +2089,7 @@ def main():
     )
 
     result = Ospfv2(module).execute_module()
+    emit_warnings(module, result)
     module.exit_json(**result)
 
 

--- a/plugins/modules/ios_ospfv3.py
+++ b/plugins/modules/ios_ospfv3.py
@@ -2207,7 +2207,6 @@ parsed:
 
 
 from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     emit_warnings,
 )

--- a/plugins/modules/ios_ospfv3.py
+++ b/plugins/modules/ios_ospfv3.py
@@ -2208,6 +2208,10 @@ parsed:
 
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    emit_warnings,
+)
+
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.argspec.ospfv3.ospfv3 import (
     Ospfv3Args,
 )
@@ -2239,6 +2243,7 @@ def main():
     )
 
     result = Ospfv3(module).execute_module()
+    emit_warnings(module, result)
     module.exit_json(**result)
 
 

--- a/plugins/modules/ios_ping.py
+++ b/plugins/modules/ios_ping.py
@@ -152,7 +152,6 @@ rtt:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     emit_warnings,
 )

--- a/plugins/modules/ios_ping.py
+++ b/plugins/modules/ios_ping.py
@@ -153,6 +153,10 @@ rtt:
 
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    emit_warnings,
+)
+
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.argspec.ping.ping import (
     PingArgs,
 )
@@ -168,6 +172,7 @@ def main():
     module = AnsibleModule(argument_spec=PingArgs.argument_spec)
 
     result = Ping(module).execute_module()
+    emit_warnings(module, result)
     module.exit_json(**result)
 
 

--- a/plugins/modules/ios_prefix_lists.py
+++ b/plugins/modules/ios_prefix_lists.py
@@ -1017,7 +1017,6 @@ commands:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     emit_warnings,
 )

--- a/plugins/modules/ios_prefix_lists.py
+++ b/plugins/modules/ios_prefix_lists.py
@@ -1018,6 +1018,10 @@ commands:
 
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    emit_warnings,
+)
+
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.argspec.prefix_lists.prefix_lists import (
     Prefix_listsArgs,
 )
@@ -1046,6 +1050,7 @@ def main():
     )
 
     result = Prefix_lists(module).execute_module()
+    emit_warnings(module, result)
     module.exit_json(**result)
 
 

--- a/plugins/modules/ios_route_maps.py
+++ b/plugins/modules/ios_route_maps.py
@@ -2323,6 +2323,10 @@ commands:
 
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    emit_warnings,
+)
+
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.argspec.route_maps.route_maps import (
     Route_mapsArgs,
 )
@@ -2351,6 +2355,7 @@ def main():
     )
 
     result = Route_maps(module).execute_module()
+    emit_warnings(module, result)
     module.exit_json(**result)
 
 

--- a/plugins/modules/ios_route_maps.py
+++ b/plugins/modules/ios_route_maps.py
@@ -2322,7 +2322,6 @@ commands:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     emit_warnings,
 )

--- a/plugins/modules/ios_service.py
+++ b/plugins/modules/ios_service.py
@@ -665,6 +665,10 @@ parsed:
 
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    emit_warnings,
+)
+
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.argspec.service.service import (
     ServiceArgs,
 )
@@ -693,6 +697,7 @@ def main():
     )
 
     result = Service(module).execute_module()
+    emit_warnings(module, result)
     module.exit_json(**result)
 
 

--- a/plugins/modules/ios_service.py
+++ b/plugins/modules/ios_service.py
@@ -664,7 +664,6 @@ parsed:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     emit_warnings,
 )

--- a/plugins/modules/ios_snmp_server.py
+++ b/plugins/modules/ios_snmp_server.py
@@ -2646,7 +2646,6 @@ parsed:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     emit_warnings,
 )

--- a/plugins/modules/ios_snmp_server.py
+++ b/plugins/modules/ios_snmp_server.py
@@ -2647,6 +2647,10 @@ parsed:
 
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    emit_warnings,
+)
+
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.argspec.snmp_server.snmp_server import (
     Snmp_serverArgs,
 )
@@ -2675,6 +2679,7 @@ def main():
     )
 
     result = Snmp_server(module).execute_module()
+    emit_warnings(module, result)
     module.exit_json(**result)
 
 

--- a/plugins/modules/ios_static_routes.py
+++ b/plugins/modules/ios_static_routes.py
@@ -978,6 +978,10 @@ parsed:
 
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    emit_warnings,
+)
+
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.argspec.static_routes.static_routes import (
     Static_routesArgs,
 )
@@ -1006,6 +1010,7 @@ def main():
     )
 
     result = Static_routes(module).execute_module()
+    emit_warnings(module, result)
     module.exit_json(**result)
 
 

--- a/plugins/modules/ios_static_routes.py
+++ b/plugins/modules/ios_static_routes.py
@@ -977,7 +977,6 @@ parsed:
 
 
 from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     emit_warnings,
 )

--- a/plugins/modules/ios_system.py
+++ b/plugins/modules/ios_system.py
@@ -124,6 +124,7 @@ import re
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     ComplexList,
+    emit_warnings,
 )
 
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.ios import (
@@ -344,6 +345,7 @@ def main():
         if not module.check_mode:
             load_config(module, commands)
         result["changed"] = True
+    emit_warnings(module, result)
     module.exit_json(**result)
 
 

--- a/plugins/modules/ios_user.py
+++ b/plugins/modules/ios_user.py
@@ -623,8 +623,8 @@ from functools import partial
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
-    remove_default_spec,
     emit_warnings,
+    remove_default_spec,
 )
 
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.ios import (

--- a/plugins/modules/ios_user.py
+++ b/plugins/modules/ios_user.py
@@ -624,6 +624,7 @@ from functools import partial
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     remove_default_spec,
+    emit_warnings,
 )
 
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.ios import (
@@ -952,6 +953,7 @@ def main():
         if not module.check_mode:
             load_config(module, commands)
         result["changed"] = True
+    emit_warnings(module, result)
     module.exit_json(**result)
 
 

--- a/plugins/modules/ios_vlans.py
+++ b/plugins/modules/ios_vlans.py
@@ -1324,7 +1324,6 @@ parsed:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     emit_warnings,
 )

--- a/plugins/modules/ios_vlans.py
+++ b/plugins/modules/ios_vlans.py
@@ -1325,6 +1325,10 @@ parsed:
 
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    emit_warnings,
+)
+
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.argspec.vlans.vlans import (
     VlansArgs,
 )
@@ -1363,6 +1367,7 @@ def main():
 
     if _is_l2_device(module) or module.params.get("state") in ["rendered", "parsed"]:
         result = Vlans(module).execute_module()
+        emit_warnings(module, result)
         module.exit_json(**result)
     else:
         module.fail_json("""Resource VLAN is not valid for the target device.""")

--- a/plugins/modules/ios_vrf.py
+++ b/plugins/modules/ios_vrf.py
@@ -349,6 +349,10 @@ import time
 from functools import partial
 
 from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    emit_warnings,
+)
 from ansible.module_utils.connection import exec_command
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.config import (
     NetworkConfig,
@@ -979,6 +983,7 @@ def main():
             load_config(module, commands)
         result["changed"] = True
     check_declarative_intent_params(want, module, result)
+    emit_warnings(module, result)
     module.exit_json(**result)
 
 

--- a/plugins/modules/ios_vrf.py
+++ b/plugins/modules/ios_vrf.py
@@ -349,13 +349,12 @@ import time
 from functools import partial
 
 from ansible.module_utils.basic import AnsibleModule
-
-from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
-    emit_warnings,
-)
 from ansible.module_utils.connection import exec_command
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.config import (
     NetworkConfig,
+)
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    emit_warnings,
 )
 
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.ios import (

--- a/plugins/modules/ios_vrf_address_family.py
+++ b/plugins/modules/ios_vrf_address_family.py
@@ -1183,7 +1183,6 @@ parsed:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     emit_warnings,
 )

--- a/plugins/modules/ios_vrf_address_family.py
+++ b/plugins/modules/ios_vrf_address_family.py
@@ -1184,6 +1184,10 @@ parsed:
 
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    emit_warnings,
+)
+
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.argspec.vrf_address_family.vrf_address_family import (
     Vrf_address_familyArgs,
 )
@@ -1212,6 +1216,7 @@ def main():
     )
 
     result = Vrf_address_family(module).execute_module()
+    emit_warnings(module, result)
     module.exit_json(**result)
 
 

--- a/plugins/modules/ios_vrf_global.py
+++ b/plugins/modules/ios_vrf_global.py
@@ -874,7 +874,6 @@ parsed:
 
 
 from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     emit_warnings,
 )

--- a/plugins/modules/ios_vrf_global.py
+++ b/plugins/modules/ios_vrf_global.py
@@ -875,6 +875,10 @@ parsed:
 
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    emit_warnings,
+)
+
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.argspec.vrf_global.vrf_global import (
     Vrf_globalArgs,
 )
@@ -903,6 +907,7 @@ def main():
     )
 
     result = Vrf_global(module).execute_module()
+    emit_warnings(module, result)
     module.exit_json(**result)
 
 

--- a/plugins/modules/ios_vrf_interfaces.py
+++ b/plugins/modules/ios_vrf_interfaces.py
@@ -582,6 +582,10 @@ parsed:
 
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    emit_warnings,
+)
+
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.argspec.vrf_interfaces.vrf_interfaces import (
     Vrf_interfacesArgs,
 )
@@ -610,6 +614,7 @@ def main():
     )
 
     result = Vrf_interfaces(module).execute_module()
+    emit_warnings(module, result)
     module.exit_json(**result)
 
 

--- a/plugins/modules/ios_vrf_interfaces.py
+++ b/plugins/modules/ios_vrf_interfaces.py
@@ -581,7 +581,6 @@ parsed:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     emit_warnings,
 )

--- a/plugins/modules/ios_vxlan_vtep.py
+++ b/plugins/modules/ios_vxlan_vtep.py
@@ -369,6 +369,10 @@ commands:
 
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    emit_warnings,
+)
+
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.argspec.vxlan_vtep.vxlan_vtep import (
     Vxlan_vtepArgs,
 )
@@ -397,6 +401,7 @@ def main():
     )
 
     result = Vxlan_vtep(module).execute_module()
+    emit_warnings(module, result)
     module.exit_json(**result)
 
 

--- a/plugins/modules/ios_vxlan_vtep.py
+++ b/plugins/modules/ios_vxlan_vtep.py
@@ -368,7 +368,6 @@ commands:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     emit_warnings,
 )

--- a/plugins/terminal/ios.py
+++ b/plugins/terminal/ios.py
@@ -25,7 +25,7 @@ import json
 import re
 
 from ansible.errors import AnsibleConnectionFailure
-from ansible.module_utils._text import to_bytes, to_text
+from ansible.module_utils.common.text.converters import to_bytes, to_text
 from ansible.utils.display import Display
 from ansible_collections.ansible.netcommon.plugins.plugin_utils.terminal_base import TerminalBase
 

--- a/tests/unit/mock/loader.py
+++ b/tests/unit/mock/loader.py
@@ -24,7 +24,7 @@ __metaclass__ = type
 import os
 
 from ansible.errors import AnsibleParserError
-from ansible.module_utils._text import to_bytes, to_text
+from ansible.module_utils.common.text.converters import to_bytes, to_text
 from ansible.parsing.dataloader import DataLoader
 
 

--- a/tests/unit/mock/procenv.py
+++ b/tests/unit/mock/procenv.py
@@ -23,7 +23,7 @@ from contextlib import contextmanager
 from io import BytesIO, StringIO
 from unittest import TestCase
 
-from ansible.module_utils._text import to_bytes
+from ansible.module_utils.common.text.converters import to_bytes
 
 
 @contextmanager

--- a/tests/unit/mock/vault_helper.py
+++ b/tests/unit/mock/vault_helper.py
@@ -17,7 +17,7 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-from ansible.module_utils._text import to_bytes
+from ansible.module_utils.common.text.converters import to_bytes
 from ansible.parsing.vault import VaultSecret
 
 

--- a/tests/unit/modules/conftest.py
+++ b/tests/unit/modules/conftest.py
@@ -9,8 +9,8 @@ import json
 
 import pytest
 
-from ansible.module_utils._text import to_bytes
-from ansible.module_utils.common._collections_compat import MutableMapping
+from ansible.module_utils.common.text.converters import to_bytes
+from collections.abc import MutableMapping
 
 
 @pytest.fixture

--- a/tests/unit/modules/conftest.py
+++ b/tests/unit/modules/conftest.py
@@ -7,10 +7,11 @@ __metaclass__ = type
 
 import json
 
+from collections.abc import MutableMapping
+
 import pytest
 
 from ansible.module_utils.common.text.converters import to_bytes
-from collections.abc import MutableMapping
 
 
 @pytest.fixture

--- a/tests/unit/modules/network/ios/test_ios_command.py
+++ b/tests/unit/modules/network/ios/test_ios_command.py
@@ -124,16 +124,17 @@ class TestIosCommandModule(TestIosModule):
     def test_ios_command_configure_check_warning(self):
         commands = ["configure terminal"]
         set_module_args({"commands": commands, "_ansible_check_mode": True})
-        result = self.execute_module()
-        self.assertEqual(
-            result["warnings"],
-            [
+        with patch("ansible.module_utils.basic.AnsibleModule.warn") as mock_warn:
+            result = self.execute_module()
+            mock_warn.assert_called_once_with(
                 "Only show commands are supported when using check mode, not executing configure terminal",
-            ],
-        )
+            )
+        self.assertNotIn("warnings", result)
 
     def test_ios_command_configure_not_warning(self):
         commands = ["configure terminal"]
         set_module_args(dict(commands=commands))
-        result = self.execute_module()
-        self.assertEqual(result["warnings"], [])
+        with patch("ansible.module_utils.basic.AnsibleModule.warn") as mock_warn:
+            result = self.execute_module()
+            mock_warn.assert_not_called()
+        self.assertNotIn("warnings", result)

--- a/tests/unit/modules/utils.py
+++ b/tests/unit/modules/utils.py
@@ -8,7 +8,7 @@ from unittest import TestCase
 from unittest.mock import patch
 
 from ansible.module_utils import basic
-from ansible.module_utils._text import to_bytes
+from ansible.module_utils.common.text.converters import to_bytes
 
 
 cur_context = None

--- a/tests/unit/plugins/cliconf/test_ios.py
+++ b/tests/unit/plugins/cliconf/test_ios.py
@@ -33,7 +33,7 @@ except ImportError:
 
 from unittest import TestCase
 
-from ansible.module_utils._text import to_bytes
+from ansible.module_utils.common.text.converters import to_bytes
 
 from ansible_collections.cisco.ios.plugins.cliconf import ios
 


### PR DESCRIPTION
## Summary

- Replace deprecated `ansible.module_utils._text` imports with `ansible.module_utils.common.text.converters` across plugins and unit tests (16 files).
- Replace `ansible.module_utils.common._collections_compat` with `collections.abc` in `plugins/cliconf/ios.py` and `tests/unit/modules/conftest.py`.
- Remove `ansible.module_utils.six.moves.zip` import in favour of the Python 3 builtin `zip`.
- Use `emit_warnings()` from `ansible.netcommon` before `exit_json` across all resource and legacy modules (42 modules), matching the approach in [arista.eos#656](https://github.com/ansible-collections/arista.eos/pull/656).
- Fix `ios_config` to append idempotency warnings to a list rather than assigning a bare string.
- Update `test_ios_command` unit tests to assert warnings are emitted via `module.warn()`.

## Dependencies

- **Blocked by** [ansible.netcommon#788](https://github.com/ansible-collections/ansible.netcommon/pull/788) — provides `emit_warnings`. CI is expected to fail until that PR merges, same as arista.eos#656.

## Test plan

- [x] `ansible-test sanity --test pep8 --test compile --test import --test pylint --test validate-modules --test changelog`
- [x] `pytest tests/unit/ -n 2` (544 passed)
- [x] Verified no remaining `_text`, `_collections_compat`, or `six` imports in collection code