### PR TITLE
ci: split secret-free jobs to pull_request, Sonar label-gated on pull_request_target

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,0 +1,33 @@
+---
+name: "SonarCloud 🔍"
+
+concurrency:
+  group: sonar-${{ github.head_ref || github.run_id }}-${{ github.event_name }}
+  cancel-in-progress: true
+
+on:  # yamllint disable-line rule:truthy
+  push:
+    branches: [main]
+  pull_request_target:
+    branches: [main]
+    types:
+      - labeled
+      - opened
+      - synchronize
+  workflow_dispatch:
+
+jobs:
+  sonar:
+    name: SonarCloud
+    if: >-
+      github.event_name == 'push' ||
+      contains(github.event.pull_request.labels.*.name, 'safe to test')
+    uses: ansible/ansible-content-actions/.github/workflows/sonarcloud.yaml@main
+    with:
+      python_version: "3.12"
+      galaxy_dependencies: |
+        git+https://github.com/ansible-collections/ansible.utils.git
+        git+https://github.com/ansible-collections/ansible.netcommon.git
+      sonar_scanner_java_opts: "-Xss2m"
+    secrets:
+      SONAR_TOKEN: ${{ secrets.ANSIBLE_COLLECTIONS_ORG_SONAR_TOKEN_CICD_BOT }}

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -19,9 +19,6 @@ on:  # yamllint disable-line rule:truthy
 jobs:
   sonar:
     name: SonarCloud
-    if: >-
-      github.event_name == 'push' ||
-      contains(github.event.pull_request.labels.*.name, 'safe to test')
     uses: ansible/ansible-content-actions/.github/workflows/sonarcloud.yaml@main
     with:
       python_version: "3.12"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ concurrency:
 on:  # yamllint disable-line rule:truthy
   push:
     branches: [main]
-  pull_request_target:
+  pull_request:
     branches: [main]
   workflow_dispatch:
   schedule:
@@ -17,6 +17,7 @@ on:  # yamllint disable-line rule:truthy
 jobs:
   sonar:
     name: SonarCloud
+    if: github.event_name == 'push'
     uses: ansible/ansible-content-actions/.github/workflows/sonarcloud.yaml@main
     with:
       python_version: "3.12"
@@ -29,7 +30,7 @@ jobs:
 
   changelog:
     uses: ansible/ansible-content-actions/.github/workflows/changelog.yaml@main
-    if: github.event_name == 'pull_request_target'
+    if: github.event_name == 'pull_request'
 
   build-import:
     uses: ansible/ansible-content-actions/.github/workflows/build_import.yaml@main

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,19 +15,6 @@ on:  # yamllint disable-line rule:truthy
     - cron: '0 0 * * *'
 
 jobs:
-  sonar:
-    name: SonarCloud
-    if: github.event_name == 'push'
-    uses: ansible/ansible-content-actions/.github/workflows/sonarcloud.yaml@main
-    with:
-      python_version: "3.12"
-      galaxy_dependencies: |
-        git+https://github.com/ansible-collections/ansible.utils.git
-        git+https://github.com/ansible-collections/ansible.netcommon.git
-      sonar_scanner_java_opts: "-Xss2m"
-    secrets:
-      SONAR_TOKEN: ${{ secrets.ANSIBLE_COLLECTIONS_ORG_SONAR_TOKEN_CICD_BOT }}
-
   changelog:
     uses: ansible/ansible-content-actions/.github/workflows/changelog.yaml@main
     if: github.event_name == 'pull_request'
@@ -77,7 +64,6 @@ jobs:
       - sanity
       - unit-galaxy
       - ansible-lint
-      - sonar
       - report-status
     runs-on: ubuntu-latest
     steps:
@@ -89,6 +75,5 @@ jobs:
           '${{ needs.sanity.result }}',
           '${{ needs.unit-galaxy.result }}',
           '${{ needs.ansible-lint.result }}',
-          '${{ needs.unit-source.result }}',
-          '${{ needs.sonar.result }}'
+          '${{ needs.unit-source.result }}'
           ])"

--- a/changelogs/fragments/ci_pull_request_trigger.yaml
+++ b/changelogs/fragments/ci_pull_request_trigger.yaml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - ci - Run secret-free test jobs on pull_request and limit SonarCloud to push events.

--- a/changelogs/fragments/ci_pull_request_trigger.yaml
+++ b/changelogs/fragments/ci_pull_request_trigger.yaml
@@ -1,3 +1,4 @@
 ---
 trivial:
-  - ci - Run secret-free test jobs on pull_request and limit SonarCloud to push events.
+  - ci - Run secret-free test jobs on pull_request and move SonarCloud to a
+    label-gated pull_request_target workflow.


### PR DESCRIPTION
## Summary

Split CI into two workflows by security boundary — same pattern as CML integration (`integration-libssh.yml` + `integration-cml.yml` in netcommon).

### `tests.yml` — `pull_request` (no secrets)
- ansible-lint, changelog, sanity, unit-galaxy, unit-source, build-import
- Fork PRs get immediate feedback; no `checkout@v7` fork workaround needed
- `SONAR_TOKEN` never exposed to fork PR code

### `sonarcloud.yml` — `pull_request_target` + label gating (needs secrets)
- Runs on **push to main** (post-merge analysis)
- Runs on PRs only when a maintainer adds the **`safe to test`** label
- Triggered on `labeled` / `opened` / `synchronize`, matching CML integration workflows
- Uses existing `ansible-content-actions` `sonarcloud.yaml` reusable workflow (already has `safe to test` guard + PR head checkout)

## Why Option B

| Concern | Option A (push-only Sonar) | Option B (label-gated Sonar) |
|---------|---------------------------|------------------------------|
| Fork PR lint/sanity/unit | ✅ `pull_request` | ✅ `pull_request` |
| PR Sonar coverage | ❌ only after merge | ✅ when maintainer labels |
| Secret exposure | ✅ minimal | ✅ only on gated `pull_request_target` |
| Upstream changes | ✅ none needed | ✅ none needed |

## Test plan

- [ ] Fork PR: `tests.yml` jobs run and pass without `allow-unsafe-pr-checkout`
- [ ] Fork PR without `safe to test`: `sonarcloud.yml` skipped
- [ ] Fork PR with `safe to test` label: Sonar runs and analyzes PR head
- [ ] Push to `main`: Sonar runs on merge
- [ ] `all_green` in `tests.yml` no longer depends on Sonar (separate workflow)