### PR TITLE
fix(ios_bgp_global): accept ASDOT local_as notation (type int -> str for local_as.number)

### DIFF
--- a/changelogs/fragments/fix-bgp-global-asdot-local-as.yaml
+++ b/changelogs/fragments/fix-bgp-global-asdot-local-as.yaml
@@ -1,0 +1,4 @@
+bugfixes:
+  - ios_bgp_global - fix ios_bgp_global and ios_facts crash on ASDOT (4-byte dotted) local_as
+    notation (e.g. "501.65083") by changing local_as.number argspec type from int to str,
+    consistent with remote_as which already accepts ASDOT values

--- a/docs/cisco.ios.ios_bgp_global_module.rst
+++ b/docs/cisco.ios.ios_bgp_global_module.rst
@@ -4892,13 +4892,14 @@ Parameters
                     <b>number</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
-                        <span style="color: purple">integer</span>
+                        <span style="color: purple">string</span>
                     </div>
                 </td>
                 <td>
                 </td>
                 <td>
                         <div>AS number used as local AS</div>
+                        <div>Accepts plain integers (e.g. <code>65000</code>) and ASDOT notation (e.g. <code>501.65083</code>)</div>
                         <div>Please refer vendor documentation for valid values</div>
                 </td>
             </tr>

--- a/plugins/module_utils/network/ios/argspec/bgp_global/bgp_global.py
+++ b/plugins/module_utils/network/ios/argspec/bgp_global/bgp_global.py
@@ -500,7 +500,7 @@ class Bgp_globalArgs(object):  # pylint: disable=R0903
                             "type": "dict",
                             "options": {
                                 "set": {"type": "bool"},
-                                "number": {"type": "int"},
+                                "number": {"type": "str"},
                                 "dual_as": {"type": "bool"},
                                 "no_prepend": {
                                     "type": "dict",

--- a/plugins/modules/ios_bgp_global.py
+++ b/plugins/modules/ios_bgp_global.py
@@ -971,8 +971,9 @@ options:
               number:
                 description:
                   - AS number used as local AS
+                  - Accepts plain integers (e.g. C(65000)) and ASDOT notation (e.g. C(501.65083))
                   - Please refer vendor documentation for valid values
-                type: int
+                type: str
               dual_as:
                 description: Accept either real AS or local AS from the ebgp peer
                 type: bool

--- a/tests/integration/targets/ios_bgp_global/tests/cli/merged.yaml
+++ b/tests/integration/targets/ios_bgp_global/tests/cli/merged.yaml
@@ -58,9 +58,10 @@
   always:
     - ansible.builtin.include_tasks: _remove_config.yaml
 
-- name: TEST ASDOT local-as
+- name: TEST ASDOT notation — local-as, backward compat, combined remote+local
   block:
-    - name: Setup ASDOT BGP config using ios_config
+    # Scenario 1: ASDOT local-as gathered as string + merged idempotent
+    - name: Setup ASDOT asnotation dot with local-as 501.65083
       cisco.ios.ios_config:
         lines:
           - bgp asnotation dot
@@ -68,37 +69,67 @@
           - neighbor 192.0.2.1 local-as 501.65083
         parents: router bgp 65000
 
-    - name: Gather bgp_global with ASDOT local-as (must not fail with type error)
+    - name: Gather — local_as.number must be string "501.65083" (not float)
       cisco.ios.ios_bgp_global:
         state: gathered
       register: asdot_result
 
-    - name: Assert local_as.number is gathered as string not float
+    - name: Assert ASDOT local_as.number gathered as string and merged idempotent
       ansible.builtin.assert:
         that:
           - asdot_result.changed == false
-          - asdot_result.gathered.neighbors | length > 0
           - (asdot_result.gathered.neighbors | selectattr('neighbor_address', 'equalto', '192.0.2.1') | list | first).local_as.number == "501.65083"
 
-    - name: Merged with ASDOT local_as.number must be idempotent
+    - ansible.builtin.include_tasks: _remove_config.yaml
+
+    # Scenario 2: Integer local_as.number backward compat (int coerced to str)
+    - name: Setup plain integer local-as 234
+      cisco.ios.ios_config:
+        lines:
+          - neighbor 192.0.2.1 remote-as 100
+          - neighbor 192.0.2.1 local-as 234
+        parents: router bgp 65000
+
+    - name: Merged with integer local_as.number=234 must be idempotent (backward compat)
       cisco.ios.ios_bgp_global:
         config:
           as_number: "65000"
-          bgp:
-            asnotation: true
           neighbors:
             - neighbor_address: 192.0.2.1
               remote_as: "100"
               local_as:
                 set: true
-                number: "501.65083"
+                number: 234
         state: merged
-      register: asdot_merged_result
+      register: int_result
 
-    - name: Assert merged is idempotent for ASDOT local_as
+    - name: Assert integer local_as.number accepted without error
       ansible.builtin.assert:
         that:
-          - asdot_merged_result.changed == false
+          - int_result.changed == false
+
+    - ansible.builtin.include_tasks: _remove_config.yaml
+
+    # Scenario 3: Combined ASDOT remote-as and local-as both returned as strings
+    - name: Setup ASDOT remote-as 501.65083 and local-as 300.65
+      cisco.ios.ios_config:
+        lines:
+          - bgp asnotation dot
+          - neighbor 192.0.2.1 remote-as 501.65083
+          - neighbor 192.0.2.1 local-as 300.65
+        parents: router bgp 65000
+
+    - name: Gather — both remote_as and local_as.number must be strings
+      cisco.ios.ios_bgp_global:
+        state: gathered
+      register: combined_result
+
+    - name: Assert both ASDOT fields gathered as strings
+      ansible.builtin.assert:
+        that:
+          - combined_result.changed == false
+          - (combined_result.gathered.neighbors | selectattr('neighbor_address', 'equalto', '192.0.2.1') | list | first).remote_as == "501.65083"
+          - (combined_result.gathered.neighbors | selectattr('neighbor_address', 'equalto', '192.0.2.1') | list | first).local_as.number == "300.65"
 
   always:
     - ansible.builtin.include_tasks: _remove_config.yaml

--- a/tests/integration/targets/ios_bgp_global/tests/cli/merged.yaml
+++ b/tests/integration/targets/ios_bgp_global/tests/cli/merged.yaml
@@ -74,11 +74,29 @@
         state: gathered
       register: asdot_result
 
-    - name: Assert ASDOT local_as.number gathered as string and merged idempotent
+    - name: Assert ASDOT local_as.number gathered as string
       ansible.builtin.assert:
         that:
           - asdot_result.changed == false
           - (asdot_result.gathered.neighbors | selectattr('neighbor_address', 'equalto', '192.0.2.1') | list | first).local_as.number == "501.65083"
+
+    - name: Merged with ASDOT local_as.number string must be idempotent
+      cisco.ios.ios_bgp_global:
+        config:
+          as_number: "65000"
+          neighbors:
+            - neighbor_address: 192.0.2.1
+              remote_as: "100"
+              local_as:
+                set: true
+                number: "501.65083"
+        state: merged
+      register: asdot_merged_result
+
+    - name: Assert merged with ASDOT local_as.number is idempotent
+      ansible.builtin.assert:
+        that:
+          - asdot_merged_result.changed == false
 
     - ansible.builtin.include_tasks: _remove_config.yaml
 

--- a/tests/integration/targets/ios_bgp_global/tests/cli/merged.yaml
+++ b/tests/integration/targets/ios_bgp_global/tests/cli/merged.yaml
@@ -57,3 +57,48 @@
           - result['changed'] == false
   always:
     - ansible.builtin.include_tasks: _remove_config.yaml
+
+- name: TEST ASDOT local-as
+  block:
+    - name: Setup ASDOT BGP config using ios_config
+      cisco.ios.ios_config:
+        lines:
+          - bgp asnotation dot
+          - neighbor 192.0.2.1 remote-as 100
+          - neighbor 192.0.2.1 local-as 501.65083
+        parents: router bgp 65000
+
+    - name: Gather bgp_global with ASDOT local-as (must not fail with type error)
+      cisco.ios.ios_bgp_global:
+        state: gathered
+      register: asdot_result
+
+    - name: Assert local_as.number is gathered as string not float
+      ansible.builtin.assert:
+        that:
+          - asdot_result.changed == false
+          - asdot_result.gathered.neighbors | length > 0
+          - (asdot_result.gathered.neighbors | selectattr('neighbor_address', 'equalto', '192.0.2.1') | list | first).local_as.number == "501.65083"
+
+    - name: Merged with ASDOT local_as.number must be idempotent
+      cisco.ios.ios_bgp_global:
+        config:
+          as_number: "65000"
+          bgp:
+            asnotation: true
+          neighbors:
+            - neighbor_address: 192.0.2.1
+              remote_as: "100"
+              local_as:
+                set: true
+                number: "501.65083"
+        state: merged
+      register: asdot_merged_result
+
+    - name: Assert merged is idempotent for ASDOT local_as
+      ansible.builtin.assert:
+        that:
+          - asdot_merged_result.changed == false
+
+  always:
+    - ansible.builtin.include_tasks: _remove_config.yaml

--- a/tests/unit/modules/network/ios/test_ios_bgp_global.py
+++ b/tests/unit/modules/network/ios/test_ios_bgp_global.py
@@ -847,3 +847,81 @@ class TestIosBgpGlobalModule(TestIosModule):
             },
         )
         self.execute_module(changed=False, commands=[])
+
+    def test_ios_bgp_global_asdot_local_as_int_backward_compat(self):
+        """Integer local_as.number (e.g. 234) must still be accepted after type changed to str."""
+        self.execute_show_command.return_value = dedent(
+            """\
+            router bgp 65000
+             neighbor 192.0.2.1 remote-as 100
+             neighbor 192.0.2.1 local-as 234
+            """,
+        )
+        set_module_args(
+            {
+                "config": {
+                    "as_number": "65000",
+                    "neighbors": [
+                        {
+                            "neighbor_address": "192.0.2.1",
+                            "remote_as": "100",
+                            "local_as": {"set": True, "number": 234},
+                        },
+                    ],
+                },
+                "state": "merged",
+            },
+        )
+        self.execute_module(changed=False, commands=[])
+
+    def test_ios_bgp_global_asdot_combined_parsed(self):
+        """ASDOT remote_as and ASDOT local_as.number must both be strings when parsed together."""
+        set_module_args(
+            dict(
+                running_config=dedent(
+                    """\
+                    router bgp 65000
+                     bgp asnotation dot
+                     neighbor 192.0.2.1 remote-as 501.65083
+                     neighbor 192.0.2.1 local-as 300.65
+                    """,
+                ),
+                state="parsed",
+            ),
+        )
+        result = self.execute_module(changed=False)
+        neighbor = next(
+            n for n in result["parsed"]["neighbors"] if n["neighbor_address"] == "192.0.2.1"
+        )
+        self.assertEqual(neighbor["remote_as"], "501.65083")
+        self.assertIsInstance(neighbor["remote_as"], str)
+        self.assertEqual(neighbor["local_as"]["number"], "300.65")
+        self.assertIsInstance(neighbor["local_as"]["number"], str)
+
+    def test_ios_bgp_global_asdot_combined_merged_idempotent(self):
+        """Merged with ASDOT remote_as and ASDOT local_as.number together must be idempotent."""
+        self.execute_show_command.return_value = dedent(
+            """\
+            router bgp 65000
+             bgp asnotation dot
+             neighbor 192.0.2.1 remote-as 501.65083
+             neighbor 192.0.2.1 local-as 300.65
+            """,
+        )
+        set_module_args(
+            {
+                "config": {
+                    "as_number": "65000",
+                    "bgp": {"asnotation": True},
+                    "neighbors": [
+                        {
+                            "neighbor_address": "192.0.2.1",
+                            "remote_as": "501.65083",
+                            "local_as": {"set": True, "number": "300.65"},
+                        },
+                    ],
+                },
+                "state": "merged",
+            },
+        )
+        self.execute_module(changed=False, commands=[])

--- a/tests/unit/modules/network/ios/test_ios_bgp_global.py
+++ b/tests/unit/modules/network/ios/test_ios_bgp_global.py
@@ -797,3 +797,53 @@ class TestIosBgpGlobalModule(TestIosModule):
             commands = ["router bgp 6500", "no neighbor 192.0.2.2 shutdown"]
             result = self.execute_module(changed=True)
             self.assertEqual(sorted(result["commands"]), sorted(commands))
+
+    def test_ios_bgp_global_asdot_local_as_parsed(self):
+        """local_as.number must be returned as string "501.65083" (not float) for ASDOT notation."""
+        set_module_args(
+            dict(
+                running_config=dedent(
+                    """\
+                    router bgp 65000
+                     bgp asnotation dot
+                     neighbor 192.0.2.1 remote-as 100
+                     neighbor 192.0.2.1 local-as 501.65083
+                    """,
+                ),
+                state="parsed",
+            ),
+        )
+        result = self.execute_module(changed=False)
+        neighbor = next(
+            n for n in result["parsed"]["neighbors"] if n["neighbor_address"] == "192.0.2.1"
+        )
+        self.assertEqual(neighbor["local_as"]["number"], "501.65083")
+        self.assertIsInstance(neighbor["local_as"]["number"], str)
+
+    def test_ios_bgp_global_asdot_local_as_merged_idempotent(self):
+        """merged state with ASDOT local_as must be idempotent when device already has it."""
+        self.execute_show_command.return_value = dedent(
+            """\
+            router bgp 65000
+             bgp asnotation dot
+             neighbor 192.0.2.1 remote-as 100
+             neighbor 192.0.2.1 local-as 501.65083
+            """,
+        )
+        set_module_args(
+            {
+                "config": {
+                    "as_number": "65000",
+                    "bgp": {"asnotation": True},
+                    "neighbors": [
+                        {
+                            "neighbor_address": "192.0.2.1",
+                            "remote_as": "100",
+                            "local_as": {"set": True, "number": "501.65083"},
+                        },
+                    ],
+                },
+                "state": "merged",
+            },
+        )
+        self.execute_module(changed=False, commands=[])


### PR DESCRIPTION
## Description
- **What:** Changes `local_as.number` argspec type from `int` to `str` in `plugins/module_utils/network/ios/argspec/bgp_global/bgp_global.py`.
- **Why:** When a device has `bgp asnotation dot` enabled and a neighbor configured with `local-as 501.65083` (ASDOT 4-byte AS notation), `ast.literal_eval("501.65083")` produces a Python float. Ansible's `check_type_int()` rejects it, crashing `ios_bgp_global` and `ios_facts` with _"argument 'number' is of type float and we were unable to convert to int"_.
- **How:** Type `local_as.number` as `str` — consistent with `remote_as` in the same argspec which already accepts ASDOT. Ansible's `check_type_str()` silently coerces plain integers to strings, so existing playbooks passing `local_as.number: 234` (int) are **not broken**. The setval Jinja2 template already uses `local_as.number|string`, so no `rm_templates` change is needed.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test update

## Related Issue
- Fixes #1096

## Component Name
ios_bgp_global

## Self-Review Checklist
- [x] I have performed a self-review of my code
- [x] I have removed all commented code (no commented code should be merged)
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment
- [x] I have verified the changes work with the target IOS version(s)
- [x] I have reviewed the acceptance criteria for related tickets

## Testing Instructions
### Prerequisites
- IOS-XE device with `bgp asnotation dot` configured globally

### Steps to Test
1. Configure: `router bgp 65000 / bgp asnotation dot / neighbor 192.0.2.1 remote-as 100 / neighbor 192.0.2.1 local-as 501.65083`
2. Run `ios_bgp_global state=gathered` — verify `local_as.number` is string `"501.65083"`, no type error
3. Run `ios_bgp_global state=merged` with `local_as: {number: "501.65083"}` — verify `changed: false`
4. Backward compat: run merged with `local_as: {number: 234}` (plain int) — must not fail
5. Combined: configure ASDOT for both `remote-as` and `local-as`; verify both gathered as strings

### Expected Results
- Steps 2–3: No errors; ASDOT local_as.number gathered as string; merged idempotent
- Step 4: Integer `234` coerced to `"234"` — no breaking change
- Step 5: Both `remote_as` and `local_as.number` returned as strings

### Test Results
```
# Device validation (IOS-XE, 3 scenarios)
S1 PASS: ASDOT local_as.number gathered as string
S2 PASS: integer local_as.number accepted, idempotent
S3 PASS: combined ASDOT remote_as and local_as.number both strings
iosxe-jay: ok=12  changed=6  unreachable=0  failed=0

# Unit tests
576 passed, 0 failed

# Sanity
sanity-py3.11-2.18: OK
```

## Acceptance Criteria Verification
- [x] All acceptance criteria have been reviewed and verified
- [x] Acceptance criteria checklist:
  - [x] `local_as.number` type changed from `int` to `str` in argspec
  - [x] All other AS number fields audited — `remote_as` and `as_number` already `str`; no other `int` fields affected
  - [x] setval template confirmed to use `local_as.number|string` — no rm_template change needed
  - [x] Unit test: ASDOT parsed config returns `local_as.number` as string
  - [x] Unit test: merged with ASDOT `local_as.number` is idempotent
  - [x] Unit test: integer `local_as.number` still accepted (backward compat)
  - [x] Unit test: combined ASDOT `remote_as` + `local_as.number` both parsed as strings
  - [x] Changelog fragment added under `bugfixes`

## Additional Context
ASDOT (dotted decimal) notation is standard for 4-byte BGP AS numbers in enterprise and SP environments. Any `ios_facts` or `ios_bgp_global` call against a device with `bgp asnotation dot` configured is completely blocked without this fix.

Root cause: `remote_as` was already typed `str` (worked with ASDOT); `local_as.number` typed `int` was the sole inconsistency causing the crash.

### Command Output / Logs
**Before:**
```
fatal: argument 'number' is of type <class 'float'> found in
'config -> neighbors -> local_as'. and we were unable to convert to int
```

**After:**
```
gathered: local_as.number = "501.65083"  (string)
merged:   changed = false  (idempotent)
```

### Required Actions
- [x] Requires changelog fragment — `changelogs/fragments/fix-bgp-global-asdot-local-as.yaml`
- [x] Requires integration test updates — ASDOT block added to `merged.yaml`
- [x] Requires unit test updates — 5 new test methods in `test_ios_bgp_global.py`

Assisted-by: Claude Code / Sonnet 4.6 (1M context) (Anthropic)