### PR TITLE
ci: split secret-free jobs to pull_request, Sonar label-gated on pull_request_target

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,0 +1,33 @@
+---
+name: "SonarCloud 🔍"
+
+concurrency:
+  group: sonar-${{ github.head_ref || github.run_id }}-${{ github.event_name }}
+  cancel-in-progress: true
+
+on:  # yamllint disable-line rule:truthy
+  push:
+    branches: [main]
+  pull_request_target:
+    branches: [main]
+    types:
+      - labeled
+      - opened
+      - synchronize
+  workflow_dispatch:
+
+jobs:
+  sonar:
+    name: SonarCloud
+    if: >-
+      github.event_name == 'push' ||
+      contains(github.event.pull_request.labels.*.name, 'safe to test')
+    uses: ansible/ansible-content-actions/.github/workflows/sonarcloud.yaml@main
+    with:
+      python_version: "3.12"
+      galaxy_dependencies: |
+        git+https://github.com/ansible-collections/ansible.utils.git
+        git+https://github.com/ansible-collections/ansible.netcommon.git
+      sonar_scanner_java_opts: "-Xss2m"
+    secrets:
+      SONAR_TOKEN: ${{ secrets.ANSIBLE_COLLECTIONS_ORG_SONAR_TOKEN_CICD_BOT }}

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -19,9 +19,6 @@ on:  # yamllint disable-line rule:truthy
 jobs:
   sonar:
     name: SonarCloud
-    if: >-
-      github.event_name == 'push' ||
-      contains(github.event.pull_request.labels.*.name, 'safe to test')
     uses: ansible/ansible-content-actions/.github/workflows/sonarcloud.yaml@main
     with:
       python_version: "3.12"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ concurrency:
 on:  # yamllint disable-line rule:truthy
   push:
     branches: [main]
-  pull_request_target:
+  pull_request:
     branches: [main]
   workflow_dispatch:
   schedule:
@@ -17,6 +17,7 @@ on:  # yamllint disable-line rule:truthy
 jobs:
   sonar:
     name: SonarCloud
+    if: github.event_name == 'push'
     uses: ansible/ansible-content-actions/.github/workflows/sonarcloud.yaml@main
     with:
       python_version: "3.12"
@@ -29,7 +30,7 @@ jobs:
 
   changelog:
     uses: ansible/ansible-content-actions/.github/workflows/changelog.yaml@main
-    if: github.event_name == 'pull_request_target'
+    if: github.event_name == 'pull_request'
 
   build-import:
     uses: ansible/ansible-content-actions/.github/workflows/build_import.yaml@main

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,19 +15,6 @@ on:  # yamllint disable-line rule:truthy
     - cron: '0 0 * * *'
 
 jobs:
-  sonar:
-    name: SonarCloud
-    if: github.event_name == 'push'
-    uses: ansible/ansible-content-actions/.github/workflows/sonarcloud.yaml@main
-    with:
-      python_version: "3.12"
-      galaxy_dependencies: |
-        git+https://github.com/ansible-collections/ansible.utils.git
-        git+https://github.com/ansible-collections/ansible.netcommon.git
-      sonar_scanner_java_opts: "-Xss2m"
-    secrets:
-      SONAR_TOKEN: ${{ secrets.ANSIBLE_COLLECTIONS_ORG_SONAR_TOKEN_CICD_BOT }}
-
   changelog:
     uses: ansible/ansible-content-actions/.github/workflows/changelog.yaml@main
     if: github.event_name == 'pull_request'
@@ -77,7 +64,6 @@ jobs:
       - sanity
       - unit-galaxy
       - ansible-lint
-      - sonar
       - report-status
     runs-on: ubuntu-latest
     steps:
@@ -89,6 +75,5 @@ jobs:
           '${{ needs.sanity.result }}',
           '${{ needs.unit-galaxy.result }}',
           '${{ needs.ansible-lint.result }}',
-          '${{ needs.unit-source.result }}',
-          '${{ needs.sonar.result }}'
+          '${{ needs.unit-source.result }}'
           ])"

--- a/changelogs/fragments/ci_pull_request_trigger.yaml
+++ b/changelogs/fragments/ci_pull_request_trigger.yaml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - ci - Run secret-free test jobs on pull_request and limit SonarCloud to push events.

--- a/changelogs/fragments/ci_pull_request_trigger.yaml
+++ b/changelogs/fragments/ci_pull_request_trigger.yaml
@@ -1,3 +1,4 @@
 ---
 trivial:
-  - ci - Run secret-free test jobs on pull_request and limit SonarCloud to push events.
+  - ci - Run secret-free test jobs on pull_request and move SonarCloud to a
+    label-gated pull_request_target workflow.


### PR DESCRIPTION
## Summary

Split CI into two workflows by security boundary — same pattern as CML integration.

### `tests.yml` — `pull_request` (no secrets)
- ansible-lint, changelog, sanity, unit-galaxy, unit-source, build-import
- Fork PRs get immediate feedback; no `checkout@v7` fork workaround needed

### `sonarcloud.yml` — `pull_request_target` (needs `SONAR_TOKEN`)
- Runs on push to main and on PRs when `safe to test` is applied
- Label gating enforced by reusable `ansible-content-actions` `sonarcloud.yaml`

> Branch pushed to `ansible-collections/cisco.ios` (not a fork) so `pull_request` workflow changes are exercised on this PR before merge.

Supersedes #1356 (fork-head PR could not fully validate new workflow definitions).

## Test plan

- [ ] This PR (same-repo branch): `tests.yml` jobs run under `pull_request` with updated workflow files
- [ ] After merge: `sonarcloud.yml` becomes active on `main` for push and label-gated PR Sonar
- [ ] Fork PRs: secret-free jobs pass checkout; Sonar requires `safe to test` after merge