### PR TITLE
fix(ios_route_maps): emit bare 'continue' when continue_entry.set=true

### DIFF
--- a/changelogs/fragments/fix-route-maps-continue-entry.yaml
+++ b/changelogs/fragments/fix-route-maps-continue-entry.yaml
@@ -1,0 +1,4 @@
+bugfixes:
+  - ios_route_maps - fix continue_entry.set=true silently ignored; bare "continue" command
+    was never generated because the setval template raised UndefinedError when entry_sequence
+    was absent.

--- a/plugins/module_utils/network/ios/rm_templates/route_maps.py
+++ b/plugins/module_utils/network/ios/rm_templates/route_maps.py
@@ -686,7 +686,7 @@ class Route_mapsTemplate(NetworkTemplate):
                 $""",
                 re.VERBOSE,
             ),
-            "setval": "continue {{ continue_entry.entry_sequence }}",
+            "setval": "{% if continue_entry.entry_sequence is defined %}continue {{ continue_entry.entry_sequence }}{% else %}continue{% endif %}",
             "result": {
                 "{{ route_map }}": {
                     "{{ action|d() + '_' + sequence|d() }}": {

--- a/tests/integration/targets/ios_route_maps/tests/cli/merged.yaml
+++ b/tests/integration/targets/ios_route_maps/tests/cli/merged.yaml
@@ -170,3 +170,57 @@
           - result['changed'] == false
   always:
     - ansible.builtin.include_tasks: _remove_config.yaml
+
+# Regression test: continue_entry.set=true must emit bare "continue" command
+- block:
+    - ansible.builtin.include_tasks: _remove_config.yaml
+
+    - name: Merge continue_entry.set=true — bare continue must be generated
+      register: result
+      cisco.ios.ios_route_maps: &id_continue
+        config:
+          - route_map: TEST_CONTINUE_ENTRY
+            entries:
+              - sequence: 10
+                action: permit
+                continue_entry:
+                  set: true
+                description: Test bare continue
+        state: merged
+
+    - name: Assert bare continue command generated
+      ansible.builtin.assert:
+        that:
+          - result['changed'] == true
+          - "'continue' in result['commands']"
+
+    - name: Merge continue_entry.set=true again (idempotency)
+      register: result
+      cisco.ios.ios_route_maps: *id_continue
+
+    - name: Assert idempotent with bare continue
+      ansible.builtin.assert:
+        that:
+          - result['changed'] == false
+
+    - name: Merge continue_entry.entry_sequence=20 — must generate "continue 20"
+      register: result
+      cisco.ios.ios_route_maps:
+        config:
+          - route_map: TEST_CONTINUE_ENTRY
+            entries:
+              - sequence: 10
+                action: permit
+                continue_entry:
+                  entry_sequence: 20
+                description: Test bare continue
+        state: merged
+
+    - name: Assert continue 20 generated
+      ansible.builtin.assert:
+        that:
+          - result['changed'] == true
+          - "'continue 20' in result['commands']"
+
+  always:
+    - ansible.builtin.include_tasks: _remove_config.yaml

--- a/tests/unit/modules/network/ios/fixtures/ios_route_maps_continue.cfg
+++ b/tests/unit/modules/network/ios/fixtures/ios_route_maps_continue.cfg
@@ -1,0 +1,3 @@
+route-map TEST_CONTINUE_ENTRY permit 10
+ continue
+ description Test bare continue

--- a/tests/unit/modules/network/ios/test_ios_route_maps.py
+++ b/tests/unit/modules/network/ios/test_ios_route_maps.py
@@ -941,3 +941,79 @@ class TestIosRouteMapsModule(TestIosModule):
         )
         result = self.changed(False)
         self.assertEqual(result["commands"], [])
+
+    def test_ios_route_maps_continue_entry_bare(self):
+        """continue_entry.set=True must emit bare 'continue' command (no entry_sequence)."""
+        self.execute_show_command.return_value = ""
+        set_module_args(
+            dict(
+                config=[
+                    dict(
+                        route_map="TEST_CONTINUE_ENTRY",
+                        entries=[
+                            dict(
+                                action="permit",
+                                sequence=10,
+                                continue_entry=dict(set=True),
+                                description="Test bare continue",
+                            ),
+                        ],
+                    ),
+                ],
+                state="merged",
+            ),
+        )
+        result = self.execute_module(changed=True)
+        self.assertIn("continue", result["commands"])
+        self.assertNotIn("continue 20", result["commands"])
+
+    def test_ios_route_maps_continue_entry_bare_idempotent(self):
+        """Device already has bare 'continue' — second merged run must be idempotent."""
+        set_module_args(
+            dict(
+                config=[
+                    dict(
+                        route_map="TEST_CONTINUE_ENTRY",
+                        entries=[
+                            dict(
+                                action="permit",
+                                sequence=10,
+                                continue_entry=dict(set=True),
+                                description="Test bare continue",
+                            ),
+                        ],
+                    ),
+                ],
+                state="merged",
+            ),
+        )
+        self.load_fixtures()
+        self.execute_show_command.side_effect = lambda *args, **kwargs: load_fixture(
+            "ios_route_maps_continue.cfg",
+        )
+        result = self.changed(False)
+        self.assertEqual(result["commands"], [])
+
+    def test_ios_route_maps_continue_entry_with_sequence(self):
+        """continue_entry.entry_sequence=20 must emit 'continue 20' (no regression)."""
+        self.execute_show_command.return_value = ""
+        set_module_args(
+            dict(
+                config=[
+                    dict(
+                        route_map="TEST_CONTINUE_ENTRY",
+                        entries=[
+                            dict(
+                                action="permit",
+                                sequence=10,
+                                continue_entry=dict(entry_sequence=20),
+                                description="Test continue with seq",
+                            ),
+                        ],
+                    ),
+                ],
+                state="merged",
+            ),
+        )
+        result = self.execute_module(changed=True)
+        self.assertIn("continue 20", result["commands"])


### PR DESCRIPTION
## Description
- **What:** Fix the `continue_entry` setval in `rm_templates/route_maps.py` to correctly render a bare `continue` command when `continue_entry.set=true` is specified without an `entry_sequence`.
- **Why:** The bare `continue` IOS command was silently dropped — never sent to the device — even when the user correctly set `continue_entry: {set: true}`. IOS route-map entries support two forms of the `continue` statement: a bare `continue` (advance unconditionally to the next sequence) and `continue N` (jump to a specific sequence number). The bare form was completely broken; only `continue N` worked.
- **How:** The setval template `"continue {{ continue_entry.entry_sequence }}"` failed at render time because `remove_empties()` strips `entry_sequence: null`, leaving the key absent from the data dict. The Jinja2 environment uses `StrictUndefined`, so accessing an absent key raises `UndefinedError`. The `_render()` call catches this with `fail_on_undefined=False` and returns `None`; `addcmd()` then skips the `None` command silently. The fix adds a Jinja2 conditional so the template renders `continue` (bare) when `entry_sequence` is undefined, and `continue N` when it is set.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test update

## Related Issue
- Fixes #1135

## Component Name
ios_route_maps, `rm_templates/route_maps.py`

## Self-Review Checklist
- [x] I have performed a self-review of my code
- [x] I have removed all commented code (no commented code should be merged)
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment
- [x] I have verified the changes work with the target IOS version(s)
- [x] I have reviewed the acceptance criteria for related tickets

## Testing Instructions
### Prerequisites
- IOS-XE device with route-maps configurable
- cisco.ios collection at current HEAD

### Steps to Test
1. Run `ios_route_maps` with `state: merged` and `continue_entry: {set: true}` (no `entry_sequence`) on a device
2. Verify `continue` (bare) appears in `result.commands` and in the device running-config
3. Run the same task again — verify `changed: false` (idempotency)
4. Run with `continue_entry: {entry_sequence: 20}` — verify `continue 20` is generated

### Expected Results
- Step 1: `commands` includes `continue` (bare), device config shows `continue` inside the route-map entry
- Step 2: `changed: false`
- Step 4: `commands` includes `continue 20`, `changed: true`

### Test Results
```
# Device validation (IOS-XE)
PASS: bare 'continue' generated — ['route-map TEST_CONTINUE_ENTRY permit 10', 'continue', 'description Test bare continue']
PASS: idempotent with bare continue
PASS: 'continue 20' generated — ['route-map TEST_CONTINUE_ENTRY permit 10', 'continue 20']
PASS: idempotent with 'continue 20'
iosxe-jay: ok=10  changed=4  unreachable=0  failed=0

# Unit tests
581 passed, 0 failed

# Sanity
sanity-py3.11-2.18: OK
```

## Acceptance Criteria Verification
- [x] All acceptance criteria have been reviewed and verified
- [x] Acceptance criteria checklist:
  - [x] `continue_entry.set=True` with no `entry_sequence` emits bare `continue` command
  - [x] `continue_entry.entry_sequence=20` still emits `continue 20` (no regression)
  - [x] Idempotency: second run with bare `continue` already on device reports `changed: false`
  - [x] Changelog fragment added under `bugfixes`

## Additional Context

### Root Cause — Three-step failure chain

**Step 1 — `remove_empties()` strips the key:**
When a user specifies `continue_entry: {set: true}` without `entry_sequence`, Ansible fills in `entry_sequence: null` at argspec validation. `remove_empties()` then strips null values, so the dict passed to the rm_template becomes `{"continue_entry": {"set": True}}` with `entry_sequence` entirely absent.

**Step 2 — `StrictUndefined` raises on the absent key:**
`JinjaTemplate` uses `Environment(undefined=StrictUndefined)`. Rendering `"continue {{ continue_entry.entry_sequence }}"` against `{"set": True}` raises `UndefinedError` because `entry_sequence` is not a key in the dict.

**Step 3 — Silent discard:**
`_render()` calls the Jinja2 template with `fail_on_undefined=False`. The `UndefinedError` is caught and `None` is returned. `addcmd()` checks `if command:` — `None` is falsy — so the continue command is never appended to the command list.

The workaround (`entry_sequence: 20` → `continue 20`) works because `entry_sequence` is then present in the dict and the template renders correctly.

**Fix (1-line change):**
```python
# Before
"setval": "continue {{ continue_entry.entry_sequence }}",

# After
"setval": "{% if continue_entry.entry_sequence is defined %}continue {{ continue_entry.entry_sequence }}{% else %}continue{% endif %}",
```

### Command Output / Logs
**Before (bug):**
```
commands generated: ['route-map TEST_CONTINUE_ENTRY permit 10', 'description Test bare continue']
# 'continue' is absent — IOS route-map entry silently missing the continue statement
```

**After (fix):**
```
commands generated: ['route-map TEST_CONTINUE_ENTRY permit 10', 'continue', 'description Test bare continue']
# 'continue' is present and applied correctly to the device
```

### Required Actions
- [x] Requires changelog fragment — `changelogs/fragments/fix-route-maps-continue-entry.yaml`
- [x] Requires integration test updates — `continue_entry` block added to `merged.yaml`
- [x] Requires unit test updates — 3 new test methods + fixture in `test_ios_route_maps.py`

Assisted-by: Claude Code / Sonnet 4.6 (1M context) (Anthropic)