### PR TITLE
ci: disable automatic release workflow on GitHub release publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,7 @@
 ---
 name: "Release collection 🚀"
-on: # yamllint disable-line rule:truthy
-  release:
-    types: [published]
+on:  # yamllint disable-line rule:truthy
+  workflow_dispatch:
 jobs:
   release:
     uses: ansible/ansible-content-actions/.github/workflows/release.yaml@main

--- a/changelogs/fragments/disable_auto_release_workflow.yaml
+++ b/changelogs/fragments/disable_auto_release_workflow.yaml
@@ -1,0 +1,4 @@
+---
+trivial:
+  - ci - Disable automatic release workflow on GitHub release publish;
+    trigger manually via workflow_dispatch.


### PR DESCRIPTION
## Summary

- Replace `release: published` with `workflow_dispatch` in `.github/workflows/release.yml`
- Publishing a GitHub release no longer starts the release workflow automatically; it can still be triggered manually from the Actions tab
- Matches ansible-collections/ansible.netcommon#796

## Test plan

- [ ] Confirm release workflow trigger is `workflow_dispatch` only
- [ ] Confirm workflow still appears under Actions and can be run manually