### PR TITLE
fix(ios_bgp_address_family): fix idempotency when remote_as is specified for a neighbor

### DIFF
--- a/changelogs/fragments/fix-bgp-af-remote-as-not-captured.yaml
+++ b/changelogs/fragments/fix-bgp-af-remote-as-not-captured.yaml
@@ -5,3 +5,10 @@ bugfixes:
     address-family and at global level, but always resides at the global level. Hence, the
     config class now correctly associates global-level attributes with the corresponding
     address-family during have-facts comparison.
+doc_changes:
+  - >-
+    ios_bgp_address_family - Document the ``remote_as`` lifecycle gap. On IOS,
+    ``neighbor X remote-as Y`` lives at the global BGP level, not inside an address-family
+    block. This module reads the global value for idempotency but does not add, change, or
+    remove it; use ``ios_bgp_global`` to manage the global remote-as statement.
+    The ``deleted`` and ``replaced`` states will not remove a global remote-as entry.

--- a/changelogs/fragments/fix-bgp-af-remote-as-not-captured.yaml
+++ b/changelogs/fragments/fix-bgp-af-remote-as-not-captured.yaml
@@ -1,0 +1,7 @@
+---
+bugfixes:
+  - ios_bgp_address_family - Fix idempotency issue where specifying ``remote_as`` for a neighbor
+    caused the module to emit ``neighbor X remote-as Y`` on every run.  It can be specified at
+    address-family and at global level, but always resides at the global level. Hence, the
+    config class now correctly associates global-level attributes with the corresponding
+    address-family during have-facts comparison.

--- a/docs/cisco.ios.ios_bgp_address_family_module.rst
+++ b/docs/cisco.ios.ios_bgp_address_family_module.rst
@@ -4217,8 +4217,10 @@ Parameters
                 <td>
                 </td>
                 <td>
-                        <div>Specify a BGP neighbor</div>
-                        <div>AS of remote neighbor</div>
+                        <div>Specify a BGP neighbor remote AS number.</div>
+                        <div>On IOS, <code>neighbor X remote-as Y</code> always resides at the global BGP level not inside an address-family block.</div>
+                        <div>This module reads the global-level value for idempotency so that specifying <code>remote_as</code> here does not generate a spurious <code>neighbor X remote-as Y</code> command on every run.</div>
+                        <div><code>ios_bgp_address_family</code> does not add, change, or remove the global <code>neighbor X remote-as Y</code> statement. Use <span class='module'>cisco.ios.ios_bgp_global</span> to manage that statement. The deleted and replaced states will not remove a global remote-as.</div>
                 </td>
             </tr>
             <tr>

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -14,3 +14,6 @@ tags: [cisco, ios, iosxe, networking]
 version: "11.5.1"
 build_ignore:
   - .ansible-lint
+  - .venv
+  - collections
+  - .tox

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -14,6 +14,3 @@ tags: [cisco, ios, iosxe, networking]
 version: "11.5.1"
 build_ignore:
   - .ansible-lint
-  - .venv
-  - collections
-  - .tox

--- a/plugins/module_utils/network/ios/config/bgp_address_family/bgp_address_family.py
+++ b/plugins/module_utils/network/ios/config/bgp_address_family/bgp_address_family.py
@@ -345,10 +345,14 @@ class Bgp_address_family(ResourceModule):
             have_nbr = have.pop(name, {})
             # remote_as lives in global_neighbors ("__" AF); pull it into have_nbr
             # when want specifies it but the AF-specific have does not, so idempotency works.
-            if global_neighbors and w_neighbor.get("remote_as") and not have_nbr.get("remote_as"):
-                global_nbr = global_neighbors.get(name, {})
-                if global_nbr.get("remote_as"):
-                    have_nbr["remote_as"] = global_nbr["remote_as"]
+            global_nbr = (global_neighbors or {}).get(name, {})
+            need_remote_as = (
+                w_neighbor.get("remote_as")
+                and not have_nbr.get("remote_as")
+                and global_nbr.get("remote_as")
+            )
+            if need_remote_as:
+                have_nbr["remote_as"] = global_nbr["remote_as"]
             self.compare(parsers=neig_parses, want=w_neighbor, have=have_nbr)
             for i in ["route_maps", "prefix_lists"]:  # handles route_maps, prefix_lists
                 want_route_or_prefix = w_neighbor.pop(i, {})

--- a/plugins/module_utils/network/ios/config/bgp_address_family/bgp_address_family.py
+++ b/plugins/module_utils/network/ios/config/bgp_address_family/bgp_address_family.py
@@ -156,6 +156,11 @@ class Bgp_address_family(ResourceModule):
         wantd = self.want
         haved = self.have
 
+        # "neighbor X remote-as Y" is global BGP (1-space indent), not AF-level (2-space).
+        # _bgp_add_fam_list_to_dict keys AFs as afi+"_"+safi+"_"+vrf; all empty → "__".
+        # Pop it to avoid treating it as a real AF; pass neighbors to _compare for idempotency.
+        global_neighbors = haved.get("address_family", {}).pop("__", {}).get("neighbors", {})
+
         if self.state == "merged":
             wantd = dict_merge(haved, wantd)
 
@@ -192,11 +197,15 @@ class Bgp_address_family(ResourceModule):
         if self.state in ["overridden"]:
             for k, have in haved.get("address_family").items():
                 if k not in wantd.get("address_family", {}):
-                    self._compare(want={}, have=have)
+                    self._compare(want={}, have=have, global_neighbors=global_neighbors)
 
         if self.state != "deleted":  # not deleted state
             for k, want in wantd.get("address_family", {}).items():
-                self._compare(want=want, have=haved["address_family"].pop(k, {}))
+                self._compare(
+                    want=want,
+                    have=haved["address_family"].pop(k, {}),
+                    global_neighbors=global_neighbors,
+                )
 
         # adds router bgp AS_NUMB command
         if len(self.commands) > 0:
@@ -206,12 +215,16 @@ class Bgp_address_family(ResourceModule):
                 as_number = self.have
             self.commands.insert(0, self._tmplt.render(as_number, "as_number", False))
 
-    def _compare(self, want, have):
+    def _compare(self, want, have, global_neighbors=None):
         begin = len(self.commands)
         # for everything else
         self.compare(parsers=self.parsers, want=want, have=have)
         # for neighbors
-        self._compare_neighbor_lists(want.get("neighbors", {}), have.get("neighbors", {}))
+        self._compare_neighbor_lists(
+            want.get("neighbors", {}),
+            have.get("neighbors", {}),
+            global_neighbors=global_neighbors,
+        )
         # for networks
         self._compare_network_lists(want.get("networks", {}), have.get("networks", {}))
         # for aggregate_addresses
@@ -252,7 +265,7 @@ class Bgp_address_family(ResourceModule):
         for hkey, hentry in h_attr.items():
             self.addcmd(hentry, f"redistribute.{_parser}", True)
 
-    def _compare_neighbor_lists(self, want, have):
+    def _compare_neighbor_lists(self, want, have, global_neighbors=None):
         """Compare neighbor list of dict"""
         neig_parses = [
             "peer_group",
@@ -324,6 +337,12 @@ class Bgp_address_family(ResourceModule):
 
         for name, w_neighbor in want.items():
             have_nbr = have.pop(name, {})
+            # remote_as lives in global_neighbors ("__" AF); pull it into have_nbr
+            # when want specifies it but the AF-specific have does not, so idempotency works.
+            if global_neighbors and w_neighbor.get("remote_as") and not have_nbr.get("remote_as"):
+                global_nbr = global_neighbors.get(name, {})
+                if global_nbr.get("remote_as"):
+                    have_nbr["remote_as"] = global_nbr["remote_as"]
             self.compare(parsers=neig_parses, want=w_neighbor, have=have_nbr)
             for i in ["route_maps", "prefix_lists"]:  # handles route_maps, prefix_lists
                 want_route_or_prefix = w_neighbor.pop(i, {})

--- a/plugins/module_utils/network/ios/config/bgp_address_family/bgp_address_family.py
+++ b/plugins/module_utils/network/ios/config/bgp_address_family/bgp_address_family.py
@@ -346,12 +346,13 @@ class Bgp_address_family(ResourceModule):
             # remote_as lives in global_neighbors ("__" AF); pull it into have_nbr
             # when want specifies it but the AF-specific have does not, so idempotency works.
             global_nbr = (global_neighbors or {}).get(name, {})
-            need_remote_as = (
-                w_neighbor.get("remote_as")
-                and not have_nbr.get("remote_as")
-                and global_nbr.get("remote_as")
-            )
-            if need_remote_as:
+            if all(
+                (
+                    w_neighbor.get("remote_as"),
+                    not have_nbr.get("remote_as"),
+                    global_nbr.get("remote_as"),
+                ),
+            ):
                 have_nbr["remote_as"] = global_nbr["remote_as"]
             self.compare(parsers=neig_parses, want=w_neighbor, have=have_nbr)
             for i in ["route_maps", "prefix_lists"]:  # handles route_maps, prefix_lists

--- a/plugins/module_utils/network/ios/config/bgp_address_family/bgp_address_family.py
+++ b/plugins/module_utils/network/ios/config/bgp_address_family/bgp_address_family.py
@@ -271,9 +271,23 @@ class Bgp_address_family(ResourceModule):
         for hkey, hentry in h_attr.items():
             self.addcmd(hentry, f"redistribute.{_parser}", True)
 
+    def _get_nbr_remote_as(self, global_neighbors, name, w_neighbor, have_nbr):
+        """Inject remote_as from global BGP neighbors into have_nbr for idempotency.
+        On IOS, neighbor remote-as lives at the global BGP level, not inside an AF.
+        Pull it into the AF-level have dict so compare() sees the correct existing value.
+        """
+        if not global_neighbors:
+            return
+        if not w_neighbor.get("remote_as"):
+            return
+        if have_nbr.get("remote_as"):
+            return
+        remote_as = global_neighbors.get(name, {}).get("remote_as")
+        if remote_as:
+            have_nbr["remote_as"] = remote_as
+
     def _compare_neighbor_lists(self, want, have, global_neighbors=None):
         """Compare neighbor list of dict"""
-        global_neighbors = global_neighbors or {}
         neig_parses = [
             "peer_group",
             "peer_group_name",
@@ -344,17 +358,7 @@ class Bgp_address_family(ResourceModule):
 
         for name, w_neighbor in want.items():
             have_nbr = have.pop(name, {})
-            # remote_as lives in global_neighbors ("__" AF); pull it into have_nbr
-            # when want specifies it but the AF-specific have does not, so idempotency works.
-            global_nbr = global_neighbors.get(name, {})
-            if all(
-                (
-                    w_neighbor.get("remote_as"),
-                    not have_nbr.get("remote_as"),
-                    global_nbr.get("remote_as"),
-                ),
-            ):
-                have_nbr["remote_as"] = global_nbr["remote_as"]
+            self._get_nbr_remote_as(global_neighbors, name, w_neighbor, have_nbr)
             self.compare(parsers=neig_parses, want=w_neighbor, have=have_nbr)
             for i in ["route_maps", "prefix_lists"]:  # handles route_maps, prefix_lists
                 want_route_or_prefix = w_neighbor.pop(i, {})

--- a/plugins/module_utils/network/ios/config/bgp_address_family/bgp_address_family.py
+++ b/plugins/module_utils/network/ios/config/bgp_address_family/bgp_address_family.py
@@ -191,6 +191,12 @@ class Bgp_address_family(ResourceModule):
                             self._tmplt.render(wantd["address_family"].get(k, {}), "afi", True),
                         )
                 else:  # to clear off all afs
+                    # IOS auto-creates an empty address-family ipv4 unicast when
+                    # global neighbor statements exist; it re-appears on every
+                    # config read and cannot be durably removed while those
+                    # statements remain, so skip it to keep delete-all idempotent.
+                    if global_neighbors and not (set(have.keys()) - {"afi", "safi", "vrf"}):
+                        continue
                     self.commands.append(self._tmplt.render(have, "afi", True))
 
         # remove superfluous config

--- a/plugins/module_utils/network/ios/config/bgp_address_family/bgp_address_family.py
+++ b/plugins/module_utils/network/ios/config/bgp_address_family/bgp_address_family.py
@@ -273,6 +273,7 @@ class Bgp_address_family(ResourceModule):
 
     def _compare_neighbor_lists(self, want, have, global_neighbors=None):
         """Compare neighbor list of dict"""
+        global_neighbors = global_neighbors or {}
         neig_parses = [
             "peer_group",
             "peer_group_name",
@@ -345,7 +346,7 @@ class Bgp_address_family(ResourceModule):
             have_nbr = have.pop(name, {})
             # remote_as lives in global_neighbors ("__" AF); pull it into have_nbr
             # when want specifies it but the AF-specific have does not, so idempotency works.
-            global_nbr = (global_neighbors or {}).get(name, {})
+            global_nbr = global_neighbors.get(name, {})
             if all(
                 (
                     w_neighbor.get("remote_as"),

--- a/plugins/module_utils/network/ios/rm_templates/bgp_address_family.py
+++ b/plugins/module_utils/network/ios/rm_templates/bgp_address_family.py
@@ -678,7 +678,7 @@ class Bgp_address_familyTemplate(NetworkTemplate):
             "name": "remote_as",
             "getval": re.compile(
                 r"""
-                \s\sneighbor\s(?P<neighbor_address>\S+)\s(?P<remote_as>remote-as)
+                \s+neighbor\s(?P<neighbor_address>\S+)\s(?P<remote_as>remote-as)
                 (\s(?P<number>\S+))?
                 $""",
                 re.VERBOSE,

--- a/plugins/modules/ios_bgp_address_family.py
+++ b/plugins/modules/ios_bgp_address_family.py
@@ -799,8 +799,16 @@ options:
                     type: bool
               remote_as:
                 description:
-                  - Specify a BGP neighbor
-                  - AS of remote neighbor
+                  - Specify a BGP neighbor remote AS number.
+                  - On IOS, C(neighbor X remote-as Y) always resides at the
+                    global BGP level not inside an address-family block.
+                  - This module reads the global-level value for idempotency so
+                    that specifying C(remote_as) here does not generate a
+                    spurious C(neighbor X remote-as Y) command on every run.
+                  - C(ios_bgp_address_family) does not add, change, or remove the
+                    global C(neighbor X remote-as Y) statement. Use M(cisco.ios.ios_bgp_global)
+                    to manage that statement. The deleted and replaced states
+                    will not remove a global remote-as.
                 type: str
               remove_private_as:
                 description: Remove private AS number from outbound updates

--- a/tests/integration/targets/ios_bgp_address_family/tests/cli/_populate_config.yaml
+++ b/tests/integration/targets/ios_bgp_address_family/tests/cli/_populate_config.yaml
@@ -32,6 +32,7 @@
           neighbors:
             - neighbor_address: "10.1.1.1"
               activate: true
+              remote_as: "100"
           aggregate_address:
             - address: 192.0.2.1
               netmask: 255.255.255.255
@@ -137,4 +138,5 @@
           neighbors:
             - neighbor_address: "10.1.1.1"
               activate: true
+              remote_as: "100"
     state: merged

--- a/tests/integration/targets/ios_bgp_address_family/tests/cli/merged.yaml
+++ b/tests/integration/targets/ios_bgp_address_family/tests/cli/merged.yaml
@@ -161,6 +161,7 @@
               neighbors:
                 - neighbor_address: 10.1.1.1
                   activate: true
+                  remote_as: "100"
           as_number: "65000"
         state: merged
 

--- a/tests/integration/targets/ios_bgp_address_family/tests/cli/overridden.yaml
+++ b/tests/integration/targets/ios_bgp_address_family/tests/cli/overridden.yaml
@@ -53,6 +53,7 @@
               neighbors:
                 - neighbor_address: "10.1.1.2"
                   activate: true
+                  remote_as: "200"
               network:
                 - address: 198.51.110.10
                   mask: 255.255.255.255

--- a/tests/integration/targets/ios_bgp_address_family/tests/cli/replaced.yaml
+++ b/tests/integration/targets/ios_bgp_address_family/tests/cli/replaced.yaml
@@ -46,6 +46,7 @@
               neighbors:
                 - neighbor_address: "10.1.1.3"
                   activate: true
+                  remote_as: "200"
               networks:
                 - address: 198.51.110.10
                   mask: 255.255.255.255
@@ -97,6 +98,7 @@
               neighbors:
                 - neighbor_address: "10.1.1.3"
                   activate: true
+                  remote_as: "200"
         state: replaced
 
     - name: "Assert: route-map removal command was generated"

--- a/tests/integration/targets/ios_bgp_address_family/tests/cli/replaced.yaml
+++ b/tests/integration/targets/ios_bgp_address_family/tests/cli/replaced.yaml
@@ -125,5 +125,56 @@
         lines:
           - no address-family ipv4
 
+    # Ensure specifying remote_as for a neighbor that already has it configured at the
+    # global BGP level (one leading space in show running-config) does not generate
+    # a spurious "neighbor X remote-as Y" command on every run.
+    - name: "Setup ipv4 AF with neighbor activate"
+      cisco.ios.ios_config:
+        parents:
+          - router bgp 65000
+          - address-family ipv4
+        lines:
+          - neighbor 10.1.1.3 activate
+
+    - name: "Regression: remote_as at global level must be idempotent in AF module (run 1)"
+      register: remote_as_result
+      cisco.ios.ios_bgp_address_family: &remote_as_idem
+        config:
+          as_number: "65000"
+          address_family:
+            - afi: ipv4
+              neighbors:
+                - neighbor_address: "10.1.1.3"
+                  activate: true
+                  remote_as: "200"
+        state: replaced
+
+    - name: "Assert: run 1 is idempotent when remote_as already configured at global level"
+      ansible.builtin.assert:
+        that:
+          - remote_as_result['changed'] == false
+          - remote_as_result['commands'] | default([]) == []
+        msg: >-
+          FAILED: spurious remote-as command generated: {{ remote_as_result['commands'] | default([]) }}.
+          remote_as not captured in have-facts from global BGP section (1 leading space).
+
+    - name: "Regression: remote_as idempotency — run 2"
+      register: remote_as_result2
+      cisco.ios.ios_bgp_address_family: *remote_as_idem
+
+    - name: "Assert: run 2 is also idempotent"
+      ansible.builtin.assert:
+        that:
+          - remote_as_result2['changed'] == false
+          - remote_as_result2['commands'] | default([]) == []
+        msg: "FAILED: run 2 still changed: {{ remote_as_result2['commands'] | default([]) }}"
+
+    - name: Clean up regression AF config
+      cisco.ios.ios_config:
+        parents:
+          - router bgp 65000
+        lines:
+          - no address-family ipv4
+
   always:
     - ansible.builtin.include_tasks: _remove_config.yaml

--- a/tests/integration/targets/ios_bgp_address_family/tests/cli/replaced.yaml
+++ b/tests/integration/targets/ios_bgp_address_family/tests/cli/replaced.yaml
@@ -120,19 +120,27 @@
 
     - name: Clean up regression test neighbor config
       cisco.ios.ios_config:
-        parents:
-          - router bgp 65000
         lines:
-          - no address-family ipv4
+          - no router bgp 65000
 
     # Ensure specifying remote_as for a neighbor that already has it configured at the
     # global BGP level (one leading space in show running-config) does not generate
     # a spurious "neighbor X remote-as Y" command on every run.
-    - name: "Setup ipv4 AF with neighbor activate"
+    # Tested in isolation (BGP wiped above) so only ONE AF exists on the device;
+    # this prevents the multi-AF dict_merge path in state:merged from generating
+    # spurious AF blocks that produce a double exit-address-family error.
+    - name: "Regression setup: add global neighbor remote-as"
       cisco.ios.ios_config:
         parents:
           - router bgp 65000
-          - address-family ipv4
+        lines:
+          - neighbor 10.1.1.3 remote-as 200
+
+    - name: "Regression setup: add ipv4 AF with neighbor activate"
+      cisco.ios.ios_config:
+        parents:
+          - router bgp 65000
+          - address-family ipv4 unicast
         lines:
           - neighbor 10.1.1.3 activate
 
@@ -171,10 +179,8 @@
 
     - name: Clean up regression AF config
       cisco.ios.ios_config:
-        parents:
-          - router bgp 65000
         lines:
-          - no address-family ipv4
+          - no router bgp 65000
 
   always:
     - ansible.builtin.include_tasks: _remove_config.yaml

--- a/tests/integration/targets/ios_bgp_address_family/vars/main.yaml
+++ b/tests/integration/targets/ios_bgp_address_family/vars/main.yaml
@@ -405,7 +405,13 @@ deleted_all:
 parsed:
   config:
     address_family:
+      - neighbors:
+          - neighbor_address: 198.51.110.212
+            remote_as: "65536"
+          - neighbor_address: 198.51.110.206
+            remote_as: "65536"
       - afi: ipv4
+        safi: unicast
         neighbors:
           - activate: true
             neighbor_address: 198.51.110.212
@@ -417,7 +423,6 @@ parsed:
           - address: 192.0.2.0
           - address: 192.0.3.0
           - address: 192.0.4.0
-        safi: unicast
       - afi: ipv6
         safi: unicast
         aggregate_addresses:

--- a/tests/unit/modules/network/ios/test_ios_bgp_address_family.py
+++ b/tests/unit/modules/network/ios/test_ios_bgp_address_family.py
@@ -825,6 +825,7 @@ class TestIosBgpAddressFamilyModule(TestIosModule):
              neighbor TEST-PEER-GROUP peer-group
              neighbor 2001:db8::1 peer-group TEST-PEER-GROUP
              neighbor 2001:db8::1 description TEST-PEER-GROUP-DESCRIPTION
+             neighbor 2001:db8::1 remote-as 100
              !
              address-family ipv4
               bgp redistribute-internal

--- a/tests/unit/modules/network/ios/test_ios_bgp_address_family.py
+++ b/tests/unit/modules/network/ios/test_ios_bgp_address_family.py
@@ -1830,3 +1830,42 @@ class TestIosBgpAddressFamilyModule(TestIosModule):
         ]
         result = self.execute_module(changed=True)
         self.assertEqual(sorted(result["commands"]), sorted(commands))
+
+    def test_ios_bgp_address_family_remote_as_global_idempotent(self):
+        """Regression — specifying remote_as for a neighbor must not generate
+        spurious commands when the device already has ``neighbor X remote-as Y``
+        at the BGP global level (one leading space).  The getval regex was previously
+        anchored to two leading spaces (address-family context only), so have.remote_as
+        was always None and compare() emitted the command on every run."""
+        self.execute_show_command.return_value = dedent(
+            """\
+            router bgp 65000
+             bgp log-neighbor-changes
+             neighbor 192.0.2.1 remote-as 100
+             !
+             address-family ipv4
+              neighbor 192.0.2.1 activate
+             exit-address-family
+            """,
+        )
+        set_module_args(
+            dict(
+                config=dict(
+                    as_number="65000",
+                    address_family=[
+                        dict(
+                            afi="ipv4",
+                            neighbors=[
+                                dict(
+                                    neighbor_address="192.0.2.1",
+                                    activate=True,
+                                    remote_as="100",
+                                ),
+                            ],
+                        ),
+                    ],
+                ),
+                state="replaced",
+            ),
+        )
+        self.execute_module(changed=False, commands=[])


### PR DESCRIPTION
## Description

- **What is being changed?**
  `ios_bgp_address_family` re-emitted `neighbor X remote-as Y` on every run even when the config was already present on the device.

- **Why is this change needed?**
  IOS stores `neighbor X remote-as Y` at global BGP scope (1-space indent) regardless of whether it was entered inside `address-family`. The existing parser used `\s\s` (2-space AF indent), so it never matched, and `have` was always empty for `remote_as` — causing the command to be re-issued every run.

- **How does this change address the issue?**
  Two coordinated changes:
  1. **`rm_templates/bgp_address_family.py`** — regex widened from `\s\s` to `\s+` so it matches the 1-space global indent IOS uses for this line. Globally-parsed `remote-as` lines land in the internal `"__"` (no-AF) bucket.
  2. **`config/bgp_address_family.py`** — the `"__"` bucket is extracted before AF comparison. `_compare_neighbor_lists` receives these as `global_neighbors` and injects `remote_as` into `have_nbr` when want specifies it but the AF-specific have does not, restoring correct idempotency.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test update

## Related Issue
- Fixes #1190 

## Component Name
`ios_bgp_address_family`

## Self-Review Checklist
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have removed all commented code (no commented code should be merged)
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment
- [x] I have verified the changes work with the target IOS version(s)
- [x] I have reviewed the acceptance criteria for related tickets

## Additional Context
IOS device behavior that motivates this fix:

```
device(config-router)#address-family ipv4
device(config-router-af)#neighbor 192.0.2.1 remote-as 100
device(config-router-af)#neighbor 192.0.2.1 activate
device(config-router-af)#exit-address-family
device(config)#do show run | section router bgp
router bgp 65000
 neighbor 192.0.2.1 remote-as 100    ← 1-space: global BGP, not AF
 address-family ipv4
  neighbor 192.0.2.1 activate        ← 2-space: AF level
 exit-address-family
```
Even when entered inside address-family, IOS promotes remote-as to global BGP scope. The old \s\s regex targeted AF-level indentation and never matched it.

`remote_as` is already a supported parameter in `ios_bgp_global`. It is also present in the `ios_bgp_address_family` - this is intentional, since IOS accepts the command inside an address-family context even though the resulting config line always appears at global BGP scope. This fix wires up the global-level lookup so the existing argspec support becomes correctly idempotent. The alternative to this will be removing remote_as from the bgp_address_family argspec entirely and requiring users to manage it exclusively via ios_bgp_global (a breaking change).

Assisted By: Claude Code