### PR TITLE
Fix ios_user aggregation issue with update_password & hashed_password idempotency

### DIFF
--- a/changelogs/fragments/ios_user_aggregate_password_fixes.yaml
+++ b/changelogs/fragments/ios_user_aggregate_password_fixes.yaml
@@ -10,8 +10,6 @@ bugfixes:
   - ios_user - fixed hashed_password idempotency so that re-applying the same
     type/value pair against an already-configured user produces no commands,
     preventing unnecessary password updates on repeat runs.
-
-minor_changes:
   - ios_user - update_password and password_type are now resolved per aggregate
     item via get_param_value, allowing each entry in the aggregate list to
     independently override the module-level defaults

--- a/changelogs/fragments/ios_user_aggregate_password_fixes.yaml
+++ b/changelogs/fragments/ios_user_aggregate_password_fixes.yaml
@@ -1,4 +1,11 @@
 ---
+doc_changes:
+  - ios_user - clarified that update_password (on_create/always) applies only to
+    configured_password; hashed_password always uses hash type and value comparison
+    to determine whether a change is required.
+  - ios_user - documented type 9 (scrypt) as a valid hash type alongside the
+    existing type 5 (MD5) and type 8 (PBKDF2) examples for hashed_password.
+
 bugfixes:
   - ios_user - fixed hashed_password idempotency so that re-applying the same
     type/value pair against an already-configured user produces no commands,

--- a/changelogs/fragments/ios_user_aggregate_password_fixes.yaml
+++ b/changelogs/fragments/ios_user_aggregate_password_fixes.yaml
@@ -1,7 +1,5 @@
 ---
 bugfixes:
-  - ios_user - removed accidental debugpy breakpoint import from main() that
-    blocked module execution waiting for a debugger connection.
   - ios_user - fixed hashed_password idempotency so that re-applying the same
     type/value pair against an already-configured user produces no commands,
     preventing unnecessary password updates on repeat runs.
@@ -9,8 +7,7 @@ bugfixes:
 minor_changes:
   - ios_user - update_password and password_type are now resolved per aggregate
     item via get_param_value, allowing each entry in the aggregate list to
-    independently override the module-level defaults rather than all items
-    sharing a single value read from module.params in the command-generation loop.
-  - ios_user - parse_hashed_password and parse_password_type helpers now extract
-    the stored hash type, hash value, and keyword (secret/password) from running
-    config, enabling proper diff-based idempotency checks for hashed_password.
+    independently override the module-level defaults
+  - ios_user - parse_hashed_password  helper now extracts the stored hash type,
+    hash value from running config, enabling proper diff-based idempotency
+    checks for hashed_password.

--- a/changelogs/fragments/ios_user_aggregate_password_fixes.yaml
+++ b/changelogs/fragments/ios_user_aggregate_password_fixes.yaml
@@ -1,0 +1,16 @@
+---
+bugfixes:
+  - ios_user - removed accidental debugpy breakpoint import from main() that
+    blocked module execution waiting for a debugger connection.
+  - ios_user - fixed hashed_password idempotency so that re-applying the same
+    type/value pair against an already-configured user produces no commands,
+    preventing unnecessary password updates on repeat runs.
+
+minor_changes:
+  - ios_user - update_password and password_type are now resolved per aggregate
+    item via get_param_value, allowing each entry in the aggregate list to
+    independently override the module-level defaults rather than all items
+    sharing a single value read from module.params in the command-generation loop.
+  - ios_user - parse_hashed_password and parse_password_type helpers now extract
+    the stored hash type, hash value, and keyword (secret/password) from running
+    config, enabling proper diff-based idempotency checks for hashed_password.

--- a/docs/cisco.ios.ios_user_module.rst
+++ b/docs/cisco.ios.ios_user_module.rst
@@ -97,7 +97,7 @@ Parameters
                 <td>
                 </td>
                 <td>
-                        <div>Specifies the type of hash (e.g., 5 for MD5, 8 for PBKDF2, etc.)</div>
+                        <div>Specifies the type of hash (e.g., 5 for MD5, 8 for PBKDF2, 9 for scrypt.)</div>
                         <div>For this to work, the device needs to support the desired hash type</div>
                 </td>
             </tr>
@@ -335,7 +335,7 @@ Parameters
                 <td>
                 </td>
                 <td>
-                        <div>Specifies the type of hash (e.g., 5 for MD5, 8 for PBKDF2, etc.)</div>
+                        <div>Specifies the type of hash (e.g., 5 for MD5, 8 for PBKDF2, 9 for scrypt.)</div>
                         <div>For this to work, the device needs to support the desired hash type</div>
                 </td>
             </tr>

--- a/docs/cisco.ios.ios_user_module.rst
+++ b/docs/cisco.ios.ios_user_module.rst
@@ -270,7 +270,7 @@ Parameters
                         </ul>
                 </td>
                 <td>
-                        <div>Since passwords are encrypted in the device running config, this argument will instruct the module when to change the password.  When set to <code>always</code>, the password will always be updated in the device and when set to <code>on_create</code> the password will be updated only if the username is created.</div>
+                        <div>Since passwords are encrypted in the device running config, this argument will instruct the module when to change the password.  When set to <code>always</code>, the password will always be updated in the device and when set to <code>on_create</code> the password will be updated only if the username is created. This is applicable for <code>configured_password</code>, while <code>hashed_password</code> will undergo hash and type comparision to check whether a change is required.</div>
                 </td>
             </tr>
             <tr>
@@ -517,7 +517,7 @@ Parameters
                         </ul>
                 </td>
                 <td>
-                        <div>Since passwords are encrypted in the device running config, this argument will instruct the module when to change the password.  When set to <code>always</code>, the password will always be updated in the device and when set to <code>on_create</code> the password will be updated only if the username is created.</div>
+                        <div>Since passwords are encrypted in the device running config, this argument will instruct the module when to change the password.  When set to <code>always</code>, the password will always be updated in the device and when set to <code>on_create</code> the password will be updated only if the username is created. This is applicable for <code>configured_password</code>, while <code>hashed_password</code> will undergo hash and type comparision to check whether a change is required.</div>
                 </td>
             </tr>
             <tr>

--- a/plugins/modules/ios_user.py
+++ b/plugins/modules/ios_user.py
@@ -83,7 +83,7 @@ options:
         suboptions:
           type:
             description:
-              - Specifies the type of hash (e.g., 5 for MD5, 8 for PBKDF2, etc.)
+              - Specifies the type of hash (e.g., 5 for MD5, 8 for PBKDF2, 9 for scrypt.)
               - For this to work, the device needs to support the desired hash type
             type: int
             required: true
@@ -172,7 +172,7 @@ options:
     suboptions:
       type:
         description:
-          - Specifies the type of hash (e.g., 5 for MD5, 8 for PBKDF2, etc.)
+          - Specifies the type of hash (e.g., 5 for MD5, 8 for PBKDF2, 9 for scrypt.)
           - For this to work, the device needs to support the desired hash type
         type: int
         required: true
@@ -694,8 +694,6 @@ def sshkey_fingerprint(sshkey):
 
 def map_obj_to_commands(updates, module):
     commands = list()
-    update_password = module.params["update_password"]
-    password_type = module.params["password_type"]
 
     def needs_update(want, have, x):
         return want.get(x) and want.get(x) != have.get(x)
@@ -710,6 +708,8 @@ def map_obj_to_commands(updates, module):
 
     for update in updates:
         want, have = update
+        update_password = want["update_password"]
+        password_type = want["password_type"]
         if want["state"] == "absent":
             if have["sshkey"]:
                 add_ssh(commands, want)
@@ -793,6 +793,7 @@ def map_config_to_obj(module):
             "configured_password": None,
             "hashed_password": None,
             "purge_keys": False,
+            "update_password": None,
             "password_type": parse_password_type(cfg),
             "sshkey": ssh_key_list,
             "is_only_ssh_user": False if cfg.strip() and ssh_key_list else True,
@@ -853,6 +854,8 @@ def map_params_to_obj(module):
             module.fail_json(
                 msg="More than two ssh-keys supplied for a user. The length limit for ssh-keys is 2.",
             )
+        item["update_password"] = get_value("update_password")
+        item["password_type"] = get_value("password_type")
         item["state"] = get_value("state")
         objects.append(item)
     return objects

--- a/plugins/modules/ios_user.py
+++ b/plugins/modules/ios_user.py
@@ -904,10 +904,6 @@ def find_set_difference(list1, list2, key):
 
 def main():
     """main entry point for module execution"""
-    import debugpy
-
-    debugpy.listen(3000)
-    debugpy.wait_for_client()
     hashed_password_spec = dict(
         type=dict(type="int", required=True),
         value=dict(no_log=True, required=True),

--- a/plugins/modules/ios_user.py
+++ b/plugins/modules/ios_user.py
@@ -64,7 +64,9 @@ options:
           - Since passwords are encrypted in the device running config, this argument will
             instruct the module when to change the password.  When set to C(always), the
             password will always be updated in the device and when set to C(on_create) the
-            password will be updated only if the username is created.
+            password will be updated only if the username is created. This is applicable for
+            C(configured_password), while C(hashed_password) will undergo hash and type
+            comparision to check whether a change is required.
         choices:
           - on_create
           - always
@@ -151,7 +153,9 @@ options:
       - Since passwords are encrypted in the device running config, this argument will
         instruct the module when to change the password.  When set to C(always), the
         password will always be updated in the device and when set to C(on_create) the
-        password will be updated only if the username is created.
+        password will be updated only if the username is created. This is applicable for
+        C(configured_password), while C(hashed_password) will undergo hash and type
+        comparision to check whether a change is required.
     default: always
     choices:
       - on_create
@@ -768,6 +772,13 @@ def parse_privilege(data):
         return int(match.group(1))
 
 
+def parse_hashed_password(data):
+    hashed_password = None
+    if data and data.split()[-3] in ["password", "secret"]:
+        hashed_password = {"type": int(data.split()[-2]), "value": str(data.split()[-1])}
+    return hashed_password
+
+
 def parse_password_type(data):
     type = None
     if data and data.split()[-3] in ["password", "secret"]:
@@ -791,7 +802,7 @@ def map_config_to_obj(module):
             "state": "present",
             "nopassword": "nopassword" in cfg,
             "configured_password": None,
-            "hashed_password": None,
+            "hashed_password": parse_hashed_password(cfg),
             "purge_keys": False,
             "update_password": None,
             "password_type": parse_password_type(cfg),
@@ -893,6 +904,10 @@ def find_set_difference(list1, list2, key):
 
 def main():
     """main entry point for module execution"""
+    import debugpy
+
+    debugpy.listen(3000)
+    debugpy.wait_for_client()
     hashed_password_spec = dict(
         type=dict(type="int", required=True),
         value=dict(no_log=True, required=True),

--- a/tests/integration/targets/ios_user/tests/cli/basic.yaml
+++ b/tests/integration/targets/ios_user/tests/cli/basic.yaml
@@ -158,6 +158,59 @@
       - result.changed == true
       - "'username ansibleuser6 secret' in result.commands[0]"
 
+- name: Create aggregate users - per-item passwords and on_create overrides module always
+  become: true
+  register: result
+  cisco.ios.ios_user: &aggregate_mixed_users
+    aggregate:
+      - name: ansibletest4
+        configured_password: secret4
+        update_password: on_create
+      - name: ansibletest5
+        configured_password: secret5
+        update_password: on_create
+      - name: ansibletest6
+        hashed_password:
+          type: 9
+          value: $9$B/6NVV7joWJ9w.$XueHQxIOZk0GhNC3lxUFioUeowJrtLmXxouXfTuoNpc
+        update_password: on_create
+      - name: ansibletest7
+        hashed_password:
+          type: 9
+          value: $9$9T5dvp5mSW0IWk.$yETpRHqxTJOPH7RZW.pBjuNn3PsJHtPcQFX4NHjHV5A
+        update_password: on_create
+    update_password: always
+    state: present
+
+- ansible.builtin.assert:
+    that:
+      - result.changed == true
+      - "'username ansibletest4 secret secret4' in result.commands | string"
+      - "'username ansibletest5 secret secret5' in result.commands | string"
+      - "'username ansibletest6 secret 9' in result.commands | string"
+      - "'username ansibletest7 secret 9' in result.commands | string"
+
+- name: Repeat same aggregate task - idempotency
+  become: true
+  register: result
+  cisco.ios.ios_user: *aggregate_mixed_users
+
+- ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.commands | length == 0
+
+- name: Teardown aggregate test users
+  become: true
+  cisco.ios.ios_user:
+    aggregate:
+      - name: ansibletest4
+      - name: ansibletest5
+      - name: ansibletest6
+      - name: ansibletest7
+      - name: ansibletest8
+    state: absent
+
 - name: Ensure SSH keys are not world readable
   ansible.builtin.file:
     path: "{{ item }}"

--- a/tests/integration/targets/ios_user/tests/cli/basic.yaml
+++ b/tests/integration/targets/ios_user/tests/cli/basic.yaml
@@ -9,6 +9,7 @@
       - name: ansibletest4
       - name: ansibletest5
       - name: ansibletest6
+      - name: ansibletest7
     state: absent
 
 - name: Create user (setup)
@@ -172,12 +173,12 @@
       - name: ansibletest6
         hashed_password:
           type: 9
-          value: $9$B/6NVV7joWJ9w.$XueHQxIOZk0GhNC3lxUFioUeowJrtLmXxouXfTuoNpc
+          value: $9$EiM1qesOSHrYJE$wDDm14Nk6ISHy61j/Rl0W5BY0Np.R5Rv5WJKeYxJfMA
         update_password: on_create
       - name: ansibletest7
         hashed_password:
           type: 9
-          value: $9$9T5dvp5mSW0IWk.$yETpRHqxTJOPH7RZW.pBjuNn3PsJHtPcQFX4NHjHV5A
+          value: $9$bUZc4O6rJi0.VE$Ce7MaG3QAgXApnJyIRUwqq.Bp2iAHXFoYnx.isEbcO2
         update_password: on_create
     update_password: always
     state: present
@@ -185,10 +186,10 @@
 - ansible.builtin.assert:
     that:
       - result.changed == true
-      - "'username ansibletest4 secret secret4' in result.commands | string"
-      - "'username ansibletest5 secret secret5' in result.commands | string"
-      - "'username ansibletest6 secret 9' in result.commands | string"
-      - "'username ansibletest7 secret 9' in result.commands | string"
+      - "'username ansibletest4 secret' in result.commands | string"
+      - "'username ansibletest5 secret' in result.commands | string"
+      - "'username ansibletest6 secret' in result.commands | string"
+      - "'username ansibletest7 secret' in result.commands | string"
 
 - name: Repeat same aggregate task - idempotency
   become: true

--- a/tests/integration/targets/ios_user/tests/cli/basic.yaml
+++ b/tests/integration/targets/ios_user/tests/cli/basic.yaml
@@ -209,7 +209,6 @@
       - name: ansibletest5
       - name: ansibletest6
       - name: ansibletest7
-      - name: ansibletest8
     state: absent
 
 - name: Ensure SSH keys are not world readable
@@ -241,7 +240,7 @@
 
 - ansible.builtin.assert:
     that:
-      - result.changed == true
+      - result_purge.changed == true
 
 # SSH Key Purge Test Cases
 - name: Ensure purge_keys_user(s) does not exist

--- a/tests/unit/modules/network/ios/test_ios_user.py
+++ b/tests/unit/modules/network/ios/test_ios_user.py
@@ -334,3 +334,67 @@ class TestIosUserModule(TestIosModule):
         result = self.execute_module(changed=True)
         self.assertIn("username newuser1 password pass1", result["commands"])
         self.assertIn("username newuser2 secret pass2", result["commands"])
+
+    def test_aggregate_hashed_password_type_and_value_mismatch(self):
+        # ansible (exists in fixture with type=5): same hash → no command.
+        # newuser1: different type (9) → update required.
+        # newuser2: same type (5) but different value → update required.
+        set_module_args(
+            dict(
+                aggregate=[
+                    {
+                        "name": "ansible",
+                        "hashed_password": {
+                            "type": 5,
+                            "value": "$1$3yWSXiIi$VdzV59ChiurrNdGxlDeAW/",
+                        },
+                    },
+                    {
+                        "name": "newuser1",
+                        "hashed_password": {"type": 9, "value": "newscryptvalue"},
+                    },
+                    {
+                        "name": "newuser2",
+                        "hashed_password": {"type": 5, "value": "differenthash"},
+                    },
+                ],
+            ),
+        )
+        result = self.execute_module(changed=True)
+        self.assertNotIn(
+            "username ansible secret 5 $1$3yWSXiIi$VdzV59ChiurrNdGxlDeAW/",
+            result["commands"],
+        )
+        self.assertIn("username newuser1 secret 9 newscryptvalue", result["commands"])
+        self.assertIn("username newuser2 secret 5 differenthash", result["commands"])
+
+    def test_aggregate_hashed_password_on_create_does_not_suppress_hash_comparison(self):
+        # update_password=on_create does NOT suppress hashed_password updates (unlike
+        # configured_password). Hash+type comparison always runs.
+        # ansible (exists): same hash + on_create → no change.
+        # newuser: different hash + on_create → still generates command.
+        set_module_args(
+            dict(
+                aggregate=[
+                    {
+                        "name": "ansible",
+                        "hashed_password": {
+                            "type": 5,
+                            "value": "$1$3yWSXiIi$VdzV59ChiurrNdGxlDeAW/",
+                        },
+                        "update_password": "on_create",
+                    },
+                    {
+                        "name": "newuser",
+                        "hashed_password": {"type": 9, "value": "scryptvalue"},
+                        "update_password": "on_create",
+                    },
+                ],
+            ),
+        )
+        result = self.execute_module(changed=True)
+        self.assertNotIn(
+            "username ansible secret 5 $1$3yWSXiIi$VdzV59ChiurrNdGxlDeAW/",
+            result["commands"],
+        )
+        self.assertIn("username newuser secret 9 scryptvalue", result["commands"])

--- a/tests/unit/modules/network/ios/test_ios_user.py
+++ b/tests/unit/modules/network/ios/test_ios_user.py
@@ -256,3 +256,81 @@ class TestIosUserModule(TestIosModule):
         )
         result = self.execute_module(changed=True)
         self.assertEqual(result["commands"], ["username ansible password 0 test"])
+
+    def test_add_hashed_password_idempotent(self):
+        # Same type and value as in fixture -> no commands
+        set_module_args(
+            dict(
+                name="ansible",
+                hashed_password={
+                    "type": 5,
+                    "value": "$1$3yWSXiIi$VdzV59ChiurrNdGxlDeAW/",
+                },
+            ),
+        )
+        self.execute_module(changed=False)
+
+    def test_ios_user_aggregate_update_password_on_create(self):
+        # Per-item on_create overrides module-level always.
+        # ansible (exists in fixture): on_create -> no password command.
+        # newuser (new): on_create still applies, but not-have path triggers creation.
+        set_module_args(
+            dict(
+                aggregate=[
+                    {
+                        "name": "ansible",
+                        "configured_password": "pass_ansible",
+                        "update_password": "on_create",
+                    },
+                    {
+                        "name": "newuser",
+                        "configured_password": "pass_newuser",
+                        "update_password": "on_create",
+                    },
+                ],
+                update_password="always",
+            ),
+        )
+        result = self.execute_module(changed=True)
+        self.assertNotIn("username ansible secret pass_ansible", result["commands"])
+        self.assertIn("username newuser secret pass_newuser", result["commands"])
+
+    def test_ios_user_aggregate_update_password_always(self):
+        # Per-item always: both existing (ansible) and new (newuser) get password commands.
+        set_module_args(
+            dict(
+                aggregate=[
+                    {
+                        "name": "ansible",
+                        "configured_password": "pass_ansible",
+                        "update_password": "always",
+                    },
+                    {
+                        "name": "newuser",
+                        "configured_password": "pass_newuser",
+                        "update_password": "always",
+                    },
+                ],
+            ),
+        )
+        result = self.execute_module(changed=True)
+        self.assertIn("username ansible secret pass_ansible", result["commands"])
+        self.assertIn("username newuser secret pass_newuser", result["commands"])
+
+    def test_aggregate_per_item_password_type(self):
+        # password_type per aggregate item applies independently to each user's command.
+        set_module_args(
+            dict(
+                aggregate=[
+                    {
+                        "name": "newuser1",
+                        "configured_password": "pass1",
+                        "password_type": "password",
+                    },
+                    {"name": "newuser2", "configured_password": "pass2"},
+                ],
+            ),
+        )
+        result = self.execute_module(changed=True)
+        self.assertIn("username newuser1 password pass1", result["commands"])
+        self.assertIn("username newuser2 secret pass2", result["commands"])


### PR DESCRIPTION
## Description
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
- What is being changed?
  
  - update_password and password_type are now resolved per aggregate item using get_param_value, allowing each entry in an aggregate list to independently override the module-level defaults.
  - A new parse_hashed_password() helper parses the existing hash type and value from running config, so repeated runs with the same hashed_password type/value pair correctly produce no commands.
  - Documentation for update_password clarifies that on_create/always applies only to configured_password; hashed_password always uses diff-based comparison.

- Why is this change needed?

  - `map_obj_to_commands` read update_password and password_type from module.params once at function entry. Per-item overrides set inside aggregate entries were silently ignored — all items shared the module-level value. If update_password was set only inside an aggregate item (not at the task level), the module-level default (always) took effect instead, causing password commands to be re-sent for existing users on every run.
  - `map_config_to_obj` always initialised hashed_password to None. Because have["hashed_password"] was always None, needs_update() treated every run as a change when want["hashed_password"] was set — re-applying the same hash type and value on every invocation.

- How does this change address the issue?

  - Per-item update_password and password_type are now stored in each want dict during map_params_to_obj via get_param_value, which handles the aggregate-level → task-level fallback automatically.
  - map_obj_to_commands reads them from want inside the per-item loop instead of from module.params before the loop.
  - parse_hashed_password() extracts {type, value} from the running config line, enabling a true diff against want["hashed_password"].


## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New module (adding a new module to the collection)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Collection release
- [ ] CI maintenance
- [ ] Workflow maintenance
- [ ] Configuration change

## Related Issue
<!-- Optional: Link to related issue(s) -->
- Fixes #559 

## Component Name
<!-- Mandatory: Specify the module, plugin, or component being changed -->
<!-- Examples: ios_config, ios_bgp_global, cliconf plugin, terminal plugin, etc. -->
ios_user

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have removed all commented code (no commented code should be merged)
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment
- [x] I have verified the changes work with the target IOS version(s)
- [x] I have reviewed the acceptance criteria for related tickets


Assisted By: Claude