### PR TITLE
Use warn_and_exit in legacy ios modules for ansible-core 2.23

### DIFF
--- a/changelogs/fragments/warn_and_exit_legacy_modules.yaml
+++ b/changelogs/fragments/warn_and_exit_legacy_modules.yaml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+  - ios_command, ios_config, ios_facts, ios_user - Use ``warn_and_exit`` from
+    ``ansible.netcommon`` instead of passing ``warnings`` to ``exit_json``, which
+    is deprecated in ansible-core 2.23.

--- a/plugins/modules/ios_command.py
+++ b/plugins/modules/ios_command.py
@@ -366,6 +366,7 @@ from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.p
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     to_lines,
     transform_commands,
+    warn_and_exit,
 )
 
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.ios import run_commands
@@ -423,7 +424,7 @@ def main():
         msg = "One or more conditional statements have not been satisfied"
         module.fail_json(msg=msg, failed_conditions=failed_conditions)
     result.update({"stdout": responses, "stdout_lines": list(to_lines(responses))})
-    module.exit_json(**result)
+    warn_and_exit(module, result)
 
 
 if __name__ == "__main__":

--- a/plugins/modules/ios_config.py
+++ b/plugins/modules/ios_config.py
@@ -462,6 +462,9 @@ from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.c
     NetworkConfig,
     dumps,
 )
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    warn_and_exit,
+)
 
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.ios import (
     get_config,
@@ -838,9 +841,9 @@ def main():
         if "warnings" in result:
             result["warnings"].append(msg)
         else:
-            result["warnings"] = msg
+            result["warnings"] = [msg]
 
-    module.exit_json(**result)
+    warn_and_exit(module, result)
 
 
 if __name__ == "__main__":

--- a/plugins/modules/ios_facts.py
+++ b/plugins/modules/ios_facts.py
@@ -217,6 +217,9 @@ ansible_net_neighbors:
 """
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    warn_and_exit,
+)
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.argspec.facts.facts import (
     FactsArgs,
 )
@@ -243,7 +246,7 @@ def main():
     additional_facts, additional_warnings = result
     ansible_facts.update(additional_facts)
     warnings.extend(additional_warnings)
-    module.exit_json(ansible_facts=ansible_facts, warnings=warnings)
+    warn_and_exit(module, {"ansible_facts": ansible_facts, "warnings": warnings})
 
 
 if __name__ == "__main__":

--- a/plugins/modules/ios_facts.py
+++ b/plugins/modules/ios_facts.py
@@ -216,10 +216,10 @@ ansible_net_neighbors:
   type: dict
 """
 from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     warn_and_exit,
 )
+
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.argspec.facts.facts import (
     FactsArgs,
 )

--- a/plugins/modules/ios_user.py
+++ b/plugins/modules/ios_user.py
@@ -624,6 +624,7 @@ from functools import partial
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     remove_default_spec,
+    warn_and_exit,
 )
 
 from ansible_collections.cisco.ios.plugins.module_utils.network.ios.ios import (
@@ -952,7 +953,7 @@ def main():
         if not module.check_mode:
             load_config(module, commands)
         result["changed"] = True
-    module.exit_json(**result)
+    warn_and_exit(module, result)
 
 
 if __name__ == "__main__":

--- a/tests/unit/modules/network/ios/test_ios_command.py
+++ b/tests/unit/modules/network/ios/test_ios_command.py
@@ -124,16 +124,17 @@ class TestIosCommandModule(TestIosModule):
     def test_ios_command_configure_check_warning(self):
         commands = ["configure terminal"]
         set_module_args({"commands": commands, "_ansible_check_mode": True})
-        result = self.execute_module()
-        self.assertEqual(
-            result["warnings"],
-            [
+        with patch("ansible.module_utils.basic.AnsibleModule.warn") as mock_warn:
+            result = self.execute_module()
+            mock_warn.assert_called_once_with(
                 "Only show commands are supported when using check mode, not executing configure terminal",
-            ],
-        )
+            )
+        self.assertNotIn("warnings", result)
 
     def test_ios_command_configure_not_warning(self):
         commands = ["configure terminal"]
         set_module_args(dict(commands=commands))
-        result = self.execute_module()
-        self.assertEqual(result["warnings"], [])
+        with patch("ansible.module_utils.basic.AnsibleModule.warn") as mock_warn:
+            result = self.execute_module()
+            mock_warn.assert_not_called()
+        self.assertNotIn("warnings", result)


### PR DESCRIPTION
## Summary

- Update legacy modules `ios_command`, `ios_config`, `ios_facts`, and `ios_user` to call `warn_and_exit()` from `ansible.netcommon` instead of passing `warnings` to `exit_json`.
- Fix `ios_config` to append idempotency warnings to a list rather than assigning a bare string.
- Update `test_ios_command` unit tests to assert warnings are emitted via `module.warn()` and are no longer present in the exit result dict.

Passing `warnings` to `exit_json` is deprecated in ansible-core 2.23. Resource modules are handled centrally via `ResourceModule.result` in ansible.netcommon (see ansible-collections/ansible.netcommon#788).

## Dependencies

- Requires `warn_and_exit` from [ansible.netcommon#788](https://github.com/ansible-collections/ansible.netcommon/pull/788)
- Complements import remediation in #1351 (merge order: netcommon #788 → cisco.ios #1351 → this PR)

## Test plan

- [x] `pytest tests/unit/modules/network/ios/test_ios_command.py` — updated warning assertions pass
- [x] `pytest tests/unit/modules/network/ios/test_ios_config.py`
- [x] `pytest tests/unit/modules/network/ios/test_ios_facts.py`
- [x] `pytest tests/unit/modules/network/ios/test_ios_user.py`
- [x] `pytest tests/unit/ -n 2` (544 passed)