### PR TITLE
fix(terminal): catch '% IPv6 routing not enabled' CLI error

### DIFF
--- a/changelogs/fragments/fix_ipv6_routing_not_enabled_terminal_error.yaml
+++ b/changelogs/fragments/fix_ipv6_routing_not_enabled_terminal_error.yaml
@@ -1,0 +1,6 @@
+---
+bugfixes:
+  - terminal - Add ``% IPv6 routing not enabled`` to ``terminal_stderr_re`` so
+    that configuring BGP IPv6/VPNv6 address-family without ``ipv6 unicast-routing``
+    correctly raises an error instead of silently succeeding
+    (https://github.com/ansible-collections/cisco.ios/issues/1301).

--- a/plugins/terminal/ios.py
+++ b/plugins/terminal/ios.py
@@ -63,6 +63,7 @@ class TerminalModule(TerminalBase):
         ),
         re.compile(rb"% BGP: Error initializing topology", re.I),
         re.compile(rb"%SNMP agent not enabled", re.I),
+        re.compile(rb"% ?IPv6 routing not enabled", re.I),
         re.compile(rb"% Invalid", re.I),
         re.compile(
             rb"%You must disable VTPv1 and VTPv2 or switch to VTPv3 before configuring a VLAN name longer than 32 characters",

--- a/tests/unit/plugins/terminal/test_ios.py
+++ b/tests/unit/plugins/terminal/test_ios.py
@@ -1,0 +1,101 @@
+#
+# (c) 2026 Red Hat Inc.
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+from __future__ import absolute_import, division, print_function
+
+
+__metaclass__ = type
+
+import pytest
+
+from ansible_collections.cisco.ios.plugins.terminal.ios import TerminalModule
+
+
+@pytest.fixture()
+def terminal_stderr_patterns():
+    return TerminalModule.terminal_stderr_re
+
+
+def _matches_any(patterns, text):
+    """Return True if any pattern in the list matches the given byte string."""
+    for pattern in patterns:
+        if pattern.search(text):
+            return True
+    return False
+
+
+class TestTerminalStderrRegex:
+    """Tests for terminal_stderr_re patterns, focusing on routing-not-enabled errors."""
+
+    @pytest.mark.parametrize(
+        "error_output",
+        [
+            b"% IPv6 routing not enabled",
+            b"%IPv6 routing not enabled",
+            b"% ipv6 routing not enabled",
+        ],
+        ids=[
+            "ipv6-with-space",
+            "ipv6-no-space",
+            "ipv6-lowercase",
+        ],
+    )
+    def test_routing_not_enabled_detected(self, terminal_stderr_patterns, error_output):
+        assert _matches_any(terminal_stderr_patterns, error_output)
+
+    @pytest.mark.parametrize(
+        "error_output",
+        [
+            b"% Error",
+            b"% Bad secret",
+            b"invalid input detected at '^' marker",
+            b"% BGP: Error initializing topology",
+            b"%SNMP agent not enabled",
+            b"Command authorization failed",
+            b"% Invalid input",
+        ],
+        ids=[
+            "percent-error",
+            "bad-secret",
+            "invalid-input",
+            "bgp-error",
+            "snmp-not-enabled",
+            "command-auth-failed",
+            "invalid",
+        ],
+    )
+    def test_existing_errors_still_detected(self, terminal_stderr_patterns, error_output):
+        assert _matches_any(terminal_stderr_patterns, error_output)
+
+    @pytest.mark.parametrize(
+        "safe_output",
+        [
+            b"router bgp 65001",
+            b"address-family ipv6",
+            b"IPv6 routing is enabled",
+            b"ipv6 unicast-routing",
+        ],
+        ids=[
+            "bgp-config-command",
+            "address-family-command",
+            "ipv6-routing-enabled",
+            "ipv6-unicast-routing-command",
+        ],
+    )
+    def test_safe_output_not_flagged(self, terminal_stderr_patterns, safe_output):
+        assert not _matches_any(terminal_stderr_patterns, safe_output)


### PR DESCRIPTION
## Summary
- Add regex pattern `% ?IPv6 routing not enabled` to `terminal_stderr_re` in `plugins/terminal/ios.py` to detect the uncaught IOS CLI error produced when configuring BGP IPv6/VPNv6 address-family without `ipv6 unicast-routing` enabled on the device.
- Without this fix, Ansible silently reports success when the configuration actually failed.
- Add unit tests for the new pattern in `tests/unit/plugins/terminal/test_ios.py`.

## Details
When running commands like `address-family ipv6` under `router bgp` without `ipv6 unicast-routing` enabled, Cisco IOS produces:
```
% IPv6 routing not enabled
```
This error was not matched by any existing `terminal_stderr_re` pattern, so the terminal plugin did not raise an error and Ansible reported the task as successful.

## Test plan
- [x] 3 positive tests: `% IPv6 routing not enabled` detected (with/without space after `%`, lowercase)
- [x] 7 regression tests: existing error patterns still matched correctly
- [x] 4 negative tests: safe output (config commands, status messages) not falsely flagged
- [x] All 14 unit tests pass

Fixes #1301

🤖 Generated with [Claude Code](https://claude.com/claude-code)